### PR TITLE
Returning expiry UNIX timestamp along with access token for Login API

### DIFF
--- a/app/api/models/user.py
+++ b/app/api/models/user.py
@@ -8,6 +8,7 @@ def add_models_to_namespace(api_namespace):
     api_namespace.models[change_password_request_data_model.name] = change_password_request_data_model
     api_namespace.models[update_user_request_body_model.name] = update_user_request_body_model
     api_namespace.models[login_request_body_model.name] = login_request_body_model
+    api_namespace.models[login_response_body_model.name] = login_response_body_model
 
 
 public_user_api_model = Model('User list model', {
@@ -110,9 +111,14 @@ change_password_request_data_model = Model('Change password request data model',
     'new_password': fields.String(required=True, description='User\'s new password')
 })
 
-login_request_body_model = Model('Login data model', {
+login_request_body_model = Model('Login request data model', {
     'username': fields.String(required=True, description='User\'s username'),
     'password': fields.String(required=True, description='User\'s password')
+})
+
+login_response_body_model = Model('Login response data model', {
+    'access_token': fields.String(required=True, description='User\'s access token'),
+    'expiry': fields.Float(required=True, description='Access token expiry UNIX timestamp')
 })
 
 update_user_request_body_model = Model('Update User request data model', {

--- a/app/api/resources/common.py
+++ b/app/api/resources/common.py
@@ -3,5 +3,5 @@ from flask_restplus import reqparse
 auth_header_parser = reqparse.RequestParser()
 auth_header_parser.add_argument('Authorization',
                                 required=True,
-                                help='Authentication access token',
+                                help='Authentication access token. E.g.: JWT <access_token>',
                                 location='headers')

--- a/app/api/resources/user.py
+++ b/app/api/resources/user.py
@@ -183,6 +183,7 @@ class LoginUser(Resource):
 
     @classmethod
     @users_ns.doc('login')
+    @users_ns.response(200, 'Successful login', login_response_body_model)
     @users_ns.expect(login_request_body_model)  # , skip_none=True
     def post(cls):
         """
@@ -190,7 +191,8 @@ class LoginUser(Resource):
 
         The user can login with (username or email) + password.
         Username field can be either the User's username or the email.
-        The return value is an access token valid for 1 week.
+        The return value is an access token and the expiry timestamp.
+        The token is valid for 1 week.
         """
-        # pass
         return jwt.request_handler()
+

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -17,7 +17,7 @@
                         "in": "header",
                         "type": "string",
                         "required": true,
-                        "description": "Authentication access token"
+                        "description": "Authentication access token. E.g.: JWT <access_token>"
                     },
                     {
                         "name": "payload",
@@ -37,11 +37,14 @@
             "post": {
                 "responses": {
                     "200": {
-                        "description": "Success"
+                        "description": "Successful login",
+                        "schema": {
+                            "$ref": "#/definitions/Login response data model"
+                        }
                     }
                 },
                 "summary": "Login user",
-                "description": "The user can login with (username or email) + password.\nUsername field can be either the User's username or the email.\nThe return value is an access token valid for 1 week.",
+                "description": "The user can login with (username or email) + password.\nUsername field can be either the User's username or the email.\nThe return value is an access token and the expiry timestamp.\nThe token is valid for 1 week.",
                 "operationId": "login",
                 "parameters": [
                     {
@@ -49,7 +52,7 @@
                         "required": true,
                         "in": "body",
                         "schema": {
-                            "$ref": "#/definitions/Login data model"
+                            "$ref": "#/definitions/Login request data model"
                         }
                     }
                 ],
@@ -83,30 +86,6 @@
             }
         },
         "/user": {
-            "delete": {
-                "responses": {
-                    "404": {
-                        "description": "User not found."
-                    },
-                    "204": {
-                        "description": "User successfully deleted."
-                    }
-                },
-                "summary": "Deletes user",
-                "operationId": "delete_user",
-                "parameters": [
-                    {
-                        "name": "Authorization",
-                        "in": "header",
-                        "type": "string",
-                        "required": true,
-                        "description": "Authentication access token"
-                    }
-                ],
-                "tags": [
-                    "Users"
-                ]
-            },
             "get": {
                 "responses": {
                     "404": {
@@ -127,7 +106,7 @@
                         "in": "header",
                         "type": "string",
                         "required": true,
-                        "description": "Authentication access token"
+                        "description": "Authentication access token. E.g.: JWT <access_token>"
                     },
                     {
                         "name": "X-Fields",
@@ -135,6 +114,30 @@
                         "type": "string",
                         "format": "mask",
                         "description": "An optional fields mask"
+                    }
+                ],
+                "tags": [
+                    "Users"
+                ]
+            },
+            "delete": {
+                "responses": {
+                    "404": {
+                        "description": "User not found."
+                    },
+                    "204": {
+                        "description": "User successfully deleted."
+                    }
+                },
+                "summary": "Deletes user",
+                "operationId": "delete_user",
+                "parameters": [
+                    {
+                        "name": "Authorization",
+                        "in": "header",
+                        "type": "string",
+                        "required": true,
+                        "description": "Authentication access token. E.g.: JWT <access_token>"
                     }
                 ],
                 "tags": [
@@ -158,7 +161,7 @@
                         "in": "header",
                         "type": "string",
                         "required": true,
-                        "description": "Authentication access token"
+                        "description": "Authentication access token. E.g.: JWT <access_token>"
                     },
                     {
                         "name": "payload",
@@ -189,7 +192,7 @@
                         "in": "header",
                         "type": "string",
                         "required": true,
-                        "description": "Authentication access token"
+                        "description": "Authentication access token. E.g.: JWT <access_token>"
                     },
                     {
                         "name": "payload",
@@ -293,7 +296,7 @@
                         "in": "header",
                         "type": "string",
                         "required": true,
-                        "description": "Authentication access token"
+                        "description": "Authentication access token. E.g.: JWT <access_token>"
                     }
                 ],
                 "tags": [
@@ -569,7 +572,7 @@
             },
             "type": "object"
         },
-        "Login data model": {
+        "Login request data model": {
             "required": [
                 "password",
                 "username"
@@ -582,6 +585,23 @@
                 "password": {
                     "type": "string",
                     "description": "User's password"
+                }
+            },
+            "type": "object"
+        },
+        "Login response data model": {
+            "required": [
+                "access_token",
+                "expiry"
+            ],
+            "properties": {
+                "access_token": {
+                    "type": "string",
+                    "description": "User's access token"
+                },
+                "expiry": {
+                    "type": "number",
+                    "description": "Access token expiry UNIX timestamp"
                 }
             },
             "type": "object"

--- a/run.py
+++ b/run.py
@@ -1,10 +1,11 @@
 import os
 
-from flask import Flask
+from flask import Flask, jsonify
 from flask_restplus import Api
-from flask_jwt import JWT
 from flask_sqlalchemy import SQLAlchemy
+from flask_jwt import JWT
 from app.security import authenticate, identity
+from datetime import datetime
 
 CONFIG_NAME_MAPPER = {
     'development': 'config.DevelopmentConfig',
@@ -21,10 +22,6 @@ if flask_config_name is None:
 
 application.config.from_object(CONFIG_NAME_MAPPER[flask_config_name])
 
-db = SQLAlchemy(application)
-# returns 'access_token'
-jwt = JWT(application, authenticate, identity)
-
 api = Api(
     app=application,
     title='Mentorship System API',
@@ -34,13 +31,6 @@ api = Api(
 )
 
 
-@application.before_first_request
-def create_tables():
-    from app.database.db_utils import db
-    # db.drop_all()
-    db.create_all()
-
-
 # Adding namespaces
 def add_namespaces():
     # called here to avoid circular imports
@@ -48,6 +38,33 @@ def add_namespaces():
     from app.api.resources.admin import admin_ns as admin_namespace
     api.add_namespace(user_namespace, path='/')
     api.add_namespace(admin_namespace, path='/')
+
+
+jwt = JWT(application, authenticate, identity)
+
+
+@jwt.auth_response_handler
+def custom_jwt_response_handler(access_token, identity):
+    payload = jwt.jwt_payload_callback(identity)
+
+    if 'exp' in payload:
+        expiry = payload['exp']
+    else:
+        expiry = datetime.utcnow() + application.config.get('JWT_EXPIRATION_DELTA')
+
+    return jsonify({
+        'access_token': access_token.decode('utf-8'),
+        'expiry': expiry.timestamp()
+    })
+
+
+db = SQLAlchemy(application)
+
+
+@application.before_first_request
+def create_tables():
+    # db.drop_all()
+    db.create_all()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description

The Login API response returns the expiry UNIX timestamp, along with the access_token.

Fixes #39 

**Current Response:**
```
{
      "access_token": "YOUR_TOKEN",
      "expiry": "EXPIRY_DATE_UNIX_TIMESTAMP"
}
```

**Printscreen from Swagger UI:**

![image](https://user-images.githubusercontent.com/11148726/41195711-b9e01fde-6c2a-11e8-93bc-873b2e519710.png)

### Type of Change:

- Code
- Documentation

**Code/Quality Assurance Only**
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?

I ran the app and performed a login operation on the Swagger UI.

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Update Swagger documentation and the exported file at /docs folder

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes
