### PR TITLE
Add support to read environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,17 @@ The project runs on Python 3.
 3. Install all the dependencies in `requirements.txt` file:
 `pip install -r requirements.txt`
 
-4. Run the app:
+4. Export the following environment variables:
+
+```
+export  SECRET_KEY=<your-secret-key>
+```
+
+5. Run the app:
 `python run.py`
 
-5. When you are done using the app, decativate the virtual environment:
+6. When you are done using the app, deactivate the virtual environment:
 `deactivate`
-
 
 ### Run tests
 

--- a/config.py
+++ b/config.py
@@ -1,10 +1,12 @@
 from datetime import timedelta
+import os
 
 
 class BaseConfig(object):
     DEBUG = False
     TESTING = False
-    SECRET_KEY = 'EXAMPLE_SECRET_KEY'
+
+    SECRET_KEY = os.getenv('SECRET_KEY')
 
     # SQLAlchemy settings
     SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
@@ -16,17 +18,21 @@ class BaseConfig(object):
 
 
 class ProductionConfig(BaseConfig):
+    ENV = 'production'
+
     # SQLALCHEMY_DATABASE_URI = 'mysql://user@localhost/foo'
     SQLALCHEMY_DATABASE_URI = 'sqlite:///prod_data.db'
 
 
 class DevelopmentConfig(BaseConfig):
+    ENV = 'development'
     DEBUG = True
 
     SQLALCHEMY_DATABASE_URI = 'sqlite:///dev_data.db'
 
 
 class TestingConfig(BaseConfig):
+    ENV = 'testing'
     DEBUG = True
     TESTING = True
 
@@ -34,3 +40,17 @@ class TestingConfig(BaseConfig):
     SQLALCHEMY_DATABASE_URI = 'sqlite://'
     # SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
     # SQLALCHEMY_DATABASE_URI = 'sqlite:///test_data.db'
+
+
+def get_env_config():
+    flask_config_name = os.getenv('FLASK_ENVIRONMENT_CONFIG', 'dev')
+    if flask_config_name not in ['prod', 'test', 'dev']:
+        raise ValueError('The environment config value has to be within these values: prod, dev, test.')
+    return CONFIGURATION_MAPPER[flask_config_name]
+
+
+CONFIGURATION_MAPPER = {
+    'dev': 'config.DevelopmentConfig',
+    'test': 'config.TestingConfig',
+    'prod': 'config.ProductionConfig'
+}

--- a/run.py
+++ b/run.py
@@ -6,21 +6,12 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_jwt import JWT
 from app.security import authenticate, identity
 from datetime import datetime
-
-CONFIG_NAME_MAPPER = {
-    'development': 'config.DevelopmentConfig',
-    'testing': 'config.TestingConfig',
-    'production': 'config.ProductionConfig'
-}
+from config import get_env_config
 
 application = Flask(__name__)
 
 # setup application environment
-flask_config_name = os.getenv('FLASK_CONFIG')
-if flask_config_name is None:
-    flask_config_name = 'development'
-
-application.config.from_object(CONFIG_NAME_MAPPER[flask_config_name])
+application.config.from_object(get_env_config())
 
 api = Api(
     app=application,

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -12,16 +12,16 @@ class TestTestingConfig(TestCase):
         return application
 
     def test_app_testing_config(self):
-        self.assertEqual(application.config['SECRET_KEY'], 'EXAMPLE_SECRET_KEY')
+        self.assertIsNone(application.config['SECRET_KEY'])
         self.assertTrue(application.config['DEBUG'])
         self.assertTrue(application.config['TESTING'])
         self.assertFalse(application.config['SQLALCHEMY_TRACK_MODIFICATIONS'])
-        self.assertEqual(application.config['SQLALCHEMY_DATABASE_URI'], 'sqlite://')
-        self.assertFalse(current_app is None)
+        self.assertEqual('sqlite://', application.config['SQLALCHEMY_DATABASE_URI'])
+        self.assertIsNotNone(current_app)
 
         # testing JWT configurations
-        self.assertTrue(application.config['JWT_AUTH_URL_RULE'] == '/login')
-        self.assertEqual(application.config['JWT_EXPIRATION_DELTA'], timedelta(weeks=1))
+        self.assertEqual('/login', application.config['JWT_AUTH_URL_RULE'])
+        self.assertEqual(timedelta(weeks=1), application.config['JWT_EXPIRATION_DELTA'])
 
 
 class TestDevelopmentConfig(TestCase):
@@ -30,16 +30,16 @@ class TestDevelopmentConfig(TestCase):
         return application
 
     def test_app_development_config(self):
-        self.assertEqual(application.config['SECRET_KEY'], 'EXAMPLE_SECRET_KEY')
+        self.assertIsNone(application.config['SECRET_KEY'])
         self.assertTrue(application.config['DEBUG'])
         self.assertFalse(application.config['TESTING'])
         self.assertFalse(application.config['SQLALCHEMY_TRACK_MODIFICATIONS'])
-        self.assertEqual(application.config['SQLALCHEMY_DATABASE_URI'], 'sqlite:///dev_data.db')
-        self.assertFalse(current_app is None)
+        self.assertEqual('sqlite:///dev_data.db', application.config['SQLALCHEMY_DATABASE_URI'])
+        self.assertIsNotNone(current_app)
 
         # testing JWT configurations
-        self.assertEqual(application.config['JWT_AUTH_URL_RULE'], '/login')
-        self.assertEqual(application.config['JWT_EXPIRATION_DELTA'], timedelta(weeks=1))
+        self.assertEqual('/login', application.config['JWT_AUTH_URL_RULE'])
+        self.assertEqual(timedelta(weeks=1), application.config['JWT_EXPIRATION_DELTA'])
 
 
 class TestProductionConfig(TestCase):
@@ -48,16 +48,16 @@ class TestProductionConfig(TestCase):
         return application
 
     def test_app_production_config(self):
-        self.assertEqual(application.config['SECRET_KEY'], 'EXAMPLE_SECRET_KEY')
+        self.assertIsNone(application.config['SECRET_KEY'])
         self.assertFalse(application.config['DEBUG'])
         self.assertFalse(application.config['TESTING'])
         self.assertFalse(application.config['SQLALCHEMY_TRACK_MODIFICATIONS'])
-        self.assertEqual(application.config['SQLALCHEMY_DATABASE_URI'], 'sqlite:///prod_data.db')
-        self.assertFalse(current_app is None)
+        self.assertEqual('sqlite:///prod_data.db', application.config['SQLALCHEMY_DATABASE_URI'])
+        self.assertIsNotNone(current_app)
 
         # testing JWT configurations
-        self.assertTrue(application.config['JWT_AUTH_URL_RULE'] == '/login')
-        self.assertEqual(application.config['JWT_EXPIRATION_DELTA'], timedelta(weeks=1))
+        self.assertEqual('/login', application.config['JWT_AUTH_URL_RULE'])
+        self.assertEqual(timedelta(weeks=1), application.config['JWT_EXPIRATION_DELTA'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Description

- Currently reading `SECRET_KEY` and `ENVIRONMENT_CONFIGURATION` from environment variables;
- Updated README to inform of what variables to use on `.env` file;
- Raising error with environment configuration is not in these values: `dev`, `test` or `prod`;
- Updated `test_app_config.py` according to changes.

With these changes, we can set sensitive data on the `.env` file and import them without hardcoding it on the code

Fixes #21 

### Type of Change:
- Code
- Quality Assurance
- Documentation

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?

- Ran unittest `test_config_app.py` (fixed tests according to this change)
- created `.env` file with exported with different types of configurations, to test if the app only accepted `dev`, `test` and `prod` how it should

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
