### PR TITLE
Revoke a user's admin role

### DIFF
--- a/app/api/dao/admin.py
+++ b/app/api/dao/admin.py
@@ -4,19 +4,45 @@ from app.database.models.user import UserModel
 class AdminDAO:
 
     @staticmethod
-    def assign_new_user(data):
+    def assign_new_user(assigner_user_id, data):
 
         new_admin_user_id = data['user_id']
+
+        if assigner_user_id is new_admin_user_id:
+            return {"message": "You cannot assign yourself as an Admin."}, 403
+
         new_admin_user = UserModel.find_by_id(new_admin_user_id)
 
         if new_admin_user:
 
             if new_admin_user.is_admin:
-                return {"message": "User is already an Admin"}, 201
+                return {"message": "User is already an Admin."}, 400
 
             new_admin_user.is_admin = True
             new_admin_user.save_to_db()
 
-            return {"message": "User is now an Admin"}, 201
+            return {"message": "User is now an Admin."}, 200
 
-        return {"message": "User does not exist"}, 401
+        return {"message": "User does not exist."}, 404
+
+    @staticmethod
+    def revoke_admin_user(revoker_user_id, data):
+
+        admin_user_id = data['user_id']
+
+        if revoker_user_id is admin_user_id:
+            return {"message": "You cannot revoke your admin status."}, 403
+
+        new_admin_user = UserModel.find_by_id(admin_user_id)
+
+        if new_admin_user:
+
+            if not new_admin_user.is_admin:
+                return {"message": "User is not an Admin."}, 400
+
+            new_admin_user.is_admin = False
+            new_admin_user.save_to_db()
+
+            return {"message": "User admin status was revoked."}, 200
+
+        return {"message": "User does not exist."}, 404

--- a/app/api/dao/mentorship_relation.py
+++ b/app/api/dao/mentorship_relation.py
@@ -44,7 +44,7 @@ class MentorshipRelationDAO:
         # validate if mentor user exists
         mentor_user = UserModel.find_by_id(mentor_id)
         if mentor_user is None:
-            return {'message': 'Mentor user does not exist.'}, 400
+            return {'message': 'Mentor user does not exist.'}, 404
 
         # validate if mentor is available to mentor
         if not mentor_user.available_to_mentor:
@@ -53,7 +53,7 @@ class MentorshipRelationDAO:
         # validate if mentee user exists
         mentee_user = UserModel.find_by_id(mentee_id)
         if mentee_user is None:
-            return {'message': 'Mentee user does not exist.'}, 400
+            return {'message': 'Mentee user does not exist.'}, 404
 
         # validate if mentee is wants to be mentored
         if not mentee_user.need_mentoring:

--- a/app/api/models/admin.py
+++ b/app/api/models/admin.py
@@ -2,10 +2,10 @@ from flask_restplus import fields, Model
 
 
 def add_models_to_namespace(api_namespace):
-    api_namespace.models[assign_new_admin_request_body.name] = assign_new_admin_request_body
+    api_namespace.models[assign_and_revoke_user_admin_request_body.name] = assign_and_revoke_user_admin_request_body
 
 
-assign_new_admin_request_body = Model('Assign User model', {
+assign_and_revoke_user_admin_request_body = Model('Assign User model', {
     'user_id': fields.Integer(
         required=True,
         description='The unique identifier of a user'

--- a/app/api/resources/admin.py
+++ b/app/api/resources/admin.py
@@ -1,6 +1,7 @@
 from flask import request
 from flask_restplus import Resource
 from flask_jwt import jwt_required, current_identity
+
 from run import api
 from app.api.models.admin import *
 from app.api.dao.admin import AdminDAO
@@ -17,7 +18,7 @@ class AssignNewUserAdmin(Resource):
 
     @classmethod
     @jwt_required()
-    @admin_ns.expect(auth_header_parser, assign_new_admin_request_body, validate=True)
+    @admin_ns.expect(auth_header_parser, assign_and_revoke_user_admin_request_body, validate=True)
     def post(cls):
         """
         Assigns a User as a new Admin.
@@ -25,9 +26,30 @@ class AssignNewUserAdmin(Resource):
 
         if current_identity.is_admin:
             data = request.json
-            return DAO.assign_new_user(data)
+            return DAO.assign_new_user(current_identity.id, data)
 
         else:
             return {
-                       "message": "You don't have admin status. You can't assign another admin"
-                   }, 401
+                       "message": "You don't have admin status. You can't assign other user as admin."
+                   }, 403
+
+
+@admin_ns.route('admin/remove')
+class RevokeUserAdmin(Resource):
+
+    @classmethod
+    @jwt_required()
+    @admin_ns.expect(auth_header_parser, assign_and_revoke_user_admin_request_body, validate=True)
+    def post(cls):
+        """
+        Revoke admin status from another User Admin.
+        """
+
+        if current_identity.is_admin:
+            data = request.json
+            return DAO.revoke_admin_user(current_identity.id, data)
+
+        else:
+            return {
+                       "message": "You don't have admin status. You can't revoke other admin user."
+                   }, 403

--- a/app/database/models/user.py
+++ b/app/database/models/user.py
@@ -113,6 +113,10 @@ class UserModel(db.Model):
         return cls.query.filter_by(id=_id).first()
 
     @classmethod
+    def get_all_admins(cls, is_admin=True):
+        return cls.query.filter_by(is_admin=is_admin).all()
+
+    @classmethod
     def is_empty(cls):
         return cls.query.first() is None
 

--- a/docs/Mentorship Backend.postman_collection.json
+++ b/docs/Mentorship Backend.postman_collection.json
@@ -168,6 +168,31 @@
 			"response": []
 		},
 		{
+			"name": "POST /admin/remove",
+			"request": {
+				"url": "http://127.0.0.1:5000/admin/new",
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "JWT eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE1Mjc4NTI3NzEsImlhdCI6MTUyNzg1MjQ3MSwibmJmIjoxNTI3ODUyNDcxLCJpZGVudGl0eSI6MX0.bXm5OrEvZnS6PxI4XQkOF4z-ZcFbYZreanutmYTUWyA",
+						"description": ""
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json",
+						"description": ""
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"user_id\": 2\n}"
+				},
+				"description": "Assign a new user as an Admin"
+			},
+			"response": []
+		},
+		{
 			"name": "GET /mentorship-relations",
 			"request": {
 				"url": "http://127.0.0.1:5000/mentorship-relations",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -33,6 +33,37 @@
                 ]
             }
         },
+        "/admin/remove": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    }
+                },
+                "summary": "Revoke admin status from another User Admin",
+                "operationId": "post_revoke_user_admin",
+                "parameters": [
+                    {
+                        "name": "Authorization",
+                        "in": "header",
+                        "type": "string",
+                        "required": true,
+                        "description": "Authentication access token. E.g.: JWT <access_token>"
+                    },
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/Assign User model"
+                        }
+                    }
+                ],
+                "tags": [
+                    "Admins"
+                ]
+            }
+        },
         "/login": {
             "post": {
                 "responses": {
@@ -153,20 +184,17 @@
             }
         },
         "/user": {
-            "get": {
+            "delete": {
                 "responses": {
                     "404": {
                         "description": "User not found."
                     },
-                    "200": {
-                        "description": "Success",
-                        "schema": {
-                            "$ref": "#/definitions/User list model"
-                        }
+                    "204": {
+                        "description": "User successfully deleted."
                     }
                 },
-                "summary": "Returns a user",
-                "operationId": "get_user",
+                "summary": "Deletes user",
+                "operationId": "delete_user",
                 "parameters": [
                     {
                         "name": "Authorization",
@@ -174,13 +202,6 @@
                         "type": "string",
                         "required": true,
                         "description": "Authentication access token. E.g.: JWT <access_token>"
-                    },
-                    {
-                        "name": "X-Fields",
-                        "in": "header",
-                        "type": "string",
-                        "format": "mask",
-                        "description": "An optional fields mask"
                     }
                 ],
                 "tags": [
@@ -219,17 +240,20 @@
                     "Users"
                 ]
             },
-            "delete": {
+            "get": {
                 "responses": {
                     "404": {
                         "description": "User not found."
                     },
-                    "204": {
-                        "description": "User successfully deleted."
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/User list model"
+                        }
                     }
                 },
-                "summary": "Deletes user",
-                "operationId": "delete_user",
+                "summary": "Returns a user",
+                "operationId": "get_user",
                 "parameters": [
                     {
                         "name": "Authorization",
@@ -237,6 +261,13 @@
                         "type": "string",
                         "required": true,
                         "description": "Authentication access token. E.g.: JWT <access_token>"
+                    },
+                    {
+                        "name": "X-Fields",
+                        "in": "header",
+                        "type": "string",
+                        "format": "mask",
+                        "description": "An optional fields mask"
                     }
                 ],
                 "tags": [

--- a/tests/admin/test_dao.py
+++ b/tests/admin/test_dao.py
@@ -1,6 +1,7 @@
 import unittest
 
 from tests.base_test_case import BaseTestCase
+from tests.test_data import user1
 from app.database.models.user import UserModel
 from app.api.dao.admin import AdminDAO
 from run import db
@@ -26,12 +27,106 @@ class TestAdminDao(BaseTestCase):
         self.assertFalse(user.is_admin)
 
         data = dict(
-            user_id='2'
+            user_id=2
         )
-        dao.assign_new_user(data)
+        dao.assign_new_user(1, data)
 
         user = UserModel.query.filter_by(id=2).first()
         self.assertTrue(user.is_admin)
+
+    def test_dao_assign_admin_role_to_myself(self):
+        dao = AdminDAO()
+
+        user = UserModel(
+            name=user1['name'],
+            username=user1['username'],
+            email=user1['email'],
+            password=user1['password'],
+            terms_and_conditions_checked=user1['terms_and_conditions_checked']
+        )
+        user.save_to_db()
+
+        user = UserModel.query.filter_by(id=2).first()
+        self.assertFalse(user.is_admin)
+
+        data = dict(
+            user_id=2
+        )
+
+        dao_result = dao.assign_new_user(2, data)
+
+        self.assertEqual(({"message": "You cannot assign yourself as an Admin."}, 403), dao_result)
+
+    def test_dao_revoke_admin_role_to_valid_user(self):
+        dao = AdminDAO()
+
+        user = UserModel(
+            name=user1['name'],
+            username=user1['username'],
+            email=user1['email'],
+            password=user1['password'],
+            terms_and_conditions_checked=user1['terms_and_conditions_checked']
+        )
+        user.save_to_db()
+
+        user = UserModel.query.filter_by(id=2).first()
+        self.assertFalse(user.is_admin)
+        user.is_admin = True
+        user.save_to_db()
+        self.assertTrue(user.is_admin)
+
+        data = dict(
+            user_id=2
+        )
+        dao.revoke_admin_user(1, data)
+
+        user = UserModel.query.filter_by(id=2).first()
+        self.assertFalse(user.is_admin)
+
+    def test_dao_revoke_admin_role_to_non_existing_user(self):
+        dao = AdminDAO()
+
+        data = dict(
+            user_id=123
+        )
+
+        dao_result = dao.revoke_admin_user(1, data)
+
+        self.assertEqual(({"message": "User does not exist."}, 404), dao_result)
+
+    def test_dao_revoke_admin_role_to_non_admin_user(self):
+        dao = AdminDAO()
+
+        user = UserModel(
+            name=user1['name'],
+            username=user1['username'],
+            email=user1['email'],
+            password=user1['password'],
+            terms_and_conditions_checked=user1['terms_and_conditions_checked']
+        )
+        user.save_to_db()
+
+        user = UserModel.query.filter_by(id=2).first()
+        self.assertFalse(user.is_admin)
+
+        data = dict(
+            user_id=2
+        )
+
+        dao_result = dao.revoke_admin_user(1, data)
+
+        self.assertEqual(({"message": "User is not an Admin."}, 400), dao_result)
+
+    def test_dao_revoke_admin_role_to_myself(self):
+        dao = AdminDAO()
+
+        data = dict(
+            user_id=1
+        )
+
+        dao_result = dao.revoke_admin_user(1, data)
+
+        self.assertEqual(({"message": "You cannot revoke your admin status."}, 403), dao_result)
 
 
 if __name__ == '__main__':

--- a/tests/users/test_dao.py
+++ b/tests/users/test_dao.py
@@ -34,6 +34,23 @@ class TestUserDao(BaseTestCase):
         self.assertIsInstance(user.registration_date, datetime.datetime)
         self.assertFalse(user.is_email_verified)
 
+    def test_dao_delete_only_user_admin(self):
+        dao = UserDAO()
+
+        before_delete_user = UserModel.query.filter_by(id=1).first()
+        self.assertIsNotNone(before_delete_user)
+        self.assertTrue(before_delete_user.is_admin)
+
+        dao_result = dao.delete_user(1)
+
+        # Verify that user was inserted in database through DAO
+        after_delete_user = UserModel.query.filter_by(id=1).first()
+        self.assertTrue(after_delete_user.is_admin)
+        self.assertIsNotNone(after_delete_user)
+        self.assertEqual(1, after_delete_user.id)
+        self.assertEqual(({"message": "You cannot delete your account, since you are the only Admin left."}, 400),
+                         dao_result)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Description

- [x] Added DAO function and API at POST /admin/remove, to revoke an admin role from a user
- [x] Added tests for DAO function
- [x] Updated Swagger API
- [x] Fix some points of discussion pending for project weekly meeting
- [x] Make sure these logic is respected... as a user:
     - [x] I can assign myself as an admin = F
     - [x] I can revoke my admin role = F
     - [x] I have to be an admin to assign and revoke admin roles of others = T
     - [x] I cannot delete my account if I’m the only Admin = T

Fixes #17 

### Type of Change:

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?

Added 3 tests for the AdminDAO function that revokes admin roles for the following cases:
- Revoking a user which is not an admin - should fail
- Revoking a user that does not exist - should fail
- Revoking a user that is an admin - should succeed

Tested on Swagger UI, the same tests above to test the API response.

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Update Postman API at /docs folder
- [x] Update Swagger documentation and the exported file at /docs folder

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
