### PR TITLE
Delete mentorship request API

### DIFF
--- a/app/api/dao/mentorship_relation.py
+++ b/app/api/dao/mentorship_relation.py
@@ -205,3 +205,31 @@ class MentorshipRelationDAO:
         request.save_to_db()
 
         return {'message': 'Mentorship relation was cancelled successfully.'}, 200
+
+    @staticmethod
+    def delete_request(user_id, request_id):
+
+        user = UserModel.find_by_id(user_id)
+
+        # verify if user exists
+        if user is None:
+            return {'message': 'User does not exist.'}, 404
+
+        request = MentorshipRelationModel.find_by_id(request_id)
+
+        # verify if request exists
+        if request is None:
+            return {'message': 'This mentorship relation request does not exist.'}, 404
+
+        # verify if request is in pending state
+        if request.state is not MentorshipRelationState.PENDING:
+            return {'message': 'This mentorship relation is not in the pending state.'}, 400
+
+        # verify if user created the mentorship request
+        if request.action_user_id is not user_id:
+            return {'message': 'You cannot delete a mentorship request that you did not create.'}, 400
+
+        # All was checked
+        request.delete_from_db()
+
+        return {'message': 'Mentorship relation was deleted successfully.'}, 200

--- a/app/api/resources/mentorship_relation.py
+++ b/app/api/resources/mentorship_relation.py
@@ -140,3 +140,24 @@ class CancelMentorshipRelation(Resource):
         response = DAO.cancel_relation(user_id=user_id, relation_id=request_id)
 
         return response
+
+
+@mentorship_relation_ns.route('mentorship_relation/<int:request_id>')
+class DeleteMentorshipRelation(Resource):
+
+    @classmethod
+    @jwt_required
+    @mentorship_relation_ns.doc('delete_mentorship_relation')
+    @mentorship_relation_ns.expect(auth_header_parser)
+    @mentorship_relation_ns.response(200, 'Deleted mentorship relation with success.')
+    def delete(cls, request_id):
+        """
+        Delete a mentorship request.
+        """
+
+        # TODO check if user id is well parsed, if it is an integer
+
+        user_id = get_jwt_identity()
+        response = DAO.delete_request(user_id=user_id, request_id=request_id)
+
+        return response

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -126,6 +126,37 @@
                 ]
             }
         },
+        "/mentorship_relation/{request_id}": {
+            "parameters": [
+                {
+                    "name": "request_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "delete": {
+                "responses": {
+                    "200": {
+                        "description": "Deleted mentorship relation with success."
+                    }
+                },
+                "summary": "Delete a mentorship request",
+                "operationId": "delete_mentorship_relation",
+                "parameters": [
+                    {
+                        "name": "Authorization",
+                        "in": "header",
+                        "type": "string",
+                        "required": true,
+                        "description": "Authentication access token. E.g.: Bearer <access_token>"
+                    }
+                ],
+                "tags": [
+                    "Mentorship Relation"
+                ]
+            }
+        },
         "/mentorship_relation/{request_id}/accept": {
             "parameters": [
                 {
@@ -301,6 +332,38 @@
                     "Users"
                 ]
             },
+            "put": {
+                "responses": {
+                    "404": {
+                        "description": "User not found."
+                    },
+                    "204": {
+                        "description": "User successfully updated."
+                    }
+                },
+                "summary": "Updates user profile",
+                "operationId": "update_user_profile",
+                "parameters": [
+                    {
+                        "name": "Authorization",
+                        "in": "header",
+                        "type": "string",
+                        "required": true,
+                        "description": "Authentication access token. E.g.: Bearer <access_token>"
+                    },
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/Update User request data model"
+                        }
+                    }
+                ],
+                "tags": [
+                    "Users"
+                ]
+            },
             "get": {
                 "responses": {
                     "404": {
@@ -329,38 +392,6 @@
                         "type": "string",
                         "format": "mask",
                         "description": "An optional fields mask"
-                    }
-                ],
-                "tags": [
-                    "Users"
-                ]
-            },
-            "put": {
-                "responses": {
-                    "404": {
-                        "description": "User not found."
-                    },
-                    "204": {
-                        "description": "User successfully updated."
-                    }
-                },
-                "summary": "Updates user profile",
-                "operationId": "update_user_profile",
-                "parameters": [
-                    {
-                        "name": "Authorization",
-                        "in": "header",
-                        "type": "string",
-                        "required": true,
-                        "description": "Authentication access token. E.g.: Bearer <access_token>"
-                    },
-                    {
-                        "name": "payload",
-                        "required": true,
-                        "in": "body",
-                        "schema": {
-                            "$ref": "#/definitions/Update User request data model"
-                        }
                     }
                 ],
                 "tags": [

--- a/tests/mentorship_relation/test_api_delete_request.py
+++ b/tests/mentorship_relation/test_api_delete_request.py
@@ -1,0 +1,99 @@
+import json
+import unittest
+from datetime import datetime, timedelta
+
+from app.database.sqlalchemy_extension import db
+from app.database.models.mentorship_relation import MentorshipRelationModel
+from app.utils.enum_utils import MentorshipRelationState
+from app.database.models.user import UserModel
+from tests.base_test_case import BaseTestCase
+from tests.test_data import user1, user2
+from tests.test_utils import get_test_request_header
+
+
+class TestDeleteMentorshipRequestApi(BaseTestCase):
+
+    # Setup consists of adding 2 users into the database
+    # User 1 is the mentorship relation requester = action user
+    # User 2 is the receiver
+    def setUp(self):
+        super(TestDeleteMentorshipRequestApi, self).setUp()
+
+        self.first_user = UserModel(
+            name=user1['name'],
+            email=user1['email'],
+            username=user1['username'],
+            password=user1['password'],
+            terms_and_conditions_checked=user1['terms_and_conditions_checked']
+        )
+        self.second_user = UserModel(
+            name=user2['name'],
+            email=user2['email'],
+            username=user2['username'],
+            password=user2['password'],
+            terms_and_conditions_checked=user2['terms_and_conditions_checked']
+        )
+
+        # making sure both are available to be mentor or mentee
+        self.first_user.need_mentoring = True
+        self.first_user.available_to_mentor = True
+        self.second_user.need_mentoring = True
+        self.second_user.available_to_mentor = True
+
+        self.notes_example = 'description of a good mentorship relation'
+
+        self.now_datetime = datetime.now()
+        self.end_date_example = self.now_datetime + timedelta(weeks=5)
+
+        db.session.add(self.first_user)
+        db.session.add(self.second_user)
+        db.session.commit()
+
+        # create new mentorship relation
+
+        self.mentorship_relation = MentorshipRelationModel(
+            action_user_id=self.first_user.id,
+            mentor_user=self.first_user,
+            mentee_user=self.second_user,
+            creation_date=self.now_datetime.timestamp(),
+            end_date=self.end_date_example.timestamp(),
+            state=MentorshipRelationState.PENDING,
+            notes=self.notes_example
+        )
+
+        db.session.add(self.mentorship_relation)
+        db.session.commit()
+
+    def test_sender_delete_mentorship_request(self):
+        request_id = self.mentorship_relation.id
+
+        self.assertEqual(MentorshipRelationState.PENDING, self.mentorship_relation.state)
+        self.assertIsNotNone(MentorshipRelationModel.query.filter_by(id=request_id).first())
+
+        with self.client:
+            response = self.client.delete('/mentorship_relation/%s' % request_id,
+                                          headers=get_test_request_header(self.first_user.id))
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({'message': 'Mentorship relation was deleted successfully.'},
+                         json.loads(response.data))
+        self.assertIsNone(MentorshipRelationModel.query.filter_by(id=request_id).first())
+
+    def test_receiver_delete_mentorship_request(self):
+        request_id = self.mentorship_relation.id
+
+        self.assertEqual(MentorshipRelationState.PENDING, self.mentorship_relation.state)
+        self.assertIsNotNone(MentorshipRelationModel.query.filter_by(id=request_id).first())
+
+        with self.client:
+            response = self.client.delete('/mentorship_relation/%s' % request_id,
+                                          headers=get_test_request_header(self.second_user.id))
+
+        self.assertEqual(400, response.status_code)
+        self.assertEqual({'message': 'You cannot delete a mentorship request that you did not create.'},
+                         json.loads(response.data))
+        self.assertIsNotNone(MentorshipRelationModel.query.filter_by(id=request_id).first())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/mentorship_relation/test_dao_delete_request.py
+++ b/tests/mentorship_relation/test_dao_delete_request.py
@@ -1,0 +1,136 @@
+from datetime import datetime, timedelta
+
+from app.api.dao.mentorship_relation import MentorshipRelationDAO
+from app.utils.enum_utils import MentorshipRelationState
+from app.database.models.mentorship_relation import MentorshipRelationModel
+from app.database.models.user import UserModel
+from app.database.sqlalchemy_extension import db
+from tests.base_test_case import BaseTestCase
+from tests.test_data import user1, user2
+
+
+class TestMentorshipRelationDeleteDAO(BaseTestCase):
+
+    # Setup consists of adding 2 users into the database
+    # User 1 is the mentorship relation requester = action user
+    # User 2 is the receiver
+    def setUp(self):
+        super(TestMentorshipRelationDeleteDAO, self).setUp()
+
+        self.first_user = UserModel(
+            name=user1['name'],
+            email=user1['email'],
+            username=user1['username'],
+            password=user1['password'],
+            terms_and_conditions_checked=user1['terms_and_conditions_checked']
+        )
+        self.second_user = UserModel(
+            name=user2['name'],
+            email=user2['email'],
+            username=user2['username'],
+            password=user2['password'],
+            terms_and_conditions_checked=user2['terms_and_conditions_checked']
+        )
+
+        # making sure both are available to be mentor or mentee
+        self.first_user.need_mentoring = True
+        self.first_user.available_to_mentor = True
+        self.second_user.need_mentoring = True
+        self.second_user.available_to_mentor = True
+
+        self.notes_example = 'description of a good mentorship relation'
+
+        self.now_datetime = datetime.now()
+        self.end_date_example = self.now_datetime + timedelta(weeks=5)
+
+        db.session.add(self.first_user)
+        db.session.add(self.second_user)
+        db.session.commit()
+
+        # create new mentorship relation
+
+        self.mentorship_relation = MentorshipRelationModel(
+            action_user_id=self.first_user.id,
+            mentor_user=self.first_user,
+            mentee_user=self.second_user,
+            creation_date=self.now_datetime.timestamp(),
+            end_date=self.end_date_example.timestamp(),
+            state=MentorshipRelationState.PENDING,
+            notes=self.notes_example
+        )
+
+        db.session.add(self.mentorship_relation)
+        db.session.commit()
+
+    def test_dao_delete_non_existing_mentorship_request(self):
+
+        result = MentorshipRelationDAO.delete_request(self.first_user.id, 123)
+
+        self.assertEqual(({'message': 'This mentorship relation request does not exist.'}, 404), result)
+        self.assertIsNotNone(MentorshipRelationModel.query.filter_by(id=self.mentorship_relation.id).first())
+
+    def test_dao_sender_does_not_exist(self):
+
+        result = MentorshipRelationDAO.delete_request(123, self.mentorship_relation.id)
+
+        self.assertEqual(({'message': 'User does not exist.'}, 404), result)
+        self.assertIsNotNone(MentorshipRelationModel.query.filter_by(id=self.mentorship_relation.id).first())
+
+    def test_dao_receiver_tries_to_delete_mentorship_request(self):
+
+        result = MentorshipRelationDAO.delete_request(self.second_user.id, self.mentorship_relation.id)
+
+        self.assertEqual(({'message': 'You cannot delete a mentorship request that you did not create.'}, 400), result)
+        self.assertIsNotNone(MentorshipRelationModel.query.filter_by(id=self.mentorship_relation.id).first())
+
+    def test_dao_sender_delete_mentorship_request(self):
+        relation_id = self.mentorship_relation.id
+
+        self.assertIsNotNone(MentorshipRelationModel.query.filter_by(id=relation_id).first())
+
+        result = MentorshipRelationDAO.delete_request(self.first_user.id, relation_id)
+        self.assertEqual(({'message': 'Mentorship relation was deleted successfully.'}, 200), result)
+
+        self.assertIsNone(MentorshipRelationModel.query.filter_by(id=relation_id).first())
+
+    def test_dao_user_not_involved_tries_to_delete_mentorship_request(self):
+
+        result = MentorshipRelationDAO.delete_request(self.admin_user.id, self.mentorship_relation.id)
+
+        self.assertEqual(({'message': 'You cannot delete a mentorship request that you did not create.'}, 400), result)
+        self.assertIsNotNone(MentorshipRelationModel.query.filter_by(id=self.mentorship_relation.id).first())
+
+    def test_dao_mentorship_delete_request_not_in_pending_state(self):
+        relation_id = self.mentorship_relation.id
+
+        self.mentorship_relation.state = MentorshipRelationState.ACCEPTED
+        db.session.add(self.mentorship_relation)
+        db.session.commit()
+
+        result = MentorshipRelationDAO.delete_request(self.first_user.id, self.mentorship_relation.id)
+        self.assertEqual(({'message': 'This mentorship relation is not in the pending state.'}, 400), result)
+        self.assertIsNotNone(MentorshipRelationModel.query.filter_by(id=relation_id).first())
+
+        self.mentorship_relation.state = MentorshipRelationState.COMPLETED
+        db.session.add(self.mentorship_relation)
+        db.session.commit()
+
+        result = MentorshipRelationDAO.delete_request(self.first_user.id, self.mentorship_relation.id)
+        self.assertEqual(({'message': 'This mentorship relation is not in the pending state.'}, 400), result)
+        self.assertIsNotNone(MentorshipRelationModel.query.filter_by(id=relation_id).first())
+
+        self.mentorship_relation.state = MentorshipRelationState.CANCELLED
+        db.session.add(self.mentorship_relation)
+        db.session.commit()
+
+        result = MentorshipRelationDAO.delete_request(self.first_user.id, self.mentorship_relation.id)
+        self.assertEqual(({'message': 'This mentorship relation is not in the pending state.'}, 400), result)
+        self.assertIsNotNone(MentorshipRelationModel.query.filter_by(id=relation_id).first())
+
+        self.mentorship_relation.state = MentorshipRelationState.REJECTED
+        db.session.add(self.mentorship_relation)
+        db.session.commit()
+
+        result = MentorshipRelationDAO.delete_request(self.first_user.id, self.mentorship_relation.id)
+        self.assertEqual(({'message': 'This mentorship relation is not in the pending state.'}, 400), result)
+        self.assertIsNotNone(MentorshipRelationModel.query.filter_by(id=relation_id).first())


### PR DESCRIPTION
### Description

I developed the API to delete a mentorship request: `DELETE /mentorship_relation/{id}` 
With these constraints:
- Only the requester of the relation can delete this
- The relation has to be in a pending state to be deleted

Fixes #65 

### Type of Change:

- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?

- Wrote tests for DAO class and the API itself.
- DAO tests covers all the predicted use cases of the `delete_request` function. Its tests if the request is deleted or not from the database.
- Ran these tests with success.

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] Update Swagger documentation and the exported file at /docs folder

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes