### PR TITLE
APIs to list previous, current and pending mentorship relations

### DIFF
--- a/app/api/dao/mentorship_relation.py
+++ b/app/api/dao/mentorship_relation.py
@@ -233,3 +233,58 @@ class MentorshipRelationDAO:
         request.delete_from_db()
 
         return {'message': 'Mentorship relation was deleted successfully.'}, 200
+
+    @staticmethod
+    def list_past_mentorship_relations(user_id):
+
+        user = UserModel.find_by_id(user_id)
+
+        # verify if user exists
+        if user is None:
+            return {'message': 'User does not exist.'}, 404
+
+        now_timestamp = datetime.now().timestamp()
+        past_relations = []
+        all_relations = user.mentor_relations + user.mentee_relations
+
+        for relation in all_relations:
+            if relation.end_date < now_timestamp:
+                past_relations += [relation]
+
+        return past_relations, 200
+
+    @staticmethod
+    def list_current_mentorship_relation(user_id):
+
+        user = UserModel.find_by_id(user_id)
+
+        # verify if user exists
+        if user is None:
+            return {'message': 'User does not exist.'}, 404
+
+        all_relations = user.mentor_relations + user.mentee_relations
+
+        for relation in all_relations:
+            if relation.state is MentorshipRelationState.ACCEPTED:
+                return relation
+
+        return {'message': 'You are not in a current mentorship relation.'}, 200
+
+    @staticmethod
+    def list_pending_mentorship_relations(user_id):
+
+        user = UserModel.find_by_id(user_id)
+
+        # verify if user exists
+        if user is None:
+            return {'message': 'User does not exist.'}, 404
+
+        now_timestamp = datetime.now().timestamp()
+        pending_requests = []
+        all_relations = user.mentor_relations + user.mentee_relations
+
+        for relation in all_relations:
+            if relation.state is MentorshipRelationState.PENDING and relation.end_date > now_timestamp:
+                pending_requests += [relation]
+
+        return pending_requests, 200

--- a/app/api/resources/mentorship_relation.py
+++ b/app/api/resources/mentorship_relation.py
@@ -1,10 +1,11 @@
 from flask import request
-from flask_restplus import Resource, Namespace
+from flask_restplus import Resource, Namespace, marshal
 from flask_jwt_extended import jwt_required, get_jwt_identity
 
 from app.api.resources.common import auth_header_parser
 from app.api.dao.mentorship_relation import MentorshipRelationDAO
 from app.api.models.mentorship_relation import *
+from app.database.models.mentorship_relation import MentorshipRelationModel
 
 mentorship_relation_ns = Namespace('Mentorship Relation',
                                    description='Operations related to '
@@ -69,7 +70,7 @@ class GetAllMyMentorshipRelation(Resource):
     @mentorship_relation_ns.marshal_list_with(mentorship_request_response_body)
     def get(cls):
         """
-        Lists all mentorship relations.
+        Lists all mentorship relations of current user.
         """
 
         user_id = get_jwt_identity()
@@ -159,5 +160,70 @@ class DeleteMentorshipRelation(Resource):
 
         user_id = get_jwt_identity()
         response = DAO.delete_request(user_id=user_id, request_id=request_id)
+
+        return response
+
+
+@mentorship_relation_ns.route('mentorship_relations/past')
+class ListPastMentorshipRelations(Resource):
+
+    @classmethod
+    @jwt_required
+    @mentorship_relation_ns.doc('get_past_mentorship_relations')
+    @mentorship_relation_ns.expect(auth_header_parser)
+    @mentorship_relation_ns.response(200, 'Returned past mentorship relations with success.',
+                                     model=mentorship_request_response_body)
+    @mentorship_relation_ns.marshal_list_with(mentorship_request_response_body)
+    def get(cls):
+        """
+        Lists past mentorship relations of the current user.
+        """
+
+        user_id = get_jwt_identity()
+        response = DAO.list_past_mentorship_relations(user_id)
+
+        return response
+
+
+@mentorship_relation_ns.route('mentorship_relations/current')
+class ListCurrentMentorshipRelation(Resource):
+
+    @classmethod
+    @jwt_required
+    @mentorship_relation_ns.doc('get_current_mentorship_relation')
+    @mentorship_relation_ns.expect(auth_header_parser)
+    @mentorship_relation_ns.response(200, 'Returned current mentorship relation with success.',
+                                     model=mentorship_request_response_body)
+    def get(cls):
+        """
+        Lists current mentorship relation of the current user.
+        """
+
+        user_id = get_jwt_identity()
+        response = DAO.list_current_mentorship_relation(user_id)
+
+        if isinstance(response, MentorshipRelationModel):
+            return marshal(response, mentorship_request_response_body), 200
+        else:
+            return response
+
+
+@mentorship_relation_ns.route('mentorship_relations/pending')
+class ListPendingMentorshipRequests(Resource):
+
+    @classmethod
+    @jwt_required
+    @mentorship_relation_ns.doc('get_pending_mentorship_relations')
+    @mentorship_relation_ns.expect(auth_header_parser)
+    @mentorship_relation_ns.response(200, 'Returned pending mentorship relation with success.',
+                                     model=mentorship_request_response_body)
+    @mentorship_relation_ns.marshal_list_with(mentorship_request_response_body)
+    def get(cls):
+        """
+        Lists pending mentorship requests of the current user.
+        """
+
+        user_id = get_jwt_identity()
+        response = DAO.list_pending_mentorship_relations(user_id)
 
         return response

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -260,8 +260,100 @@
                         }
                     }
                 },
-                "summary": "Lists all mentorship relations",
+                "summary": "Lists all mentorship relations of current user",
                 "operationId": "get_all_user_mentorship_relations",
+                "parameters": [
+                    {
+                        "name": "Authorization",
+                        "in": "header",
+                        "type": "string",
+                        "required": true,
+                        "description": "Authentication access token. E.g.: Bearer <access_token>"
+                    },
+                    {
+                        "name": "X-Fields",
+                        "in": "header",
+                        "type": "string",
+                        "format": "mask",
+                        "description": "An optional fields mask"
+                    }
+                ],
+                "tags": [
+                    "Mentorship Relation"
+                ]
+            }
+        },
+        "/mentorship_relations/current": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Returned current mentorship relation with success.",
+                        "schema": {
+                            "$ref": "#/definitions/List mentorship relation request model"
+                        }
+                    }
+                },
+                "summary": "Lists current mentorship relation of the current user",
+                "operationId": "get_current_mentorship_relation",
+                "parameters": [
+                    {
+                        "name": "Authorization",
+                        "in": "header",
+                        "type": "string",
+                        "required": true,
+                        "description": "Authentication access token. E.g.: Bearer <access_token>"
+                    }
+                ],
+                "tags": [
+                    "Mentorship Relation"
+                ]
+            }
+        },
+        "/mentorship_relations/past": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Returned past mentorship relations with success.",
+                        "schema": {
+                            "$ref": "#/definitions/List mentorship relation request model"
+                        }
+                    }
+                },
+                "summary": "Lists past mentorship relations of the current user",
+                "operationId": "get_past_mentorship_relations",
+                "parameters": [
+                    {
+                        "name": "Authorization",
+                        "in": "header",
+                        "type": "string",
+                        "required": true,
+                        "description": "Authentication access token. E.g.: Bearer <access_token>"
+                    },
+                    {
+                        "name": "X-Fields",
+                        "in": "header",
+                        "type": "string",
+                        "format": "mask",
+                        "description": "An optional fields mask"
+                    }
+                ],
+                "tags": [
+                    "Mentorship Relation"
+                ]
+            }
+        },
+        "/mentorship_relations/pending": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Returned pending mentorship relation with success.",
+                        "schema": {
+                            "$ref": "#/definitions/List mentorship relation request model"
+                        }
+                    }
+                },
+                "summary": "Lists pending mentorship requests of the current user",
+                "operationId": "get_pending_mentorship_relations",
                 "parameters": [
                     {
                         "name": "Authorization",
@@ -308,30 +400,6 @@
             }
         },
         "/user": {
-            "delete": {
-                "responses": {
-                    "404": {
-                        "description": "User not found."
-                    },
-                    "204": {
-                        "description": "User successfully deleted."
-                    }
-                },
-                "summary": "Deletes user",
-                "operationId": "delete_user",
-                "parameters": [
-                    {
-                        "name": "Authorization",
-                        "in": "header",
-                        "type": "string",
-                        "required": true,
-                        "description": "Authentication access token. E.g.: Bearer <access_token>"
-                    }
-                ],
-                "tags": [
-                    "Users"
-                ]
-            },
             "put": {
                 "responses": {
                     "404": {
@@ -358,6 +426,30 @@
                         "schema": {
                             "$ref": "#/definitions/Update User request data model"
                         }
+                    }
+                ],
+                "tags": [
+                    "Users"
+                ]
+            },
+            "delete": {
+                "responses": {
+                    "404": {
+                        "description": "User not found."
+                    },
+                    "204": {
+                        "description": "User successfully deleted."
+                    }
+                },
+                "summary": "Deletes user",
+                "operationId": "delete_user",
+                "parameters": [
+                    {
+                        "name": "Authorization",
+                        "in": "header",
+                        "type": "string",
+                        "required": true,
+                        "description": "Authentication access token. E.g.: Bearer <access_token>"
                     }
                 ],
                 "tags": [

--- a/tests/mentorship_relation/test_api_list_relations.py
+++ b/tests/mentorship_relation/test_api_list_relations.py
@@ -1,0 +1,118 @@
+import json
+import unittest
+from datetime import datetime, timedelta
+
+from app.database.sqlalchemy_extension import db
+from app.database.models.mentorship_relation import MentorshipRelationModel
+from app.utils.enum_utils import MentorshipRelationState
+from app.database.models.user import UserModel
+from tests.base_test_case import BaseTestCase
+from tests.test_data import user1, user2
+from tests.test_utils import get_test_request_header
+
+
+class TestListMentorshipRelationsApi(BaseTestCase):
+
+    # Setup consists of adding 2 users into the database
+    # User 1 is the mentorship relation requester = action user
+    # User 2 is the receiver
+    def setUp(self):
+        super(TestListMentorshipRelationsApi, self).setUp()
+
+        self.first_user = UserModel(
+            name=user1['name'],
+            email=user1['email'],
+            username=user1['username'],
+            password=user1['password'],
+            terms_and_conditions_checked=user1['terms_and_conditions_checked']
+        )
+        self.second_user = UserModel(
+            name=user2['name'],
+            email=user2['email'],
+            username=user2['username'],
+            password=user2['password'],
+            terms_and_conditions_checked=user2['terms_and_conditions_checked']
+        )
+
+        # making sure both are available to be mentor or mentee
+        self.first_user.need_mentoring = True
+        self.first_user.available_to_mentor = True
+        self.second_user.need_mentoring = True
+        self.second_user.available_to_mentor = True
+
+        self.notes_example = 'description of a good mentorship relation'
+
+        self.now_datetime = datetime.now()
+        self.past_end_date_example = self.now_datetime - timedelta(weeks=5)
+        self.future_end_date_example = self.now_datetime + timedelta(weeks=5)
+
+        db.session.add(self.first_user)
+        db.session.add(self.second_user)
+        db.session.commit()
+
+        # create new mentorship relation
+
+        self.past_mentorship_relation = MentorshipRelationModel(
+            action_user_id=self.first_user.id,
+            mentor_user=self.first_user,
+            mentee_user=self.second_user,
+            creation_date=self.now_datetime.timestamp(),
+            end_date=self.past_end_date_example.timestamp(),
+            state=MentorshipRelationState.PENDING,
+            notes=self.notes_example
+        )
+
+        self.future_pending_mentorship_relation = MentorshipRelationModel(
+            action_user_id=self.first_user.id,
+            mentor_user=self.first_user,
+            mentee_user=self.second_user,
+            creation_date=self.now_datetime.timestamp(),
+            end_date=self.future_end_date_example.timestamp(),
+            state=MentorshipRelationState.PENDING,
+            notes=self.notes_example
+        )
+
+        self.future_accepted_mentorship_relation = MentorshipRelationModel(
+            action_user_id=self.first_user.id,
+            mentor_user=self.first_user,
+            mentee_user=self.second_user,
+            creation_date=self.now_datetime.timestamp(),
+            end_date=self.future_end_date_example.timestamp(),
+            state=MentorshipRelationState.ACCEPTED,
+            notes=self.notes_example
+        )
+
+        db.session.add(self.past_mentorship_relation)
+        db.session.add(self.future_pending_mentorship_relation)
+        db.session.add(self.future_accepted_mentorship_relation)
+        db.session.commit()
+
+    def test_list_past_mentorship_relations(self):
+        with self.client:
+            response = self.client.get('/mentorship_relations/past',
+                                       headers=get_test_request_header(self.second_user.id))
+
+            self.assertEqual(200, response.status_code)
+            self.assertEqual([self.past_mentorship_relation.json()], json.loads(response.data))
+
+    def test_list_pending_mentorship_relations(self):
+        with self.client:
+            response = self.client.get('/mentorship_relations/pending',
+                                       headers=get_test_request_header(self.second_user.id))
+
+            self.assertEqual(200, response.status_code)
+            self.assertEqual([self.future_pending_mentorship_relation.json()],
+                             json.loads(response.data))
+
+    def test_list_current_mentorship_relation(self):
+        with self.client:
+            response = self.client.get('/mentorship_relations/current',
+                                       headers=get_test_request_header(self.second_user.id))
+
+            self.assertEqual(200, response.status_code)
+            self.assertEqual(self.future_accepted_mentorship_relation.json(),
+                             json.loads(response.data))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/mentorship_relation/test_dao_list_relations.py
+++ b/tests/mentorship_relation/test_dao_list_relations.py
@@ -1,0 +1,119 @@
+import unittest
+from datetime import datetime, timedelta
+
+from app.api.dao.mentorship_relation import MentorshipRelationDAO
+from app.database.models.mentorship_relation import MentorshipRelationModel
+from app.database.models.user import UserModel
+from app.database.sqlalchemy_extension import db
+from app.utils.enum_utils import MentorshipRelationState
+from tests.base_test_case import BaseTestCase
+from tests.test_data import user1, user2
+
+
+class TestListMentorshipRelationsDAO(BaseTestCase):
+
+    # Setup consists of adding 2 users into the database
+    def setUp(self):
+        super(TestListMentorshipRelationsDAO, self).setUp()
+
+        self.first_user = UserModel(
+            name=user1['name'],
+            email=user1['email'],
+            username=user1['username'],
+            password=user1['password'],
+            terms_and_conditions_checked=user1['terms_and_conditions_checked']
+        )
+        self.second_user = UserModel(
+            name=user2['name'],
+            email=user2['email'],
+            username=user2['username'],
+            password=user2['password'],
+            terms_and_conditions_checked=user2['terms_and_conditions_checked']
+        )
+
+        # making sure both are available to be mentor or mentee
+        self.first_user.need_mentoring = True
+        self.first_user.available_to_mentor = True
+        self.second_user.need_mentoring = True
+        self.second_user.available_to_mentor = True
+
+        self.notes_example = 'description of a good mentorship relation'
+
+        self.now_datetime = datetime.now()
+        self.past_end_date_example = self.now_datetime - timedelta(weeks=5)
+        self.future_end_date_example = self.now_datetime + timedelta(weeks=5)
+
+        db.session.add(self.first_user)
+        db.session.add(self.second_user)
+        db.session.commit()
+
+        # create new mentorship relation
+
+        self.past_mentorship_relation = MentorshipRelationModel(
+            action_user_id=self.first_user.id,
+            mentor_user=self.first_user,
+            mentee_user=self.second_user,
+            creation_date=self.now_datetime.timestamp(),
+            end_date=self.past_end_date_example.timestamp(),
+            state=MentorshipRelationState.PENDING,
+            notes=self.notes_example
+        )
+
+        self.future_pending_mentorship_relation = MentorshipRelationModel(
+            action_user_id=self.first_user.id,
+            mentor_user=self.first_user,
+            mentee_user=self.second_user,
+            creation_date=self.now_datetime.timestamp(),
+            end_date=self.future_end_date_example.timestamp(),
+            state=MentorshipRelationState.PENDING,
+            notes=self.notes_example
+        )
+
+        self.future_accepted_mentorship_relation = MentorshipRelationModel(
+            action_user_id=self.first_user.id,
+            mentor_user=self.first_user,
+            mentee_user=self.second_user,
+            creation_date=self.now_datetime.timestamp(),
+            end_date=self.future_end_date_example.timestamp(),
+            state=MentorshipRelationState.ACCEPTED,
+            notes=self.notes_example
+        )
+
+        db.session.add(self.past_mentorship_relation)
+        db.session.add(self.future_pending_mentorship_relation)
+        db.session.add(self.future_accepted_mentorship_relation)
+        db.session.commit()
+
+    def test_dao_list_past_mentorship_relations_all(self):
+
+        result = MentorshipRelationDAO.list_past_mentorship_relations(user_id=self.first_user.id)
+
+        expected_response = [self.past_mentorship_relation]
+
+        self.assertIsNotNone(result[0])
+        self.assertEqual(expected_response, result[0])
+
+    def test_dao_list_current_mentorship_relation(self):
+
+        result = MentorshipRelationDAO.list_current_mentorship_relation(user_id=self.first_user.id)
+        expected_response = self.future_accepted_mentorship_relation
+
+        self.assertEqual(expected_response, result)
+
+    def test_dao_list_non_existing_current_mentorship_relation(self):
+        result = MentorshipRelationDAO.list_current_mentorship_relation(user_id=self.admin_user.id)
+        expected_response = ({'message': 'You are not in a current mentorship relation.'}, 200)
+
+        self.assertEqual(expected_response, result)
+
+    def test_dao_list_pending_mentorship_relation(self):
+
+        result = MentorshipRelationDAO.list_pending_mentorship_relations(user_id=self.first_user.id)
+        expected_response = [self.future_pending_mentorship_relation]
+
+        self.assertEqual(expected_response, result[0])
+        self.assertEqual(200, result[1])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Description

Created API for listing mentorship requests and relations. 
3 Endpoints:
- `GET mentorship_relations/past`
   - presents all mentorship relations and requests passed the current date
- `GET mentorship_relations/current`
   - presents the relation in the `ACCEPTED` state
- `GET mentorship_relations/pending`
   - presents all requests in `PENDING` state that have not passed the current date yet

Fixes #11

### Type of Change:

- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
Describe the tests you ran to verify your changes. Provide instructions or GIFs so we can reproduce. List any relevant details for your test.


### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have made corresponding changes to the documentation
- [x] Update Swagger documentation and the exported file at /docs folder

**Code/Quality Assurance Only**
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
