### PR TITLE
Restrict GET /users API to authenticated users

### DIFF
--- a/app/api/models/user.py
+++ b/app/api/models/user.py
@@ -17,17 +17,41 @@ public_user_api_model = Model('User list model', {
         readOnly=True,
         description='The unique identifier of a user'
     ),
-    'name': fields.String(
-        required=True,
-        description='User name'
-    ),
     'username': fields.String(
         required=True,
         description='User username'
     ),
-    'email': fields.String(
+    'name': fields.String(
         required=True,
-        description='User email'
+        description='User name'
+    ),
+    'slack_username': fields.String(
+        required=True,
+        description='User Slack username'
+    ),
+    'bio': fields.String(
+        required=True,
+        description='User bio'
+    ),
+    'location': fields.String(
+        required=True,
+        description='User location'
+    ),
+    'interests': fields.String(
+        required=True,
+        description='User interests'
+    ),
+    'skills': fields.String(
+        required=True,
+        description='User skills'
+    ),
+    'need_mentoring': fields.Boolean(
+        required=True,
+        description='User need to be mentored indication'
+    ),
+    'available_to_mentor': fields.Boolean(
+        required=True,
+        description='User availability to mentor indication'
     )
 })
 

--- a/app/api/resources/user.py
+++ b/app/api/resources/user.py
@@ -16,12 +16,14 @@ add_models_to_namespace(users_ns)
 DAO = UserDAO()  # User data access object
 
 
-@users_ns.route('users/')
+@users_ns.route('users')
 class UserList(Resource):
 
     @classmethod
+    @jwt_required
     @users_ns.doc('list_users')
-    @users_ns.marshal_list_with(full_user_api_model)
+    @users_ns.marshal_list_with(public_user_api_model)
+    @users_ns.expect(auth_header_parser)
     def get(cls):
         """
         Returns list of all the users.
@@ -68,7 +70,7 @@ class MyUserProfile(Resource):
     @jwt_required
     @users_ns.doc('get_user')
     @users_ns.expect(auth_header_parser, validate=True)
-    @users_ns.marshal_with(public_user_api_model)  # , skip_none=True
+    @users_ns.marshal_with(full_user_api_model)  # , skip_none=True
     def get(cls):
         """
         Returns a user.
@@ -123,8 +125,10 @@ class ChangeUserPassword(Resource):
 class VerifiedUser(Resource):
 
     @classmethod
+    @jwt_required
     @users_ns.doc('get_verified_users')
-    @users_ns.marshal_with(public_user_api_model)  # , skip_none=True
+    @users_ns.marshal_list_with(public_user_api_model)  # , skip_none=True
+    @users_ns.expect(auth_header_parser)
     def get(cls):
         """
         Returns all verified users.

--- a/app/database/db_utils.py
+++ b/app/database/db_utils.py
@@ -1,4 +1,4 @@
-from . import db
+from app.database.sqlalchemy_extension import db
 
 
 def reset_database():

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -432,30 +432,6 @@
                     "Users"
                 ]
             },
-            "delete": {
-                "responses": {
-                    "404": {
-                        "description": "User not found."
-                    },
-                    "204": {
-                        "description": "User successfully deleted."
-                    }
-                },
-                "summary": "Deletes user",
-                "operationId": "delete_user",
-                "parameters": [
-                    {
-                        "name": "Authorization",
-                        "in": "header",
-                        "type": "string",
-                        "required": true,
-                        "description": "Authentication access token. E.g.: Bearer <access_token>"
-                    }
-                ],
-                "tags": [
-                    "Users"
-                ]
-            },
             "get": {
                 "responses": {
                     "404": {
@@ -464,7 +440,7 @@
                     "200": {
                         "description": "Success",
                         "schema": {
-                            "$ref": "#/definitions/User list model"
+                            "$ref": "#/definitions/User Complete model used in listing"
                         }
                     }
                 },
@@ -484,6 +460,30 @@
                         "type": "string",
                         "format": "mask",
                         "description": "An optional fields mask"
+                    }
+                ],
+                "tags": [
+                    "Users"
+                ]
+            },
+            "delete": {
+                "responses": {
+                    "404": {
+                        "description": "User not found."
+                    },
+                    "204": {
+                        "description": "User successfully deleted."
+                    }
+                },
+                "summary": "Deletes user",
+                "operationId": "delete_user",
+                "parameters": [
+                    {
+                        "name": "Authorization",
+                        "in": "header",
+                        "type": "string",
+                        "required": true,
+                        "description": "Authentication access token. E.g.: Bearer <access_token>"
                     }
                 ],
                 "tags": [
@@ -567,7 +567,7 @@
                 ]
             }
         },
-        "/users/": {
+        "/users": {
             "get": {
                 "responses": {
                     "200": {
@@ -575,7 +575,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/User Complete model used in listing"
+                                "$ref": "#/definitions/User list model"
                             }
                         }
                     }
@@ -583,6 +583,13 @@
                 "summary": "Returns list of all the users",
                 "operationId": "list_users",
                 "parameters": [
+                    {
+                        "name": "Authorization",
+                        "in": "header",
+                        "type": "string",
+                        "required": true,
+                        "description": "Authentication access token. E.g.: Bearer <access_token>"
+                    },
                     {
                         "name": "X-Fields",
                         "in": "header",
@@ -602,13 +609,23 @@
                     "200": {
                         "description": "Success",
                         "schema": {
-                            "$ref": "#/definitions/User list model"
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/User list model"
+                            }
                         }
                     }
                 },
                 "summary": "Returns all verified users",
                 "operationId": "get_verified_users",
                 "parameters": [
+                    {
+                        "name": "Authorization",
+                        "in": "header",
+                        "type": "string",
+                        "required": true,
+                        "description": "Authentication access token. E.g.: Bearer <access_token>"
+                    },
                     {
                         "name": "X-Fields",
                         "in": "header",
@@ -694,6 +711,119 @@
         }
     ],
     "definitions": {
+        "User list model": {
+            "required": [
+                "available_to_mentor",
+                "bio",
+                "interests",
+                "location",
+                "name",
+                "need_mentoring",
+                "skills",
+                "slack_username",
+                "username"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "description": "The unique identifier of a user"
+                },
+                "username": {
+                    "type": "string",
+                    "description": "User username"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "User name"
+                },
+                "slack_username": {
+                    "type": "string",
+                    "description": "User Slack username"
+                },
+                "bio": {
+                    "type": "string",
+                    "description": "User bio"
+                },
+                "location": {
+                    "type": "string",
+                    "description": "User location"
+                },
+                "interests": {
+                    "type": "string",
+                    "description": "User interests"
+                },
+                "skills": {
+                    "type": "string",
+                    "description": "User skills"
+                },
+                "need_mentoring": {
+                    "type": "boolean",
+                    "description": "User need to be mentored indication"
+                },
+                "available_to_mentor": {
+                    "type": "boolean",
+                    "description": "User availability to mentor indication"
+                }
+            },
+            "type": "object"
+        },
+        "Update User request data model": {
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "User name"
+                },
+                "username": {
+                    "type": "string",
+                    "description": "User username"
+                },
+                "bio": {
+                    "type": "string",
+                    "description": "User bio"
+                },
+                "location": {
+                    "type": "string",
+                    "description": "User location"
+                },
+                "occupation": {
+                    "type": "string",
+                    "description": "User occupation"
+                },
+                "slack_username": {
+                    "type": "string",
+                    "description": "User slack username"
+                },
+                "social_media_links": {
+                    "type": "string",
+                    "description": "User social media links"
+                },
+                "skills": {
+                    "type": "string",
+                    "description": "User skills"
+                },
+                "interests": {
+                    "type": "string",
+                    "description": "User interests"
+                },
+                "resume_url": {
+                    "type": "string",
+                    "description": "User resume url"
+                },
+                "photo_url": {
+                    "type": "string",
+                    "description": "User photo url"
+                },
+                "need_mentoring": {
+                    "type": "boolean",
+                    "description": "User need mentoring indication"
+                },
+                "available_to_mentor": {
+                    "type": "boolean",
+                    "description": "User availability to mentor indication"
+                }
+            },
+            "type": "object"
+        },
         "User Complete model used in listing": {
             "required": [
                 "email",
@@ -799,89 +929,6 @@
                 "membership_status": {
                     "type": "integer",
                     "description": "User membershipstatus"
-                }
-            },
-            "type": "object"
-        },
-        "User list model": {
-            "required": [
-                "email",
-                "name",
-                "username"
-            ],
-            "properties": {
-                "id": {
-                    "type": "integer",
-                    "description": "The unique identifier of a user"
-                },
-                "name": {
-                    "type": "string",
-                    "description": "User name"
-                },
-                "username": {
-                    "type": "string",
-                    "description": "User username"
-                },
-                "email": {
-                    "type": "string",
-                    "description": "User email"
-                }
-            },
-            "type": "object"
-        },
-        "Update User request data model": {
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "description": "User name"
-                },
-                "username": {
-                    "type": "string",
-                    "description": "User username"
-                },
-                "bio": {
-                    "type": "string",
-                    "description": "User bio"
-                },
-                "location": {
-                    "type": "string",
-                    "description": "User location"
-                },
-                "occupation": {
-                    "type": "string",
-                    "description": "User occupation"
-                },
-                "slack_username": {
-                    "type": "string",
-                    "description": "User slack username"
-                },
-                "social_media_links": {
-                    "type": "string",
-                    "description": "User social media links"
-                },
-                "skills": {
-                    "type": "string",
-                    "description": "User skills"
-                },
-                "interests": {
-                    "type": "string",
-                    "description": "User interests"
-                },
-                "resume_url": {
-                    "type": "string",
-                    "description": "User resume url"
-                },
-                "photo_url": {
-                    "type": "string",
-                    "description": "User photo url"
-                },
-                "need_mentoring": {
-                    "type": "boolean",
-                    "description": "User need mentoring indication"
-                },
-                "available_to_mentor": {
-                    "type": "boolean",
-                    "description": "User availability to mentor indication"
                 }
             },
             "type": "object"

--- a/tests/users/test_api_authentication.py
+++ b/tests/users/test_api_authentication.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from flask import json
 from flask_restplus import marshal
 
-from app.api.models.user import public_user_api_model
+from app.api.models.user import full_user_api_model
 from app.database.sqlalchemy_extension import db
 from app.database.models.user import UserModel
 from tests.base_test_case import BaseTestCase
@@ -32,7 +32,7 @@ class TestProtectedApi(BaseTestCase):
 
     def test_user_profile_with_header_api(self):
         auth_header = get_test_request_header(self.first_user.id)
-        expected_response = marshal(self.first_user, public_user_api_model)
+        expected_response = marshal(self.first_user, full_user_api_model)
         actual_response = self.client.get('/user', follow_redirects=True, headers=auth_header)
 
         self.assertEqual(200, actual_response.status_code)

--- a/tests/users/test_api_list_users.py
+++ b/tests/users/test_api_list_users.py
@@ -1,0 +1,28 @@
+import unittest
+from flask import json
+from flask_restplus import marshal
+from app.api.models.user import public_user_api_model
+from tests.base_test_case import BaseTestCase
+from tests.test_utils import get_test_request_header
+
+
+class TestListUsersApi(BaseTestCase):
+
+    def test_list_users_api_resource_non_auth(self):
+        expected_response = {'message': 'The authorization token is missing!'}
+        actual_response = self.client.get('/users', follow_redirects=True)
+
+        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_list_users_api_resource_auth(self):
+        auth_header = get_test_request_header(self.admin_user.id)
+        expected_response = [marshal(self.admin_user, public_user_api_model)]
+        actual_response = self.client.get('/users', follow_redirects=True, headers=auth_header)
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/users/test_api_resources.py
+++ b/tests/users/test_api_resources.py
@@ -16,7 +16,7 @@ from app.database.models.user import UserModel
 from tests.test_data import user1
 
 
-class TestUserApi(BaseTestCase):
+class TestUserRegistrationApi(BaseTestCase):
 
     def mail_send_mocked(self):
         return self
@@ -48,13 +48,6 @@ class TestUserApi(BaseTestCase):
                 self.assertEqual(user1['terms_and_conditions_checked'], user.terms_and_conditions_checked)
                 self.assertFalse(user.is_admin)
                 self.assertFalse(user.is_email_verified)
-
-    def test_list_users_api_resource(self):
-
-        response = self.client.get('/users', follow_redirects=True)
-        self.assertEqual(200, response.status_code)
-        # print(response)
-        # print(response.data)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description

- [x] This PR restricts the GET /users API for authenticated users.
- [x] This should be merged after PR #64 which fixes some exception throwing from flask-jwt library.
- [x] Restrict some information of users, that should not be seen by other users. **(needs discussion)**
   - [x] Username -> visible
- [x] Make GET /users/verified also retricted

Fixes #72 

### Type of Change:

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- Tested GET /users API on Swagger UI
- Developed a test to attempt to access this API without an access token

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] Any dependent changes have been merged
- [x] Update Swagger documentation and the exported file at /docs folder

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
