### PR TITLE
Fix bug of updating username already taken returning error 500

### DIFF
--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -47,7 +47,7 @@ class UserDAO:
 
         if user:
             user.delete_from_db()
-            return {"message": "User was deleted successfully"}, 201
+            return {"message": "User was deleted successfully"}, 200
 
         return {"message": "User does not exist"}, 404
 
@@ -80,15 +80,21 @@ class UserDAO:
     def update_user_profile(user_id, data):
 
         user = UserModel.find_by_id(user_id)
-
         if not user:
             return {"message": "User does not exist"}, 404
 
+        username = data.get('username', None)
+        if username:
+            user_with_same_username = UserModel.find_by_username(username)
+
+            # username should be unique
+            if user_with_same_username:
+                return {"message": "That username is already taken by another user."}, 400
+
+            user.username = username
+
         if 'name' in data and data['name']:
             user.name = data['name']
-
-        if 'username' in data and data['username']:
-            user.username = data['username']
 
         if 'bio' in data and data['bio']:
             user.bio = data['bio']
@@ -127,7 +133,7 @@ class UserDAO:
 
         user.save_to_db()
 
-        return {"message": "User was updated successfully"}, 201
+        return {"message": "User was updated successfully"}, 200
 
     @staticmethod
     def change_password(user_id, data):

--- a/app/api/resources/user.py
+++ b/app/api/resources/user.py
@@ -82,7 +82,8 @@ class MyUserProfile(Resource):
     @jwt_required
     @users_ns.doc('update_user_profile')
     @users_ns.expect(auth_header_parser, update_user_request_body_model)
-    @users_ns.response(204, 'User successfully updated.')
+    @users_ns.response(200, 'User successfully updated.')
+    @users_ns.response(404, 'User not found.')
     def put(cls):
         """
         Updates user profile
@@ -96,7 +97,8 @@ class MyUserProfile(Resource):
     @jwt_required
     @users_ns.doc('delete_user')
     @users_ns.expect(auth_header_parser, validate=True)
-    @users_ns.response(204, 'User successfully deleted.')
+    @users_ns.response(200, 'User successfully deleted.')
+    @users_ns.response(404, 'User not found.')
     def delete(cls):
         """
         Deletes user.

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -400,17 +400,17 @@
             }
         },
         "/user": {
-            "put": {
+            "delete": {
                 "responses": {
                     "404": {
                         "description": "User not found."
                     },
-                    "204": {
-                        "description": "User successfully updated."
+                    "200": {
+                        "description": "User successfully deleted."
                     }
                 },
-                "summary": "Updates user profile",
-                "operationId": "update_user_profile",
+                "summary": "Deletes user",
+                "operationId": "delete_user",
                 "parameters": [
                     {
                         "name": "Authorization",
@@ -418,14 +418,6 @@
                         "type": "string",
                         "required": true,
                         "description": "Authentication access token. E.g.: Bearer <access_token>"
-                    },
-                    {
-                        "name": "payload",
-                        "required": true,
-                        "in": "body",
-                        "schema": {
-                            "$ref": "#/definitions/Update User request data model"
-                        }
                     }
                 ],
                 "tags": [
@@ -466,17 +458,17 @@
                     "Users"
                 ]
             },
-            "delete": {
+            "put": {
                 "responses": {
                     "404": {
                         "description": "User not found."
                     },
-                    "204": {
-                        "description": "User successfully deleted."
+                    "200": {
+                        "description": "User successfully updated."
                     }
                 },
-                "summary": "Deletes user",
-                "operationId": "delete_user",
+                "summary": "Updates user profile",
+                "operationId": "update_user_profile",
                 "parameters": [
                     {
                         "name": "Authorization",
@@ -484,6 +476,14 @@
                         "type": "string",
                         "required": true,
                         "description": "Authentication access token. E.g.: Bearer <access_token>"
+                    },
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/Update User request data model"
+                        }
                     }
                 ],
                 "tags": [

--- a/tests/users/test_api_update_user.py
+++ b/tests/users/test_api_update_user.py
@@ -1,0 +1,71 @@
+import unittest
+from flask import json
+from app.database.models.user import UserModel
+from app.database.sqlalchemy_extension import db
+from tests.base_test_case import BaseTestCase
+from tests.test_data import user1
+from tests.test_utils import get_test_request_header
+
+
+class TestUpdateUserApi(BaseTestCase):
+
+    def test_update_user_api_resource_non_auth(self):
+        expected_response = {'message': 'The authorization token is missing!'}
+        actual_response = self.client.put('/user', follow_redirects=True)
+
+        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_update_username_already_taken(self):
+
+        self.first_user = UserModel(
+            name=user1['name'],
+            email=user1['email'],
+            username=user1['username'],
+            password=user1['password'],
+            terms_and_conditions_checked=user1['terms_and_conditions_checked']
+        )
+        self.first_user.is_email_verified = True
+
+        db.session.add(self.first_user)
+        db.session.commit()
+
+        auth_header = get_test_request_header(self.first_user.id)
+        expected_response = {"message": "That username is already taken by another user."}
+        actual_response = self.client.put('/user', follow_redirects=True,
+                                          headers=auth_header,
+                                          data=json.dumps(dict(username=self.admin_user.username)),
+                                          content_type='application/json')
+
+        self.assertEqual(400, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_update_username_not_taken(self):
+
+        self.first_user = UserModel(
+            name=user1['name'],
+            email=user1['email'],
+            username=user1['username'],
+            password=user1['password'],
+            terms_and_conditions_checked=user1['terms_and_conditions_checked']
+        )
+        self.first_user.is_email_verified = True
+
+        db.session.add(self.first_user)
+        db.session.commit()
+
+        user1_new_username = "new_username"
+        auth_header = get_test_request_header(self.first_user.id)
+        expected_response = {"message": "User was updated successfully"}
+        actual_response = self.client.put('/user', follow_redirects=True,
+                                          headers=auth_header,
+                                          data=json.dumps(dict(username=user1_new_username)),
+                                          content_type='application/json')
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+        self.assertEqual(user1_new_username, self.first_user.username)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description

This PR fixes the issue of updating a User's username already taken by another user. Instead of returning 500 - internal server error it returns 400 - That username is already taken by another user.
Also fixed error codes for this API.

Fixes #83 
Fixes #84 

### Type of Change:

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- Used Swagger API to change the username of a user to a username that already existed.
- Created unit tests for the API PUT /user testing both cases to update a username already taken and not taken

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Update Swagger documentation and the exported file at /docs folder

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes