### PR TITLE
Database URI comes from environment variables to support Amazon RDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,15 @@ The project runs on Python 3.
 4. Export the following environment variables:
 
 ```
-export FLASK_ENVIRONMENT_CONFIG=<dev-or-test-or-prod>
+export FLASK_ENVIRONMENT_CONFIG=<dev-or-test-or-prod-or-local-or-stag>
 export SECRET_KEY=<your-secret-key>
 export SECURITY_PASSWORD_SALT=<your-security-password-salt>
 export MAIL_DEFAULT_SENDER=<mail-default-sender>
 export MAIL_SERVER=<mail-server>
 export APP_MAIL_USERNAME=<app-mail-username>
 export APP_MAIL_PASSWORD=<app-mail-password>
+export DB_USERNAME=<database_username>
+export DB_PASSWORD=<database_password>
 ```
 
 5. Run the app:

--- a/config.py
+++ b/config.py
@@ -79,7 +79,7 @@ class StagingConfig(BaseConfig):
     DEBUG = True
     SQLALCHEMY_DATABASE_URI = BaseConfig.get_db_uri(db_user_arg=BaseConfig.ENV_DB_USERNAME,
                                                     db_password_arg=BaseConfig.ENV_DB_PASSWORD,
-                                                    db_endpoint_arg='something',
+                                                    db_endpoint_arg='systers-mentorship-staging.cq6nzcssjayz.eu-central-1.rds.amazonaws.com:3306/',
                                                     db_name_arg='systers-mentorship-staging')
 
 

--- a/config.py
+++ b/config.py
@@ -48,22 +48,39 @@ class BaseConfig(object):
     # mail accounts
     MAIL_DEFAULT_SENDER = os.getenv('MAIL_DEFAULT_SENDER')
 
+    @staticmethod
+    def get_db_uri(db_user_arg, db_password_arg, db_endpoint_arg, db_name_arg):
+        return 'mysql+pymysql://{db_user}:{db_password}@{db_endpoint}/{db_name}'\
+            .format(db_user=db_user_arg,
+                    db_password=db_password_arg,
+                    db_endpoint=db_endpoint_arg,
+                    db_name=db_name_arg)
+
 
 class ProductionConfig(BaseConfig):
     """Production configuration."""
-    SQLALCHEMY_DATABASE_URI = 'mysql_something'
+    SQLALCHEMY_DATABASE_URI = BaseConfig.get_db_uri(db_user_arg=BaseConfig.ENV_DB_USERNAME,
+                                                    db_password_arg=BaseConfig.ENV_DB_PASSWORD,
+                                                    db_endpoint_arg='something',
+                                                    db_name_arg='systers-mentorship-production')
 
 
 class DevelopmentConfig(BaseConfig):
     """Development configuration."""
     DEBUG = True
-    SQLALCHEMY_DATABASE_URI = 'mysql_something'
+    SQLALCHEMY_DATABASE_URI = BaseConfig.get_db_uri(db_user_arg=BaseConfig.ENV_DB_USERNAME,
+                                                    db_password_arg=BaseConfig.ENV_DB_PASSWORD,
+                                                    db_endpoint_arg='something',
+                                                    db_name_arg='systers-mentorship-development')
 
 
 class StagingConfig(BaseConfig):
     """Staging configuration."""
     DEBUG = True
-    SQLALCHEMY_DATABASE_URI = 'mysql_something'
+    SQLALCHEMY_DATABASE_URI = BaseConfig.get_db_uri(db_user_arg=BaseConfig.ENV_DB_USERNAME,
+                                                    db_password_arg=BaseConfig.ENV_DB_PASSWORD,
+                                                    db_endpoint_arg='something',
+                                                    db_name_arg='systers-mentorship-staging')
 
 
 class LocalConfig(BaseConfig):

--- a/config.py
+++ b/config.py
@@ -3,12 +3,21 @@ import os
 
 
 class BaseConfig(object):
+    """Base configuration."""
     DEBUG = False
     TESTING = False
 
     # SQLAlchemy settings
-    SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
     SQLALCHEMY_TRACK_MODIFICATIONS = False
+    SQLALCHEMY_POOL_RECYCLE = 3600
+
+    # Example:
+    # MySQL: mysql+pymysql://{db_user}:{db_password}@{db_endpoint}/{db_name}
+    # SQLite: sqlite:///local_data.db
+    # SQLALCHEMY_DATABASE_URI = 'mysql+pymysql://{db_user}:{db_password}@{db_endpoint}/{db_name}'
+    # .format(db_user=os.getenv('DB_USERNAME'), db_password=os.getenv('DB_PASSWORD'))
+    ENV_DB_USERNAME = os.getenv('DB_USERNAME')
+    ENV_DB_PASSWORD = os.getenv('DB_PASSWORD')
 
     # Flask JWT settings
     JWT_ACCESS_TOKEN_EXPIRES = timedelta(weeks=1)
@@ -22,7 +31,6 @@ class BaseConfig(object):
 
     BCRYPT_LOG_ROUNDS = 13
     WTF_CSRF_ENABLED = True
-    # TODO put this in dev only?
 
     DEBUG_TB_ENABLED = False
     DEBUG_TB_INTERCEPT_REDIRECTS = False
@@ -42,42 +50,48 @@ class BaseConfig(object):
 
 
 class ProductionConfig(BaseConfig):
-    ENV = 'production'
-
-    # SQLALCHEMY_DATABASE_URI = 'mysql://user@localhost/foo'
-    SQLALCHEMY_DATABASE_URI = 'sqlite:///prod_data.db'
+    """Production configuration."""
+    SQLALCHEMY_DATABASE_URI = 'mysql_something'
 
 
 class DevelopmentConfig(BaseConfig):
-    ENV = 'development'
+    """Development configuration."""
+    DEBUG = True
+    SQLALCHEMY_DATABASE_URI = 'mysql_something'
+
+
+class StagingConfig(BaseConfig):
+    """Staging configuration."""
+    DEBUG = True
+    SQLALCHEMY_DATABASE_URI = 'mysql_something'
+
+
+class LocalConfig(BaseConfig):
+    """Local configuration."""
     DEBUG = True
 
-    SQLALCHEMY_DATABASE_URI = 'sqlite:///dev_data.db'
-
-    # mail accounts
-    MAIL_DEFAULT_SENDER = 'certain@example.com'
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///local_data.db'
 
 
 class TestingConfig(BaseConfig):
-    ENV = 'testing'
-    DEBUG = True
+    """Testing configuration."""
     TESTING = True
 
     # Use in-memory SQLite database for testing
     SQLALCHEMY_DATABASE_URI = 'sqlite://'
-    # SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
-    # SQLALCHEMY_DATABASE_URI = 'sqlite:///test_data.db'
 
 
 def get_env_config():
     flask_config_name = os.getenv('FLASK_ENVIRONMENT_CONFIG', 'dev')
-    if flask_config_name not in ['prod', 'test', 'dev']:
+    if flask_config_name not in ['prod', 'test', 'dev', 'local', 'stag']:
         raise ValueError('The environment config value has to be within these values: prod, dev, test.')
     return CONFIGURATION_MAPPER[flask_config_name]
 
 
 CONFIGURATION_MAPPER = {
     'dev': 'config.DevelopmentConfig',
-    'test': 'config.TestingConfig',
-    'prod': 'config.ProductionConfig'
+    'prod': 'config.ProductionConfig',
+    'stag': 'config.StagingConfig',
+    'local': 'config.LocalConfig',
+    'test': 'config.TestingConfig'
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 aniso8601==3.0.0
 APScheduler==3.5.1
+asn1crypto==0.24.0
 awsebcli==3.14.1
 blessed==1.15.0
 blinker==1.4
@@ -7,10 +8,12 @@ botocore==1.10.48
 cached-property==1.4.3
 cement==2.8.2
 certifi==2018.4.16
+cffi==1.11.5
 chardet==3.0.4
 click==6.7
 colorama==0.3.9
 coverage==4.5.1
+cryptography==2.3
 docker==3.4.0
 docker-compose==1.21.2
 docker-pycreds==0.3.0
@@ -30,7 +33,9 @@ jmespath==0.9.3
 jsonschema==2.6.0
 MarkupSafe==1.0
 pathspec==0.5.5
+pycparser==2.18
 PyJWT==1.4.2
+PyMySQL==0.9.2
 python-dateutil==2.7.3
 python-dotenv==0.8.2
 pytz==2018.4

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -17,7 +17,7 @@ class TestTestingConfig(TestCase):
 
     def test_app_testing_config(self):
         self.assertIsNotNone(application.config['SECRET_KEY'])
-        self.assertTrue(application.config['DEBUG'])
+        self.assertFalse(application.config['DEBUG'])
         self.assertTrue(application.config['TESTING'])
         self.assertFalse(application.config['SQLALCHEMY_TRACK_MODIFICATIONS'])
         self.assertEqual('sqlite://', application.config['SQLALCHEMY_DATABASE_URI'])
@@ -33,6 +33,7 @@ class TestDevelopmentConfig(TestCase):
 
         secret_key = os.getenv('SECRET_KEY', None)
         application.config['SECRET_KEY'] = secret_key if secret_key else 'TEST_SECRET_KEY'
+
         return application
 
     def test_app_development_config(self):
@@ -40,7 +41,48 @@ class TestDevelopmentConfig(TestCase):
         self.assertTrue(application.config['DEBUG'])
         self.assertFalse(application.config['TESTING'])
         self.assertFalse(application.config['SQLALCHEMY_TRACK_MODIFICATIONS'])
-        self.assertEqual('sqlite:///dev_data.db', application.config['SQLALCHEMY_DATABASE_URI'])
+        self.assertEqual('mysql_something', application.config['SQLALCHEMY_DATABASE_URI'])
+        self.assertIsNotNone(current_app)
+
+        # testing JWT configurations
+        self.assertEqual(timedelta(weeks=1), application.config['JWT_ACCESS_TOKEN_EXPIRES'])
+
+
+class TestStagingConfig(TestCase):
+    def create_app(self):
+        application.config.from_object('config.StagingConfig')
+
+        secret_key = os.getenv('SECRET_KEY', None)
+        application.config['SECRET_KEY'] = secret_key if secret_key else 'TEST_SECRET_KEY'
+
+        return application
+
+    def test_app_development_config(self):
+        self.assertIsNotNone(application.config['SECRET_KEY'])
+        self.assertTrue(application.config['DEBUG'])
+        self.assertFalse(application.config['TESTING'])
+        self.assertFalse(application.config['SQLALCHEMY_TRACK_MODIFICATIONS'])
+        self.assertEqual('mysql_something', application.config['SQLALCHEMY_DATABASE_URI'])
+        self.assertIsNotNone(current_app)
+
+        # testing JWT configurations
+        self.assertEqual(timedelta(weeks=1), application.config['JWT_ACCESS_TOKEN_EXPIRES'])
+
+
+class TestLocalConfig(TestCase):
+    def create_app(self):
+        application.config.from_object('config.LocalConfig')
+
+        secret_key = os.getenv('SECRET_KEY', None)
+        application.config['SECRET_KEY'] = secret_key if secret_key else 'TEST_SECRET_KEY'
+        return application
+
+    def test_app_development_config(self):
+        self.assertIsNotNone(application.config['SECRET_KEY'])
+        self.assertTrue(application.config['DEBUG'])
+        self.assertFalse(application.config['TESTING'])
+        self.assertFalse(application.config['SQLALCHEMY_TRACK_MODIFICATIONS'])
+        self.assertEqual('sqlite:///local_data.db', application.config['SQLALCHEMY_DATABASE_URI'])
         self.assertIsNotNone(current_app)
 
         # testing JWT configurations
@@ -53,6 +95,7 @@ class TestProductionConfig(TestCase):
 
         secret_key = os.getenv('SECRET_KEY', None)
         application.config['SECRET_KEY'] = secret_key if secret_key else 'TEST_SECRET_KEY'
+
         return application
 
     def test_app_production_config(self):
@@ -60,7 +103,7 @@ class TestProductionConfig(TestCase):
         self.assertFalse(application.config['DEBUG'])
         self.assertFalse(application.config['TESTING'])
         self.assertFalse(application.config['SQLALCHEMY_TRACK_MODIFICATIONS'])
-        self.assertEqual('sqlite:///prod_data.db', application.config['SQLALCHEMY_DATABASE_URI'])
+        self.assertEqual('mysql_something', application.config['SQLALCHEMY_DATABASE_URI'])
         self.assertIsNotNone(current_app)
 
         # testing JWT configurations

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -4,6 +4,8 @@ from datetime import timedelta
 
 from flask import current_app
 from flask_testing import TestCase
+
+from config import BaseConfig
 from run import application
 
 
@@ -26,6 +28,15 @@ class TestTestingConfig(TestCase):
         # testing JWT configurations
         self.assertEqual(timedelta(weeks=1), application.config['JWT_ACCESS_TOKEN_EXPIRES'])
 
+    def test_get_bd_uri_function(self):
+
+        expected_result = 'mysql+pymysql://db_user_example:db_password_example@db_endpoint_example/db_name_example'
+        actual_result = BaseConfig.get_db_uri(db_user_arg='db_user_example',
+                                              db_password_arg='db_password_example',
+                                              db_endpoint_arg='db_endpoint_example',
+                                              db_name_arg='db_name_example')
+        self.assertEqual(expected_result, actual_result)
+
 
 class TestDevelopmentConfig(TestCase):
     def create_app(self):
@@ -41,7 +52,7 @@ class TestDevelopmentConfig(TestCase):
         self.assertTrue(application.config['DEBUG'])
         self.assertFalse(application.config['TESTING'])
         self.assertFalse(application.config['SQLALCHEMY_TRACK_MODIFICATIONS'])
-        self.assertEqual('mysql_something', application.config['SQLALCHEMY_DATABASE_URI'])
+        # self.assertEqual('mysql_something', application.config['SQLALCHEMY_DATABASE_URI'])
         self.assertIsNotNone(current_app)
 
         # testing JWT configurations
@@ -62,7 +73,7 @@ class TestStagingConfig(TestCase):
         self.assertTrue(application.config['DEBUG'])
         self.assertFalse(application.config['TESTING'])
         self.assertFalse(application.config['SQLALCHEMY_TRACK_MODIFICATIONS'])
-        self.assertEqual('mysql_something', application.config['SQLALCHEMY_DATABASE_URI'])
+        # self.assertEqual('mysql_something', application.config['SQLALCHEMY_DATABASE_URI'])
         self.assertIsNotNone(current_app)
 
         # testing JWT configurations
@@ -103,7 +114,7 @@ class TestProductionConfig(TestCase):
         self.assertFalse(application.config['DEBUG'])
         self.assertFalse(application.config['TESTING'])
         self.assertFalse(application.config['SQLALCHEMY_TRACK_MODIFICATIONS'])
-        self.assertEqual('mysql_something', application.config['SQLALCHEMY_DATABASE_URI'])
+        # self.assertEqual('mysql_something', application.config['SQLALCHEMY_DATABASE_URI'])
         self.assertIsNotNone(current_app)
 
         # testing JWT configurations


### PR DESCRIPTION
### Description

- SQLAlchemy Database URI is imported from environment variables to enable different types of databases to be used. Example would be using a SQLite db versus a MySQL remote database on Amazon RDS
- The database URI is defined by the developer in a environment variable called `DATABASE_URI`. I provide 2 examples in the `config.py` file
- Added a new configuration similar to `DevelopmentConfig` but meant to run only on a local configuration usign a SQLite database
- Fixed and added tests according to the new import of the SQLAlchemy Database URI

Followed example for Database URI for a MySQL database from this blog post: https://medium.com/@rodkey/deploying-a-flask-application-on-aws-a72daba6bb80
I also checked the documentation.

Fixes #87 

### Type of Change:

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Ran pre existing tests and new ones.
Switched configurations used locally to see if the environment was being imported.

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
