### PR TITLE
Name validations: only alphabetic characters

### DIFF
--- a/app/api/validations/user.py
+++ b/app/api/validations/user.py
@@ -1,4 +1,4 @@
-from app.utils.validation_utils import is_email_valid, is_username_valid, validate_length, get_stripped_string
+from app.utils.validation_utils import is_name_valid, is_email_valid, is_username_valid, validate_length, get_stripped_string
 
 # Field character limit
 
@@ -57,6 +57,9 @@ def validate_user_registration_request_data(data):
     if terms_and_conditions_checked is False:
         return {"message": "Terms and conditions are not checked."}
 
+    if not is_name_valid(name):
+        return {"message": "Your name is invalid."}
+
     if not is_email_valid(email):
         return {"message": "Your email is invalid."}
 
@@ -99,6 +102,9 @@ def validate_update_profile_request_data(data):
         is_valid = validate_length(len(get_stripped_string(name)), NAME_MIN_LENGTH, NAME_MAX_LENGTH, 'name')
         if not is_valid[0]:
             return is_valid[1]
+
+        if not is_name_valid(name):
+            return {"message": "Your name is invalid."}
 
     bio = data.get('bio', None)
     if bio:

--- a/app/utils/validation_utils.py
+++ b/app/utils/validation_utils.py
@@ -1,7 +1,12 @@
 import re
 
+name_regex = r"(^[a-zA-Z\s\-]+$)"
 email_regex = r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)"
 username_regex = r"(^[a-zA-Z0-9_]+$)"
+
+
+def is_name_valid(name):
+    return re.match(name_regex, name)
 
 
 def is_email_valid(email):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -8,14 +8,14 @@ test_admin_user = dict(
 )
 
 user1 = dict(
-    name="User1",
+    name="User",
     email="user1@email.com",
     username="user1",
     password="user1_pwd",
     terms_and_conditions_checked=True
 )
 user2 = dict(
-    name="User2",
+    name="Userb",
     email="user2@email.com",
     username="user2",
     password="user2_pwd",

--- a/tests/utils/test_name_validation.py
+++ b/tests/utils/test_name_validation.py
@@ -1,0 +1,29 @@
+import unittest
+from app.utils.validation_utils import is_name_valid
+
+
+class TestNameValidation(unittest.TestCase):
+
+    def test_empty_name(self):
+        name = ""
+        is_valid = is_name_valid(name)
+        self.assertFalse(is_valid)
+
+    def test_valid_name(self):
+        name = "valid"
+        is_valid = is_name_valid(name)
+        self.assertTrue(is_valid)
+
+    def test_valid_name_with_dash(self):
+        name = "valid-name"
+        is_valid = is_name_valid(name)
+        self.assertTrue(is_valid)
+
+    def test_invalid_name_with_special_characters(self):
+        name = "invalidname@123"
+        is_valid = is_name_valid(name)
+        self.assertFalse(is_valid)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Description
Currently, numeric or special characters alone can be used to substitute for the name field, which increases anonymity. Name field should only be allowed to have alphabetic characters

Fixes #113 
Related to bug #108

### Type of Change:
- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Ran pre existing tests and new ones.

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
