### PR TITLE
Added sent_by_me field to list Mentorship Relation API

### DIFF
--- a/app/api/dao/mentorship_relation.py
+++ b/app/api/dao/mentorship_relation.py
@@ -100,9 +100,17 @@ class MentorshipRelationDAO:
             return {'message': 'Not implemented.'}, 200
 
         user = UserModel.find_by_id(user_id)
+
+        if user is None:
+            return {'message': 'User does not exist.'}, 404
+
         all_relations = user.mentor_relations + user.mentee_relations
 
-        return all_relations
+        # add extra field for api response
+        for relation in all_relations:
+            setattr(relation, 'sent_by_me', relation.action_user_id == user_id)
+
+        return all_relations, 200
 
     @staticmethod
     def accept_request(user_id, request_id):
@@ -249,6 +257,7 @@ class MentorshipRelationDAO:
 
         for relation in all_relations:
             if relation.end_date < now_timestamp:
+                setattr(relation, 'sent_by_me', relation.action_user_id == user_id)
                 past_relations += [relation]
 
         return past_relations, 200
@@ -266,6 +275,7 @@ class MentorshipRelationDAO:
 
         for relation in all_relations:
             if relation.state is MentorshipRelationState.ACCEPTED:
+                setattr(relation, 'sent_by_me', relation.action_user_id == user_id)
                 return relation
 
         return {'message': 'You are not in a current mentorship relation.'}, 200
@@ -285,6 +295,7 @@ class MentorshipRelationDAO:
 
         for relation in all_relations:
             if relation.state is MentorshipRelationState.PENDING and relation.end_date > now_timestamp:
+                setattr(relation, 'sent_by_me', relation.action_user_id == user_id)
                 pending_requests += [relation]
 
         return pending_requests, 200

--- a/app/api/models/mentorship_relation.py
+++ b/app/api/models/mentorship_relation.py
@@ -24,6 +24,7 @@ relation_user_response_body = Model('User', {
 mentorship_request_response_body = Model('List mentorship relation request model', {
     'id': fields.Integer(required=True, description='Mentorship relation ID'),
     'action_user_id': fields.Integer(required=True, description='Mentorship relation requester user ID'),
+    'sent_by_me': fields.Boolean(required=True, description='Mentorship relation sent by current user indication'),
     'mentor': fields.Nested(relation_user_response_body),
     'mentee': fields.Nested(relation_user_response_body),
     'creation_date': fields.Float(required=True, description='Mentorship relation creation date in UNIX timestamp format'),

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -400,30 +400,6 @@
             }
         },
         "/user": {
-            "delete": {
-                "responses": {
-                    "404": {
-                        "description": "User not found."
-                    },
-                    "200": {
-                        "description": "User successfully deleted."
-                    }
-                },
-                "summary": "Deletes user",
-                "operationId": "delete_user",
-                "parameters": [
-                    {
-                        "name": "Authorization",
-                        "in": "header",
-                        "type": "string",
-                        "required": true,
-                        "description": "Authentication access token. E.g.: Bearer <access_token>"
-                    }
-                ],
-                "tags": [
-                    "Users"
-                ]
-            },
             "get": {
                 "responses": {
                     "404": {
@@ -452,6 +428,30 @@
                         "type": "string",
                         "format": "mask",
                         "description": "An optional fields mask"
+                    }
+                ],
+                "tags": [
+                    "Users"
+                ]
+            },
+            "delete": {
+                "responses": {
+                    "404": {
+                        "description": "User not found."
+                    },
+                    "200": {
+                        "description": "User successfully deleted."
+                    }
+                },
+                "summary": "Deletes user",
+                "operationId": "delete_user",
+                "parameters": [
+                    {
+                        "name": "Authorization",
+                        "in": "header",
+                        "type": "string",
+                        "required": true,
+                        "description": "Authentication access token. E.g.: Bearer <access_token>"
                     }
                 ],
                 "tags": [
@@ -1092,9 +1092,8 @@
                 "creation_date",
                 "end_date",
                 "id",
-                "mentee_id",
-                "mentor_id",
                 "notes",
+                "sent_by_me",
                 "start_date",
                 "state"
             ],
@@ -1107,13 +1106,15 @@
                     "type": "integer",
                     "description": "Mentorship relation requester user ID"
                 },
-                "mentor_id": {
-                    "type": "integer",
-                    "description": "Mentorship relation mentor ID"
+                "sent_by_me": {
+                    "type": "boolean",
+                    "description": "Mentorship relation sent by current user indication"
                 },
-                "mentee_id": {
-                    "type": "integer",
-                    "description": "Mentorship relation mentee ID"
+                "mentor": {
+                    "$ref": "#/definitions/User"
+                },
+                "mentee": {
+                    "$ref": "#/definitions/User"
                 },
                 "creation_date": {
                     "type": "number",
@@ -1138,6 +1139,23 @@
                 "notes": {
                     "type": "string",
                     "description": "Mentorship relation notes"
+                }
+            },
+            "type": "object"
+        },
+        "User": {
+            "required": [
+                "id",
+                "name"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "description": "User ID"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "User name"
                 }
             },
             "type": "object"

--- a/tests/mentorship_relation/test_dao_list_relations.py
+++ b/tests/mentorship_relation/test_dao_list_relations.py
@@ -84,7 +84,7 @@ class TestListMentorshipRelationsDAO(BaseTestCase):
         db.session.add(self.future_accepted_mentorship_relation)
         db.session.commit()
 
-    def test_dao_list_past_mentorship_relations_all(self):
+    def test_dao_list_past_mentorship_relations(self):
 
         result = MentorshipRelationDAO.list_past_mentorship_relations(user_id=self.first_user.id)
 

--- a/tests/mentorship_relation/test_dao_listing.py
+++ b/tests/mentorship_relation/test_dao_listing.py
@@ -126,7 +126,7 @@ class TestMentorshipRelationListingDAO(BaseTestCase):
         db.session.commit()
 
         result = DAO.list_mentorship_relations(user_id=self.first_user.id)
-        expected_response = [self.mentorship_relation]
+        expected_response = [self.mentorship_relation], 200
 
         self.assertIsNotNone(result)
         self.assertEqual(expected_response, result)


### PR DESCRIPTION
# Description

Added `sent_by_me` field to any MentorshipRelation API. Affected APIs include all APIs that list mentorship relations as a list or isolated, like showing the current relation.

The solution is the only hack that I could see fit.
I change the model object just before being marshalled by flask restplus.
I do this with `setattr()` function and I attribute the value from the condition if the `action_user_id` is the current user's id

Fixes #124

# Type of Change:

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Added test to see if the field `sent_by_me` value was well set
Tested on Swagger


# Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] Update Swagger documentation and the exported file at /docs folder

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
