### PR TITLE
Added Mentorship Relation Tasks feature

### DIFF
--- a/app/api/dao/mentorship_relation.py
+++ b/app/api/dao/mentorship_relation.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 
 from app.database.models.mentorship_relation import MentorshipRelationModel
+from app.database.models.tasks_list import TasksListModel
 from app.database.models.user import UserModel
 from app.utils.enum_utils import MentorshipRelationState
 
@@ -74,13 +75,17 @@ class MentorshipRelationDAO:
 
         # All validations were checked
 
+        tasks_list = TasksListModel()
+        tasks_list.save_to_db()
+
         mentorship_relation = MentorshipRelationModel(action_user_id=action_user_id,
                                                       mentor_user=mentor_user,
                                                       mentee_user=mentee_user,
                                                       creation_date=datetime.now().timestamp(),
                                                       end_date=end_date_timestamp,
                                                       state=MentorshipRelationState.PENDING,
-                                                      notes=notes)
+                                                      notes=notes,
+                                                      tasks_list=tasks_list)
 
         mentorship_relation.save_to_db()
 

--- a/app/api/dao/task.py
+++ b/app/api/dao/task.py
@@ -1,0 +1,95 @@
+from datetime import datetime
+
+from app.database.models.mentorship_relation import MentorshipRelationModel
+from app.database.models.user import UserModel
+from app.utils.enum_utils import MentorshipRelationState
+
+
+class TaskDAO:
+
+    @staticmethod
+    def create_task(user_id, mentorship_relation_id, data):
+        description = data['description']
+
+        user = UserModel.find_by_id(user_id)
+        if user is None:
+            return {'message': 'User does not exist.'}, 404
+
+        relation = MentorshipRelationModel.find_by_id(_id=mentorship_relation_id)
+        if relation is None:
+            return {'message': 'Mentorship relation does not exist.'}, 404
+
+        if relation.state is not MentorshipRelationState.ACCEPTED:
+            return {'message': 'Mentorship relation is not in the accepted state.'}, 400
+
+        now_timestamp = datetime.now().timestamp()
+        relation.tasks_list.add_task(description=description, created_at=now_timestamp)
+        relation.tasks_list.save_to_db()
+
+        return {"message": "Task was created successfully."}, 200
+
+    @staticmethod
+    def list_tasks(user_id, mentorship_relation_id):
+
+        user = UserModel.find_by_id(user_id)
+        if user is None:
+            return {'message': 'User does not exist.'}, 404
+
+        relation = MentorshipRelationModel.find_by_id(mentorship_relation_id)
+        if relation is None:
+            return {'message': 'Mentorship relation does not exist.'}, 404
+
+        if not (user_id is relation.mentee_id or user_id is relation.mentor_id):
+            return {'message': 'You are not involved in this mentorship relation.'}, 401
+
+        all_tasks = relation.tasks_list.tasks
+
+        return all_tasks
+
+    @staticmethod
+    def delete_task(user_id, mentorship_relation_id, task_id):
+
+        user = UserModel.find_by_id(user_id)
+        if user is None:
+            return {'message': 'User does not exist.'}, 404
+
+        relation = MentorshipRelationModel.find_by_id(mentorship_relation_id)
+        if relation is None:
+            return {'message': 'Mentorship relation does not exist.'}, 404
+
+        task = relation.tasks_list.find_task_by_id(task_id)
+        if task is None:
+            return {'message': 'Task does not exist.'}, 404
+
+        if not (user_id is relation.mentee_id or user_id is relation.mentor_id):
+            return {'message': 'You are not involved in this mentorship relation.'}, 401
+
+        relation.tasks_list.delete_task(task_id)
+
+        return {'message': 'Task was deleted successfully.'}, 200
+
+    @staticmethod
+    def complete_task(user_id, mentorship_relation_id, task_id):
+
+        user = UserModel.find_by_id(user_id)
+        if user is None:
+            return {'message': 'User does not exist.'}, 404
+
+        relation = MentorshipRelationModel.find_by_id(mentorship_relation_id)
+        if relation is None:
+            return {'message': 'Mentorship relation does not exist.'}, 404
+
+        if not (user_id is relation.mentee_id or user_id is relation.mentor_id):
+            return {'message': 'You are not involved in this mentorship relation.'}, 401
+
+        task = relation.tasks_list.find_task_by_id(task_id)
+        if task is None:
+            return {'message': 'Task does not exist.'}, 404
+
+        if task.get('is_done'):
+            return {'message': 'Task was already achieved.'}, 400
+        else:
+            relation.tasks_list.update_task(
+                task_id=task_id, is_done=True, completed_at=datetime.now().timestamp())
+
+        return {'message': 'Task was achieved successfully.'}, 200

--- a/app/api/models/mentorship_relation.py
+++ b/app/api/models/mentorship_relation.py
@@ -7,6 +7,8 @@ def add_models_to_namespace(api_namespace):
     api_namespace.models[send_mentorship_request_body.name] = send_mentorship_request_body
     api_namespace.models[mentorship_request_response_body.name] = mentorship_request_response_body
     api_namespace.models[relation_user_response_body.name] = relation_user_response_body
+    api_namespace.models[create_task_request_body.name] = create_task_request_body
+    api_namespace.models[list_tasks_response_body.name] = list_tasks_response_body
 
 
 send_mentorship_request_body = Model('Send mentorship relation request model', {
@@ -33,4 +35,16 @@ mentorship_request_response_body = Model('List mentorship relation request model
     'end_date': fields.Float(required=True, description='Mentorship relation end date in UNIX timestamp format'),
     'state': fields.Integer(required=True, enum=MentorshipRelationState.values, description='Mentorship relation state'),
     'notes': fields.String(required=True, description='Mentorship relation notes')
+})
+
+create_task_request_body = Model('Create task request model', {
+    'description': fields.String(required=True, description='Mentorship relation task description')
+})
+
+list_tasks_response_body = Model('List tasks response model', {
+    'id': fields.Integer(required=True, description='Task ID'),
+    'description': fields.String(required=True, description='Mentorship relation task description'),
+    'is_done': fields.Boolean(required=True, description='Mentorship relation task is done indication'),
+    'created_at': fields.Float(required=True, description='Task creation date in UNIX timestamp format'),
+    'completed_at': fields.Float(required=False, description='Task completion date in UNIX timestamp format')
 })

--- a/app/api/resources/mentorship_relation.py
+++ b/app/api/resources/mentorship_relation.py
@@ -2,6 +2,7 @@ from flask import request
 from flask_restplus import Resource, Namespace, marshal
 from flask_jwt_extended import jwt_required, get_jwt_identity
 
+from app.api.dao.task import TaskDAO
 from app.api.resources.common import auth_header_parser
 from app.api.dao.mentorship_relation import MentorshipRelationDAO
 from app.api.models.mentorship_relation import *
@@ -225,5 +226,111 @@ class ListPendingMentorshipRequests(Resource):
 
         user_id = get_jwt_identity()
         response = DAO.list_pending_mentorship_relations(user_id)
+
+        return response
+
+
+@mentorship_relation_ns.route('mentorship_relation/<int:request_id>/task')
+class CreateTask(Resource):
+
+    @classmethod
+    @jwt_required
+    @mentorship_relation_ns.doc('create_task_in_mentorship_relation')
+    @mentorship_relation_ns.expect(auth_header_parser, create_task_request_body)
+    @mentorship_relation_ns.response(200, 'Created task with success.')
+    def post(cls, request_id):
+        """
+        Create a task.
+        """
+
+        # TODO check if user id is well parsed, if it is an integer
+
+        user_id = get_jwt_identity()
+        request_body = request.json
+
+        is_valid = CreateTask.is_valid_data(request_body)
+
+        if is_valid != {}:
+            return is_valid, 400
+
+        response = TaskDAO.create_task(user_id=user_id, mentorship_relation_id=request_id, data=request_body)
+
+        return response
+
+    @staticmethod
+    def is_valid_data(data):
+
+        if 'description' not in data:
+            return {"message": "Description field is missing."}
+
+        return {}
+
+
+@mentorship_relation_ns.route('mentorship_relation/<int:request_id>/task/<int:task_id>')
+class DeleteTask(Resource):
+
+    @classmethod
+    @jwt_required
+    @mentorship_relation_ns.doc('delete_task_in_mentorship_relation')
+    @mentorship_relation_ns.expect(auth_header_parser)
+    @mentorship_relation_ns.response(200, 'Delete task with success.')
+    def delete(cls, request_id, task_id):
+        """
+        Delete a task.
+        """
+
+        # TODO check if user id is well parsed, if it is an integer
+
+        user_id = get_jwt_identity()
+
+        response = TaskDAO.delete_task(user_id=user_id, mentorship_relation_id=request_id, task_id=task_id)
+
+        return response
+
+
+@mentorship_relation_ns.route('mentorship_relation/<int:request_id>/tasks')
+class ListTasks(Resource):
+
+    @classmethod
+    @jwt_required
+    @mentorship_relation_ns.doc('list_tasks_in_mentorship_relation')
+    @mentorship_relation_ns.expect(auth_header_parser)
+    @mentorship_relation_ns.response(200, 'List tasks from a mentorship relation with success.',
+                                     model=list_tasks_response_body)
+    def get(cls, request_id):
+        """
+        List all tasks from a mentorship relation.
+        """
+
+        # TODO check if user id is well parsed, if it is an integer
+
+        user_id = get_jwt_identity()
+
+        response = TaskDAO.list_tasks(user_id=user_id, mentorship_relation_id=request_id)
+
+        if isinstance(response, tuple):
+            return response
+        else:
+            return marshal(response, list_tasks_response_body), 200
+
+
+@mentorship_relation_ns.route('mentorship_relation/<int:request_id>/task/<int:task_id>/complete')
+class UpdateTask(Resource):
+
+    @classmethod
+    @jwt_required
+    @mentorship_relation_ns.doc('update_task_in_mentorship_relation')
+    @mentorship_relation_ns.expect(auth_header_parser)
+    @mentorship_relation_ns.response(200, 'Updated task with success.')
+    def put(cls, request_id, task_id):
+        """
+        Update a task.
+        """
+
+        # TODO check if user id is well parsed, if it is an integer
+
+        user_id = get_jwt_identity()
+
+        response = TaskDAO.complete_task(user_id=user_id, mentorship_relation_id=request_id, task_id=task_id)
 
         return response

--- a/app/database/db_types/JsonCustomType.py
+++ b/app/database/db_types/JsonCustomType.py
@@ -1,0 +1,25 @@
+import json
+from app.database.sqlalchemy_extension import db
+
+
+class JsonCustomType(db.TypeDecorator):
+    """Enables JSON storage by encoding and decoding to Text field."""
+
+    impl = db.Text
+
+    @classmethod
+    def process_bind_param(cls, value, dialect):
+        if value is None:
+            return '{}'
+        else:
+            return json.dumps(value)
+
+    @classmethod
+    def process_result_value(cls, value, dialect):
+        if value is None:
+            return {}
+        else:
+            try:
+                return json.loads(value)
+            except (ValueError, TypeError):
+                return None

--- a/app/database/models/mentorship_relation.py
+++ b/app/database/models/mentorship_relation.py
@@ -1,4 +1,4 @@
-
+from app.database.models.tasks_list import TasksListModel
 from app.database.models.user import UserModel
 from app.database.sqlalchemy_extension import db
 from app.utils.enum_utils import MentorshipRelationState
@@ -30,7 +30,10 @@ class MentorshipRelationModel(db.Model):
     state = db.Column(db.Enum(MentorshipRelationState), nullable=False)
     notes = db.Column(db.String(400))
 
-    def __init__(self, action_user_id, mentor_user, mentee_user, creation_date, end_date, state, notes):
+    tasks_list_id = db.Column(db.Integer, db.ForeignKey('tasks_list.id'))
+    tasks_list = db.relationship(TasksListModel, uselist=False, backref="mentorship_relation")
+
+    def __init__(self, action_user_id, mentor_user, mentee_user, creation_date, end_date, state, notes, tasks_list):
 
         self.action_user_id = action_user_id
         self.mentor = mentor_user
@@ -39,6 +42,7 @@ class MentorshipRelationModel(db.Model):
         self.end_date = end_date
         self.state = state
         self.notes = notes
+        self.tasks_list = tasks_list
 
     def json(self):
         return {
@@ -71,5 +75,6 @@ class MentorshipRelationModel(db.Model):
         db.session.commit()
 
     def delete_from_db(self):
+        self.tasks_list.delete_from_db()
         db.session.delete(self)
         db.session.commit()

--- a/app/database/models/tasks_list.py
+++ b/app/database/models/tasks_list.py
@@ -1,0 +1,115 @@
+from enum import unique, Enum
+
+from app.database.db_types.JsonCustomType import JsonCustomType
+from app.database.sqlalchemy_extension import db
+
+
+class TasksListModel(db.Model):
+    __tablename__ = 'tasks_list'
+    __table_args__ = {'extend_existing': True}
+
+    id = db.Column(db.Integer, primary_key=True)
+    tasks = db.Column(JsonCustomType)
+    next_task_id = db.Column(db.Integer)
+
+    def __init__(self, tasks=None):
+
+        if tasks is None:
+            self.tasks = []
+            self.next_task_id = 1
+        else:
+            if isinstance(tasks, list):
+                self.tasks = []
+                self.next_task_id = len(tasks) + 1
+            else:
+                raise ValueError(TypeError)
+
+    def add_task(self, description, created_at, is_done=False, completed_at=None):
+
+        task = {
+            TasksFields.ID.value: self.next_task_id,
+            TasksFields.DESCRIPTION.value: description,
+            TasksFields.IS_DONE.value: is_done,
+            TasksFields.CREATED_AT.value: created_at,
+            TasksFields.COMPLETED_AT.value: completed_at
+        }
+        self.next_task_id += 1
+        self.tasks = self.tasks + [task]
+
+    def delete_task(self, task_id):
+
+        new_list = []
+        for task in self.tasks:
+            if task[TasksFields.ID.value] != task_id:
+                new_list = new_list + [task]
+
+        self.tasks = new_list
+        self.save_to_db()
+
+    def update_task(self, task_id, description=None, is_done=None, completed_at=None):
+
+        new_list = []
+        for task in self.tasks:
+            if task[TasksFields.ID.value] == task_id:
+                new_task = task.copy()
+                if description is not None:
+                    new_task[TasksFields.DESCRIPTION.value] = description
+
+                if is_done is not None:
+                    new_task[TasksFields.IS_DONE.value] = is_done
+
+                if completed_at is not None:
+                    new_task[TasksFields.COMPLETED_AT.value] = completed_at
+
+                new_list = new_list + [new_task]
+                continue
+
+            new_list = new_list + [task]
+
+        self.tasks = new_list
+        self.save_to_db()
+
+    def find_task_by_id(self, task_id):
+
+        for task in self.tasks:
+            if task[TasksFields.ID.value] == task_id:
+                return task
+        return None
+
+    def is_empty(self):
+        return len(self.tasks) == 0
+
+    def json(self):
+        return {
+            'id': self.id,
+            'mentorship_relation_id': self.mentorship_relation_id,
+            'tasks': self.tasks,
+            'next_task_id': self.next_task_id
+        }
+
+    def __repr__(self):
+        return "Task | id = %s; tasks = %s; next task id = %s" % (self.id, self.tasks, self.next_task_id)
+
+    @classmethod
+    def find_by_id(cls, _id):
+        return cls.query.filter_by(id=_id).first()
+
+    def save_to_db(self):
+        db.session.add(self)
+        db.session.commit()
+
+    def delete_from_db(self):
+        db.session.delete(self)
+        db.session.commit()
+
+
+@unique
+class TasksFields(Enum):
+    ID = 'id'
+    DESCRIPTION = 'description'
+    IS_DONE = 'is_done'
+    COMPLETED_AT = 'completed_at'
+    CREATED_AT = 'created_at'
+
+    def values(self):
+        return list(map(str, self))

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -250,6 +250,153 @@
                 ]
             }
         },
+        "/mentorship_relation/{request_id}/task": {
+            "parameters": [
+                {
+                    "name": "request_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "Created task with success."
+                    }
+                },
+                "summary": "Create a task",
+                "operationId": "create_task_in_mentorship_relation",
+                "parameters": [
+                    {
+                        "name": "Authorization",
+                        "in": "header",
+                        "type": "string",
+                        "required": true,
+                        "description": "Authentication access token. E.g.: Bearer <access_token>"
+                    },
+                    {
+                        "name": "payload",
+                        "required": true,
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/Create task request model"
+                        }
+                    }
+                ],
+                "tags": [
+                    "Mentorship Relation"
+                ]
+            }
+        },
+        "/mentorship_relation/{request_id}/task/{task_id}": {
+            "parameters": [
+                {
+                    "name": "request_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                },
+                {
+                    "name": "task_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "delete": {
+                "responses": {
+                    "200": {
+                        "description": "Delete task with success."
+                    }
+                },
+                "summary": "Delete a task",
+                "operationId": "delete_task_in_mentorship_relation",
+                "parameters": [
+                    {
+                        "name": "Authorization",
+                        "in": "header",
+                        "type": "string",
+                        "required": true,
+                        "description": "Authentication access token. E.g.: Bearer <access_token>"
+                    }
+                ],
+                "tags": [
+                    "Mentorship Relation"
+                ]
+            }
+        },
+        "/mentorship_relation/{request_id}/task/{task_id}/complete": {
+            "parameters": [
+                {
+                    "name": "request_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                },
+                {
+                    "name": "task_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "put": {
+                "responses": {
+                    "200": {
+                        "description": "Updated task with success."
+                    }
+                },
+                "summary": "Update a task",
+                "operationId": "update_task_in_mentorship_relation",
+                "parameters": [
+                    {
+                        "name": "Authorization",
+                        "in": "header",
+                        "type": "string",
+                        "required": true,
+                        "description": "Authentication access token. E.g.: Bearer <access_token>"
+                    }
+                ],
+                "tags": [
+                    "Mentorship Relation"
+                ]
+            }
+        },
+        "/mentorship_relation/{request_id}/tasks": {
+            "parameters": [
+                {
+                    "name": "request_id",
+                    "in": "path",
+                    "required": true,
+                    "type": "integer"
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "List tasks from a mentorship relation with success.",
+                        "schema": {
+                            "$ref": "#/definitions/List tasks response model"
+                        }
+                    }
+                },
+                "summary": "List all tasks from a mentorship relation",
+                "operationId": "list_tasks_in_mentorship_relation",
+                "parameters": [
+                    {
+                        "name": "Authorization",
+                        "in": "header",
+                        "type": "string",
+                        "required": true,
+                        "description": "Authentication access token. E.g.: Bearer <access_token>"
+                    }
+                ],
+                "tags": [
+                    "Mentorship Relation"
+                ]
+            }
+        },
         "/mentorship_relations": {
             "get": {
                 "responses": {
@@ -1156,6 +1303,49 @@
                 "name": {
                     "type": "string",
                     "description": "User name"
+                }
+            },
+            "type": "object"
+        },
+        "Create task request model": {
+            "required": [
+                "description"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "description": "Mentorship relation task description"
+                }
+            },
+            "type": "object"
+        },
+        "List tasks response model": {
+            "required": [
+                "created_at",
+                "description",
+                "id",
+                "is_done"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "description": "Task ID"
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Mentorship relation task description"
+                },
+                "is_done": {
+                    "type": "boolean",
+                    "description": "Mentorship relation task is done indication"
+                },
+                "created_at": {
+                    "type": "number",
+                    "description": "Task creation date in UNIX timestamp format"
+                },
+                "completed_at": {
+                    "type": "number",
+                    "description": "Task completion date in UNIX timestamp format"
                 }
             },
             "type": "object"

--- a/tests/mentorship_relation/relation_base_setup.py
+++ b/tests/mentorship_relation/relation_base_setup.py
@@ -1,0 +1,38 @@
+from app.database.models.user import UserModel
+from app.database.sqlalchemy_extension import db
+from tests.base_test_case import BaseTestCase
+from tests.test_data import *
+
+
+class MentorshipRelationBaseTestCase(BaseTestCase):
+
+    # Setup consists of adding 2 users into the database
+    # User 1 is the mentorship relation requester = action user
+    # User 2 is the receiver
+    def setUp(self):
+        super(MentorshipRelationBaseTestCase, self).setUp()
+
+        self.first_user = UserModel(
+            name=user1['name'],
+            email=user1['email'],
+            username=user1['username'],
+            password=user1['password'],
+            terms_and_conditions_checked=user1['terms_and_conditions_checked']
+        )
+        self.second_user = UserModel(
+            name=user2['name'],
+            email=user2['email'],
+            username=user2['username'],
+            password=user2['password'],
+            terms_and_conditions_checked=user2['terms_and_conditions_checked']
+        )
+
+        # making sure both are available to be mentor or mentee
+        self.first_user.need_mentoring = True
+        self.first_user.available_to_mentor = True
+        self.second_user.need_mentoring = True
+        self.second_user.available_to_mentor = True
+
+        db.session.add(self.first_user)
+        db.session.add(self.second_user)
+        db.session.commit()

--- a/tests/mentorship_relation/test_api_accept_request.py
+++ b/tests/mentorship_relation/test_api_accept_request.py
@@ -2,52 +2,23 @@ import json
 import unittest
 from datetime import datetime, timedelta
 
+from app.database.models.tasks_list import TasksListModel
 from app.database.sqlalchemy_extension import db
 from app.database.models.mentorship_relation import MentorshipRelationModel
 from app.utils.enum_utils import MentorshipRelationState
-from app.database.models.user import UserModel
-from tests.base_test_case import BaseTestCase
-from tests.test_data import user1, user2
+from tests.mentorship_relation.relation_base_setup import MentorshipRelationBaseTestCase
 from tests.test_utils import get_test_request_header
 
 
-class TestAcceptMentorshipRequestApi(BaseTestCase):
+class TestAcceptMentorshipRequestApi(MentorshipRelationBaseTestCase):
 
-    # Setup consists of adding 2 users into the database
-    # User 1 is the mentorship relation requester = action user
-    # User 2 is the receiver
     def setUp(self):
         super(TestAcceptMentorshipRequestApi, self).setUp()
-
-        self.first_user = UserModel(
-            name=user1['name'],
-            email=user1['email'],
-            username=user1['username'],
-            password=user1['password'],
-            terms_and_conditions_checked=user1['terms_and_conditions_checked']
-        )
-        self.second_user = UserModel(
-            name=user2['name'],
-            email=user2['email'],
-            username=user2['username'],
-            password=user2['password'],
-            terms_and_conditions_checked=user2['terms_and_conditions_checked']
-        )
-
-        # making sure both are available to be mentor or mentee
-        self.first_user.need_mentoring = True
-        self.first_user.available_to_mentor = True
-        self.second_user.need_mentoring = True
-        self.second_user.available_to_mentor = True
 
         self.notes_example = 'description of a good mentorship relation'
 
         self.now_datetime = datetime.now()
         self.end_date_example = self.now_datetime + timedelta(weeks=5)
-
-        db.session.add(self.first_user)
-        db.session.add(self.second_user)
-        db.session.commit()
 
         # create new mentorship relation
 
@@ -58,7 +29,8 @@ class TestAcceptMentorshipRequestApi(BaseTestCase):
             creation_date=self.now_datetime.timestamp(),
             end_date=self.end_date_example.timestamp(),
             state=MentorshipRelationState.PENDING,
-            notes=self.notes_example
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
         )
 
         db.session.add(self.mentorship_relation)

--- a/tests/mentorship_relation/test_api_cancel_relation.py
+++ b/tests/mentorship_relation/test_api_cancel_relation.py
@@ -2,16 +2,15 @@ import json
 import unittest
 from datetime import datetime, timedelta
 
+from app.database.models.tasks_list import TasksListModel
 from app.database.sqlalchemy_extension import db
 from app.database.models.mentorship_relation import MentorshipRelationModel
 from app.utils.enum_utils import MentorshipRelationState
-from app.database.models.user import UserModel
-from tests.base_test_case import BaseTestCase
-from tests.test_data import user1, user2
+from tests.mentorship_relation.relation_base_setup import MentorshipRelationBaseTestCase
 from tests.test_utils import get_test_request_header
 
 
-class TestCancelMentorshipRelationApi(BaseTestCase):
+class TestCancelMentorshipRelationApi(MentorshipRelationBaseTestCase):
 
     # Setup consists of adding 2 users into the database
     # User 1 is the mentorship relation requester = action user
@@ -19,35 +18,10 @@ class TestCancelMentorshipRelationApi(BaseTestCase):
     def setUp(self):
         super(TestCancelMentorshipRelationApi, self).setUp()
 
-        self.first_user = UserModel(
-            name=user1['name'],
-            email=user1['email'],
-            username=user1['username'],
-            password=user1['password'],
-            terms_and_conditions_checked=user1['terms_and_conditions_checked']
-        )
-        self.second_user = UserModel(
-            name=user2['name'],
-            email=user2['email'],
-            username=user2['username'],
-            password=user2['password'],
-            terms_and_conditions_checked=user2['terms_and_conditions_checked']
-        )
-
-        # making sure both are available to be mentor or mentee
-        self.first_user.need_mentoring = True
-        self.first_user.available_to_mentor = True
-        self.second_user.need_mentoring = True
-        self.second_user.available_to_mentor = True
-
         self.notes_example = 'description of a good mentorship relation'
 
         self.now_datetime = datetime.now()
         self.end_date_example = self.now_datetime + timedelta(weeks=5)
-
-        db.session.add(self.first_user)
-        db.session.add(self.second_user)
-        db.session.commit()
 
         # create new mentorship relation
 
@@ -58,7 +32,8 @@ class TestCancelMentorshipRelationApi(BaseTestCase):
             creation_date=self.now_datetime.timestamp(),
             end_date=self.end_date_example.timestamp(),
             state=MentorshipRelationState.ACCEPTED,
-            notes=self.notes_example
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
         )
 
         db.session.add(self.mentorship_relation)

--- a/tests/mentorship_relation/test_api_delete_request.py
+++ b/tests/mentorship_relation/test_api_delete_request.py
@@ -2,16 +2,15 @@ import json
 import unittest
 from datetime import datetime, timedelta
 
+from app.database.models.tasks_list import TasksListModel
 from app.database.sqlalchemy_extension import db
 from app.database.models.mentorship_relation import MentorshipRelationModel
 from app.utils.enum_utils import MentorshipRelationState
-from app.database.models.user import UserModel
-from tests.base_test_case import BaseTestCase
-from tests.test_data import user1, user2
+from tests.mentorship_relation.relation_base_setup import MentorshipRelationBaseTestCase
 from tests.test_utils import get_test_request_header
 
 
-class TestDeleteMentorshipRequestApi(BaseTestCase):
+class TestDeleteMentorshipRequestApi(MentorshipRelationBaseTestCase):
 
     # Setup consists of adding 2 users into the database
     # User 1 is the mentorship relation requester = action user
@@ -19,35 +18,9 @@ class TestDeleteMentorshipRequestApi(BaseTestCase):
     def setUp(self):
         super(TestDeleteMentorshipRequestApi, self).setUp()
 
-        self.first_user = UserModel(
-            name=user1['name'],
-            email=user1['email'],
-            username=user1['username'],
-            password=user1['password'],
-            terms_and_conditions_checked=user1['terms_and_conditions_checked']
-        )
-        self.second_user = UserModel(
-            name=user2['name'],
-            email=user2['email'],
-            username=user2['username'],
-            password=user2['password'],
-            terms_and_conditions_checked=user2['terms_and_conditions_checked']
-        )
-
-        # making sure both are available to be mentor or mentee
-        self.first_user.need_mentoring = True
-        self.first_user.available_to_mentor = True
-        self.second_user.need_mentoring = True
-        self.second_user.available_to_mentor = True
-
         self.notes_example = 'description of a good mentorship relation'
-
         self.now_datetime = datetime.now()
         self.end_date_example = self.now_datetime + timedelta(weeks=5)
-
-        db.session.add(self.first_user)
-        db.session.add(self.second_user)
-        db.session.commit()
 
         # create new mentorship relation
 
@@ -58,7 +31,8 @@ class TestDeleteMentorshipRequestApi(BaseTestCase):
             creation_date=self.now_datetime.timestamp(),
             end_date=self.end_date_example.timestamp(),
             state=MentorshipRelationState.PENDING,
-            notes=self.notes_example
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
         )
 
         db.session.add(self.mentorship_relation)

--- a/tests/mentorship_relation/test_api_list_relations.py
+++ b/tests/mentorship_relation/test_api_list_relations.py
@@ -5,16 +5,15 @@ from datetime import datetime, timedelta
 from flask_restplus import marshal
 
 from app.api.models.mentorship_relation import mentorship_request_response_body
+from app.database.models.tasks_list import TasksListModel
 from app.database.sqlalchemy_extension import db
 from app.database.models.mentorship_relation import MentorshipRelationModel
 from app.utils.enum_utils import MentorshipRelationState
-from app.database.models.user import UserModel
-from tests.base_test_case import BaseTestCase
-from tests.test_data import user1, user2
+from tests.mentorship_relation.relation_base_setup import MentorshipRelationBaseTestCase
 from tests.test_utils import get_test_request_header
 
 
-class TestListMentorshipRelationsApi(BaseTestCase):
+class TestListMentorshipRelationsApi(MentorshipRelationBaseTestCase):
 
     # Setup consists of adding 2 users into the database
     # User 1 is the mentorship relation requester = action user
@@ -22,36 +21,10 @@ class TestListMentorshipRelationsApi(BaseTestCase):
     def setUp(self):
         super(TestListMentorshipRelationsApi, self).setUp()
 
-        self.first_user = UserModel(
-            name=user1['name'],
-            email=user1['email'],
-            username=user1['username'],
-            password=user1['password'],
-            terms_and_conditions_checked=user1['terms_and_conditions_checked']
-        )
-        self.second_user = UserModel(
-            name=user2['name'],
-            email=user2['email'],
-            username=user2['username'],
-            password=user2['password'],
-            terms_and_conditions_checked=user2['terms_and_conditions_checked']
-        )
-
-        # making sure both are available to be mentor or mentee
-        self.first_user.need_mentoring = True
-        self.first_user.available_to_mentor = True
-        self.second_user.need_mentoring = True
-        self.second_user.available_to_mentor = True
-
         self.notes_example = 'description of a good mentorship relation'
-
         self.now_datetime = datetime.now()
         self.past_end_date_example = self.now_datetime - timedelta(weeks=5)
         self.future_end_date_example = self.now_datetime + timedelta(weeks=5)
-
-        db.session.add(self.first_user)
-        db.session.add(self.second_user)
-        db.session.commit()
 
         # create new mentorship relation
 
@@ -62,7 +35,8 @@ class TestListMentorshipRelationsApi(BaseTestCase):
             creation_date=self.now_datetime.timestamp(),
             end_date=self.past_end_date_example.timestamp(),
             state=MentorshipRelationState.PENDING,
-            notes=self.notes_example
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
         )
 
         self.future_pending_mentorship_relation = MentorshipRelationModel(
@@ -72,7 +46,8 @@ class TestListMentorshipRelationsApi(BaseTestCase):
             creation_date=self.now_datetime.timestamp(),
             end_date=self.future_end_date_example.timestamp(),
             state=MentorshipRelationState.PENDING,
-            notes=self.notes_example
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
         )
 
         self.future_accepted_mentorship_relation = MentorshipRelationModel(
@@ -82,7 +57,8 @@ class TestListMentorshipRelationsApi(BaseTestCase):
             creation_date=self.now_datetime.timestamp(),
             end_date=self.future_end_date_example.timestamp(),
             state=MentorshipRelationState.ACCEPTED,
-            notes=self.notes_example
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
         )
 
         self.admin_only_mentorship_relation = MentorshipRelationModel(
@@ -92,7 +68,8 @@ class TestListMentorshipRelationsApi(BaseTestCase):
             creation_date=self.now_datetime.timestamp(),
             end_date=self.future_end_date_example.timestamp(),
             state=MentorshipRelationState.REJECTED,
-            notes=self.notes_example
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
         )
 
         db.session.add(self.past_mentorship_relation)

--- a/tests/mentorship_relation/test_api_reject_request.py
+++ b/tests/mentorship_relation/test_api_reject_request.py
@@ -2,16 +2,15 @@ import json
 import unittest
 from datetime import datetime, timedelta
 
+from app.database.models.tasks_list import TasksListModel
 from app.database.sqlalchemy_extension import db
 from app.database.models.mentorship_relation import MentorshipRelationModel
 from app.utils.enum_utils import MentorshipRelationState
-from app.database.models.user import UserModel
-from tests.base_test_case import BaseTestCase
-from tests.test_data import user1, user2
+from tests.mentorship_relation.relation_base_setup import MentorshipRelationBaseTestCase
 from tests.test_utils import get_test_request_header
 
 
-class TestRejectMentorshipRequestApi(BaseTestCase):
+class TestRejectMentorshipRequestApi(MentorshipRelationBaseTestCase):
 
     # Setup consists of adding 2 users into the database
     # User 1 is the mentorship relation requester = action user
@@ -19,35 +18,9 @@ class TestRejectMentorshipRequestApi(BaseTestCase):
     def setUp(self):
         super(TestRejectMentorshipRequestApi, self).setUp()
 
-        self.first_user = UserModel(
-            name=user1['name'],
-            email=user1['email'],
-            username=user1['username'],
-            password=user1['password'],
-            terms_and_conditions_checked=user1['terms_and_conditions_checked']
-        )
-        self.second_user = UserModel(
-            name=user2['name'],
-            email=user2['email'],
-            username=user2['username'],
-            password=user2['password'],
-            terms_and_conditions_checked=user2['terms_and_conditions_checked']
-        )
-
-        # making sure both are available to be mentor or mentee
-        self.first_user.need_mentoring = True
-        self.first_user.available_to_mentor = True
-        self.second_user.need_mentoring = True
-        self.second_user.available_to_mentor = True
-
         self.notes_example = 'description of a good mentorship relation'
-
         self.now_datetime = datetime.now()
         self.end_date_example = self.now_datetime + timedelta(weeks=5)
-
-        db.session.add(self.first_user)
-        db.session.add(self.second_user)
-        db.session.commit()
 
         # create new mentorship relation
 
@@ -58,7 +31,8 @@ class TestRejectMentorshipRequestApi(BaseTestCase):
             creation_date=self.now_datetime.timestamp(),
             end_date=self.end_date_example.timestamp(),
             state=MentorshipRelationState.PENDING,
-            notes=self.notes_example
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
         )
 
         db.session.add(self.mentorship_relation)

--- a/tests/mentorship_relation/test_dao_accept_request.py
+++ b/tests/mentorship_relation/test_dao_accept_request.py
@@ -2,17 +2,16 @@ from datetime import datetime, timedelta
 
 from app.api.dao.mentorship_relation import MentorshipRelationDAO
 from app.database.models.mentorship_relation import MentorshipRelationModel
+from app.database.models.tasks_list import TasksListModel
 from app.utils.enum_utils import MentorshipRelationState
-from tests.base_test_case import BaseTestCase
-from app.database.models.user import UserModel
-from tests.test_data import user1, user2
+from tests.mentorship_relation.relation_base_setup import MentorshipRelationBaseTestCase
 from app.database.sqlalchemy_extension import db
 
 
 # TODO test when a user is in a current relation and tries to accept another relation
 # TODO test when a user tries to accept a relation where this user is not involved
 
-class TestMentorshipRelationAcceptRequestDAO(BaseTestCase):
+class TestMentorshipRelationAcceptRequestDAO(MentorshipRelationBaseTestCase):
 
     # Setup consists of adding 2 users into the database
     # User 1 is the mentorship relation requester = action user
@@ -20,35 +19,9 @@ class TestMentorshipRelationAcceptRequestDAO(BaseTestCase):
     def setUp(self):
         super(TestMentorshipRelationAcceptRequestDAO, self).setUp()
 
-        self.first_user = UserModel(
-            name=user1['name'],
-            email=user1['email'],
-            username=user1['username'],
-            password=user1['password'],
-            terms_and_conditions_checked=user1['terms_and_conditions_checked']
-        )
-        self.second_user = UserModel(
-            name=user2['name'],
-            email=user2['email'],
-            username=user2['username'],
-            password=user2['password'],
-            terms_and_conditions_checked=user2['terms_and_conditions_checked']
-        )
-
-        # making sure both are available to be mentor or mentee
-        self.first_user.need_mentoring = True
-        self.first_user.available_to_mentor = True
-        self.second_user.need_mentoring = True
-        self.second_user.available_to_mentor = True
-
         self.notes_example = 'description of a good mentorship relation'
-
         self.now_datetime = datetime.now()
         self.end_date_example = self.now_datetime + timedelta(weeks=5)
-
-        db.session.add(self.first_user)
-        db.session.add(self.second_user)
-        db.session.commit()
 
         # create new mentorship relation
 
@@ -59,7 +32,8 @@ class TestMentorshipRelationAcceptRequestDAO(BaseTestCase):
             creation_date=self.now_datetime.timestamp(),
             end_date=self.end_date_example.timestamp(),
             state=MentorshipRelationState.PENDING,
-            notes=self.notes_example
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
         )
 
         db.session.add(self.mentorship_relation)

--- a/tests/mentorship_relation/test_dao_cancel_relation.py
+++ b/tests/mentorship_relation/test_dao_cancel_relation.py
@@ -1,17 +1,16 @@
 from datetime import datetime, timedelta
 
 from app.api.dao.mentorship_relation import MentorshipRelationDAO
+from app.database.models.tasks_list import TasksListModel
 from app.utils.enum_utils import MentorshipRelationState
 from app.database.models.mentorship_relation import MentorshipRelationModel
-from app.database.models.user import UserModel
 from app.database.sqlalchemy_extension import db
-from tests.base_test_case import BaseTestCase
-from tests.test_data import user1, user2
+from tests.mentorship_relation.relation_base_setup import MentorshipRelationBaseTestCase
 
 
 # TODO test when a user tries to cancel a relation where this user is not involved
 
-class TestMentorshipRelationListingDAO(BaseTestCase):
+class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
 
     # Setup consists of adding 2 users into the database
     # User 1 is the mentorship relation requester = action user
@@ -19,35 +18,9 @@ class TestMentorshipRelationListingDAO(BaseTestCase):
     def setUp(self):
         super(TestMentorshipRelationListingDAO, self).setUp()
 
-        self.first_user = UserModel(
-            name=user1['name'],
-            email=user1['email'],
-            username=user1['username'],
-            password=user1['password'],
-            terms_and_conditions_checked=user1['terms_and_conditions_checked']
-        )
-        self.second_user = UserModel(
-            name=user2['name'],
-            email=user2['email'],
-            username=user2['username'],
-            password=user2['password'],
-            terms_and_conditions_checked=user2['terms_and_conditions_checked']
-        )
-
-        # making sure both are available to be mentor or mentee
-        self.first_user.need_mentoring = True
-        self.first_user.available_to_mentor = True
-        self.second_user.need_mentoring = True
-        self.second_user.available_to_mentor = True
-
         self.notes_example = 'description of a good mentorship relation'
-
         self.now_datetime = datetime.now()
         self.end_date_example = self.now_datetime + timedelta(weeks=5)
-
-        db.session.add(self.first_user)
-        db.session.add(self.second_user)
-        db.session.commit()
 
         # create new mentorship relation
 
@@ -58,7 +31,8 @@ class TestMentorshipRelationListingDAO(BaseTestCase):
             creation_date=self.now_datetime.timestamp(),
             end_date=self.end_date_example.timestamp(),
             state=MentorshipRelationState.PENDING,
-            notes=self.notes_example
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
         )
 
         db.session.add(self.mentorship_relation)

--- a/tests/mentorship_relation/test_dao_creation.py
+++ b/tests/mentorship_relation/test_dao_creation.py
@@ -3,48 +3,22 @@ from datetime import datetime, timedelta
 
 from app.api.dao.mentorship_relation import MentorshipRelationDAO
 from app.database.models.mentorship_relation import MentorshipRelationModel
+from app.database.models.tasks_list import TasksListModel
 from app.utils.enum_utils import MentorshipRelationState
-from tests.base_test_case import BaseTestCase
-from app.database.models.user import UserModel
-from tests.test_data import user1, user2
+from tests.mentorship_relation.relation_base_setup import MentorshipRelationBaseTestCase
 from app.database.sqlalchemy_extension import db
 
 
-class TestMentorshipRelationCreationDAO(BaseTestCase):
+class TestMentorshipRelationCreationDAO(MentorshipRelationBaseTestCase):
 
     # Setup consists of adding 2 users into the database
     def setUp(self):
         super(TestMentorshipRelationCreationDAO, self).setUp()
 
-        self.first_user = UserModel(
-            name=user1['name'],
-            email=user1['email'],
-            username=user1['username'],
-            password=user1['password'],
-            terms_and_conditions_checked=user1['terms_and_conditions_checked']
-        )
-        self.second_user = UserModel(
-            name=user2['name'],
-            email=user2['email'],
-            username=user2['username'],
-            password=user2['password'],
-            terms_and_conditions_checked=user2['terms_and_conditions_checked']
-        )
-
-        # making sure both are available to be mentor or mentee
-        self.first_user.need_mentoring = True
-        self.first_user.available_to_mentor = True
-        self.second_user.need_mentoring = True
-        self.second_user.available_to_mentor = True
-
         self.notes_example = 'description of a good mentorship relation'
 
         self.now_datetime = datetime.now()
         self.end_date_example = self.now_datetime + timedelta(weeks=5)
-
-        db.session.add(self.first_user)
-        db.session.add(self.second_user)
-        db.session.commit()
 
     def test_dao_create_mentorship_relation_with_good_args_mentor_is_sender(self):
         dao = MentorshipRelationDAO()
@@ -52,7 +26,8 @@ class TestMentorshipRelationCreationDAO(BaseTestCase):
             mentor_id=self.first_user.id,
             mentee_id=self.second_user.id,
             end_date=self.end_date_example.timestamp(),
-            notes=self.notes_example
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
         )
 
         # Use DAO to create a mentorship relation
@@ -95,7 +70,8 @@ class TestMentorshipRelationCreationDAO(BaseTestCase):
             mentor_id=self.first_user.id,
             mentee_id=self.second_user.id,
             end_date=self.end_date_example.timestamp(),
-            notes=self.notes_example
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
         )
 
         # Use DAO to create a mentorship relation
@@ -139,7 +115,8 @@ class TestMentorshipRelationCreationDAO(BaseTestCase):
             mentor_id=1234,
             mentee_id=self.second_user.id,
             end_date=self.end_date_example.timestamp(),
-            notes=self.notes_example
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
         )
 
         # Use DAO to create a mentorship relation
@@ -158,7 +135,8 @@ class TestMentorshipRelationCreationDAO(BaseTestCase):
             mentor_id=self.first_user.id,
             mentee_id=1234,
             end_date=self.end_date_example.timestamp(),
-            notes=self.notes_example
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
         )
 
         # Use DAO to create a mentorship relation
@@ -180,7 +158,8 @@ class TestMentorshipRelationCreationDAO(BaseTestCase):
             creation_date=self.now_datetime.timestamp(),
             end_date=self.end_date_example.timestamp(),
             state=MentorshipRelationState.ACCEPTED,
-            notes=self.notes_example
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
         )
 
         db.session.add(self.mentorship_relation)
@@ -190,7 +169,8 @@ class TestMentorshipRelationCreationDAO(BaseTestCase):
             mentor_id=self.first_user.id,
             mentee_id=self.second_user.id,
             end_date=self.end_date_example.timestamp(),
-            notes=self.notes_example
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
         )
 
         # Use DAO to create a mentorship relation
@@ -212,7 +192,8 @@ class TestMentorshipRelationCreationDAO(BaseTestCase):
             creation_date=self.now_datetime.timestamp(),
             end_date=self.end_date_example.timestamp(),
             state=MentorshipRelationState.ACCEPTED,
-            notes=self.notes_example
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
         )
 
         db.session.add(self.mentorship_relation)
@@ -223,7 +204,8 @@ class TestMentorshipRelationCreationDAO(BaseTestCase):
             mentor_id=self.second_user.id,
             mentee_id=self.first_user.id,
             end_date=self.end_date_example.timestamp(),
-            notes=self.notes_example
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
         )
 
         # Use DAO to create a mentorship relation

--- a/tests/mentorship_relation/test_dao_delete_request.py
+++ b/tests/mentorship_relation/test_dao_delete_request.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 
 from app.api.dao.mentorship_relation import MentorshipRelationDAO
+from app.database.models.tasks_list import TasksListModel
 from app.utils.enum_utils import MentorshipRelationState
 from app.database.models.mentorship_relation import MentorshipRelationModel
 from app.database.models.user import UserModel
@@ -56,7 +57,8 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
             creation_date=self.now_datetime.timestamp(),
             end_date=self.end_date_example.timestamp(),
             state=MentorshipRelationState.PENDING,
-            notes=self.notes_example
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
         )
 
         db.session.add(self.mentorship_relation)

--- a/tests/mentorship_relation/test_dao_list_relations.py
+++ b/tests/mentorship_relation/test_dao_list_relations.py
@@ -3,49 +3,22 @@ from datetime import datetime, timedelta
 
 from app.api.dao.mentorship_relation import MentorshipRelationDAO
 from app.database.models.mentorship_relation import MentorshipRelationModel
-from app.database.models.user import UserModel
+from app.database.models.tasks_list import TasksListModel
 from app.database.sqlalchemy_extension import db
 from app.utils.enum_utils import MentorshipRelationState
-from tests.base_test_case import BaseTestCase
-from tests.test_data import user1, user2
+from tests.mentorship_relation.relation_base_setup import MentorshipRelationBaseTestCase
 
 
-class TestListMentorshipRelationsDAO(BaseTestCase):
+class TestListMentorshipRelationsDAO(MentorshipRelationBaseTestCase):
 
     # Setup consists of adding 2 users into the database
     def setUp(self):
         super(TestListMentorshipRelationsDAO, self).setUp()
 
-        self.first_user = UserModel(
-            name=user1['name'],
-            email=user1['email'],
-            username=user1['username'],
-            password=user1['password'],
-            terms_and_conditions_checked=user1['terms_and_conditions_checked']
-        )
-        self.second_user = UserModel(
-            name=user2['name'],
-            email=user2['email'],
-            username=user2['username'],
-            password=user2['password'],
-            terms_and_conditions_checked=user2['terms_and_conditions_checked']
-        )
-
-        # making sure both are available to be mentor or mentee
-        self.first_user.need_mentoring = True
-        self.first_user.available_to_mentor = True
-        self.second_user.need_mentoring = True
-        self.second_user.available_to_mentor = True
-
         self.notes_example = 'description of a good mentorship relation'
-
         self.now_datetime = datetime.now()
         self.past_end_date_example = self.now_datetime - timedelta(weeks=5)
         self.future_end_date_example = self.now_datetime + timedelta(weeks=5)
-
-        db.session.add(self.first_user)
-        db.session.add(self.second_user)
-        db.session.commit()
 
         # create new mentorship relation
 
@@ -56,7 +29,8 @@ class TestListMentorshipRelationsDAO(BaseTestCase):
             creation_date=self.now_datetime.timestamp(),
             end_date=self.past_end_date_example.timestamp(),
             state=MentorshipRelationState.PENDING,
-            notes=self.notes_example
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
         )
 
         self.future_pending_mentorship_relation = MentorshipRelationModel(
@@ -66,7 +40,8 @@ class TestListMentorshipRelationsDAO(BaseTestCase):
             creation_date=self.now_datetime.timestamp(),
             end_date=self.future_end_date_example.timestamp(),
             state=MentorshipRelationState.PENDING,
-            notes=self.notes_example
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
         )
 
         self.future_accepted_mentorship_relation = MentorshipRelationModel(
@@ -76,7 +51,8 @@ class TestListMentorshipRelationsDAO(BaseTestCase):
             creation_date=self.now_datetime.timestamp(),
             end_date=self.future_end_date_example.timestamp(),
             state=MentorshipRelationState.ACCEPTED,
-            notes=self.notes_example
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
         )
 
         db.session.add(self.past_mentorship_relation)

--- a/tests/mentorship_relation/test_dao_listing.py
+++ b/tests/mentorship_relation/test_dao_listing.py
@@ -3,50 +3,23 @@ from datetime import datetime, timedelta
 
 from app.api.dao.mentorship_relation import MentorshipRelationDAO
 from app.database.models.mentorship_relation import MentorshipRelationModel
+from app.database.models.tasks_list import TasksListModel
 from app.utils.enum_utils import MentorshipRelationState
-from tests.base_test_case import BaseTestCase
-from app.database.models.user import UserModel
-from tests.test_data import user1, user2
+from tests.mentorship_relation.relation_base_setup import MentorshipRelationBaseTestCase
 from app.database.sqlalchemy_extension import db
 
 
 # TODO test combination of parameters while listing relations
 
-class TestMentorshipRelationListingDAO(BaseTestCase):
+class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
 
     # Setup consists of adding 2 users into the database
     def setUp(self):
         super(TestMentorshipRelationListingDAO, self).setUp()
 
-        self.first_user = UserModel(
-            name=user1['name'],
-            email=user1['email'],
-            username=user1['username'],
-            password=user1['password'],
-            terms_and_conditions_checked=user1['terms_and_conditions_checked']
-        )
-        self.second_user = UserModel(
-            name=user2['name'],
-            email=user2['email'],
-            username=user2['username'],
-            password=user2['password'],
-            terms_and_conditions_checked=user2['terms_and_conditions_checked']
-        )
-
-        # making sure both are available to be mentor or mentee
-        self.first_user.need_mentoring = True
-        self.first_user.available_to_mentor = True
-        self.second_user.need_mentoring = True
-        self.second_user.available_to_mentor = True
-
         self.notes_example = 'description of a good mentorship relation'
-
         self.now_datetime = datetime.now()
         self.end_date_example = self.now_datetime + timedelta(weeks=5)
-
-        db.session.add(self.first_user)
-        db.session.add(self.second_user)
-        db.session.commit()
 
         # create new mentorship relation
 
@@ -57,7 +30,8 @@ class TestMentorshipRelationListingDAO(BaseTestCase):
             creation_date=self.now_datetime.timestamp(),
             end_date=self.end_date_example.timestamp(),
             state=MentorshipRelationState.PENDING,
-            notes=self.notes_example
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
         )
 
         db.session.add(self.mentorship_relation)

--- a/tests/mentorship_relation/test_dao_reject_mentorship_request.py
+++ b/tests/mentorship_relation/test_dao_reject_mentorship_request.py
@@ -2,16 +2,15 @@ from datetime import datetime, timedelta
 
 from app.api.dao.mentorship_relation import MentorshipRelationDAO
 from app.database.models.mentorship_relation import MentorshipRelationModel
+from app.database.models.tasks_list import TasksListModel
 from app.utils.enum_utils import MentorshipRelationState
-from tests.base_test_case import BaseTestCase
-from app.database.models.user import UserModel
-from tests.test_data import user1, user2
+from tests.mentorship_relation.relation_base_setup import MentorshipRelationBaseTestCase
 from app.database.sqlalchemy_extension import db
 
 
 # TODO test when a user tries to reject a relation where this user is not involved
 
-class TestMentorshipRelationListingDAO(BaseTestCase):
+class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
 
     # Setup consists of adding 2 users into the database
     # User 1 is the mentorship relation requester = action user
@@ -19,35 +18,9 @@ class TestMentorshipRelationListingDAO(BaseTestCase):
     def setUp(self):
         super(TestMentorshipRelationListingDAO, self).setUp()
 
-        self.first_user = UserModel(
-            name=user1['name'],
-            email=user1['email'],
-            username=user1['username'],
-            password=user1['password'],
-            terms_and_conditions_checked=user1['terms_and_conditions_checked']
-        )
-        self.second_user = UserModel(
-            name=user2['name'],
-            email=user2['email'],
-            username=user2['username'],
-            password=user2['password'],
-            terms_and_conditions_checked=user2['terms_and_conditions_checked']
-        )
-
-        # making sure both are available to be mentor or mentee
-        self.first_user.need_mentoring = True
-        self.first_user.available_to_mentor = True
-        self.second_user.need_mentoring = True
-        self.second_user.available_to_mentor = True
-
         self.notes_example = 'description of a good mentorship relation'
-
         self.now_datetime = datetime.now()
         self.end_date_example = self.now_datetime + timedelta(weeks=5)
-
-        db.session.add(self.first_user)
-        db.session.add(self.second_user)
-        db.session.commit()
 
         # create new mentorship relation
 
@@ -58,7 +31,8 @@ class TestMentorshipRelationListingDAO(BaseTestCase):
             creation_date=self.now_datetime.timestamp(),
             end_date=self.end_date_example.timestamp(),
             state=MentorshipRelationState.PENDING,
-            notes=self.notes_example
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
         )
 
         db.session.add(self.mentorship_relation)

--- a/tests/mentorship_relation/test_database_model.py
+++ b/tests/mentorship_relation/test_database_model.py
@@ -1,6 +1,7 @@
 import unittest
 from datetime import datetime
 
+from app.database.models.tasks_list import TasksListModel
 from app.utils.enum_utils import MentorshipRelationState
 from tests.base_test_case import BaseTestCase
 from app.database.models.user import UserModel
@@ -58,7 +59,8 @@ class TestMentorshipRelationModel(BaseTestCase):
             creation_date=self.now_datetime,
             end_date=self.end_date_example,
             state=MentorshipRelationState.PENDING,
-            notes=self.notes_example
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
         )
         db.session.add(self.mentorship_relation)
         db.session.commit()

--- a/tests/tasks/tasks_base_setup.py
+++ b/tests/tasks/tasks_base_setup.py
@@ -1,24 +1,21 @@
-import unittest
-from datetime import datetime, timedelta
-from unittest.mock import patch
+from datetime import timedelta, datetime
 
-from app.database.models.tasks_list import TasksListModel
-from app.database.sqlalchemy_extension import db
 from app.database.models.mentorship_relation import MentorshipRelationModel
-from app.schedulers.complete_mentorship_cron_job import complete_overdue_mentorship_relations_job
-from app.utils.enum_utils import MentorshipRelationState
+from app.database.models.tasks_list import TasksListModel
 from app.database.models.user import UserModel
+from app.database.sqlalchemy_extension import db
+from app.utils.enum_utils import MentorshipRelationState
 from tests.base_test_case import BaseTestCase
 from tests.test_data import user1, user2
 
 
-class TestCompleteMentorshipRelationCronFunction(BaseTestCase):
+class TasksBaseTestCase(BaseTestCase):
 
     # Setup consists of adding 2 users into the database
     # User 1 is the mentorship relation requester = action user
     # User 2 is the receiver
     def setUp(self):
-        super(TestCompleteMentorshipRelationCronFunction, self).setUp()
+        super(TasksBaseTestCase, self).setUp()
 
         self.first_user = UserModel(
             name=user1['name'],
@@ -44,8 +41,7 @@ class TestCompleteMentorshipRelationCronFunction(BaseTestCase):
         self.notes_example = 'description of a good mentorship relation'
 
         self.now_datetime = datetime.now()
-        self.past_end_date_example = self.now_datetime - timedelta(weeks=5)
-        self.future_end_date_example = self.now_datetime + timedelta(weeks=5)
+        self.end_date_example = self.now_datetime + timedelta(weeks=5)
 
         self.tasks_list_1 = TasksListModel()
         self.tasks_list_2 = TasksListModel()
@@ -60,60 +56,64 @@ class TestCompleteMentorshipRelationCronFunction(BaseTestCase):
 
         # create new mentorship relation
 
-        self.mentorship_relation_1 = MentorshipRelationModel(
+        self.mentorship_relation_w_second_user = MentorshipRelationModel(
             action_user_id=self.first_user.id,
             mentor_user=self.first_user,
             mentee_user=self.second_user,
             creation_date=self.now_datetime.timestamp(),
-            end_date=self.past_end_date_example.timestamp(),
+            end_date=self.end_date_example.timestamp(),
             state=MentorshipRelationState.ACCEPTED,
             notes=self.notes_example,
             tasks_list=self.tasks_list_1
         )
 
-        self.mentorship_relation_2 = MentorshipRelationModel(
+        self.mentorship_relation_w_admin_user = MentorshipRelationModel(
             action_user_id=self.first_user.id,
             mentor_user=self.first_user,
-            mentee_user=self.second_user,
+            mentee_user=self.admin_user,
             creation_date=self.now_datetime.timestamp(),
-            end_date=self.past_end_date_example.timestamp(),
-            state=MentorshipRelationState.PENDING,
+            end_date=self.end_date_example.timestamp(),
+            state=MentorshipRelationState.ACCEPTED,
             notes=self.notes_example,
             tasks_list=self.tasks_list_2
         )
 
-        self.mentorship_relation_3 = MentorshipRelationModel(
-            action_user_id=self.first_user.id,
-            mentor_user=self.first_user,
-            mentee_user=self.second_user,
+        self.mentorship_relation_without_first_user = MentorshipRelationModel(
+            action_user_id=self.second_user.id,
+            mentor_user=self.second_user,
+            mentee_user=self.admin_user,
             creation_date=self.now_datetime.timestamp(),
-            end_date=self.future_end_date_example.timestamp(),
-            state=MentorshipRelationState.ACCEPTED,
+            end_date=self.end_date_example.timestamp(),
+            state=MentorshipRelationState.COMPLETED,
             notes=self.notes_example,
             tasks_list=self.tasks_list_3
         )
 
-        db.session.add(self.mentorship_relation_1)
-        db.session.add(self.mentorship_relation_2)
-        db.session.add(self.mentorship_relation_3)
+        db.session.add(self.mentorship_relation_w_second_user)
+        db.session.add(self.mentorship_relation_w_admin_user)
+        db.session.add(self.mentorship_relation_without_first_user)
         db.session.commit()
 
-    def get_test_app(self):
-        return self.app
+        self.description_example = 'This is an example of a description'
 
-    @patch('run.application', side_effect=get_test_app)
-    def test_complete_mentorship_relations_accepted(self, get_test_app_fn):
+        self.tasks_list_1.add_task(
+            description=self.description_example,
+            created_at=self.now_datetime.timestamp()
+        )
+        self.tasks_list_1.add_task(
+            description=self.description_example,
+            created_at=self.now_datetime.timestamp(),
+            is_done=True,
+            completed_at=self.end_date_example.timestamp()
+        )
+        self.tasks_list_2.add_task(
+            description=self.description_example,
+            created_at=self.now_datetime.timestamp()
+        )
 
-        self.assertEqual(MentorshipRelationState.ACCEPTED, self.mentorship_relation_1.state)
-        self.assertEqual(MentorshipRelationState.PENDING, self.mentorship_relation_2.state)
-        self.assertEqual(MentorshipRelationState.ACCEPTED, self.mentorship_relation_3.state)
+        db.session.add(self.tasks_list_1)
+        db.session.add(self.tasks_list_2)
+        db.session.commit()
 
-        complete_overdue_mentorship_relations_job()
-
-        self.assertEqual(MentorshipRelationState.COMPLETED, self.mentorship_relation_1.state)
-        self.assertEqual(MentorshipRelationState.PENDING, self.mentorship_relation_2.state)
-        self.assertEqual(MentorshipRelationState.ACCEPTED, self.mentorship_relation_3.state)
-
-
-if __name__ == "__main__":
-    unittest.main()
+        self.test_description = 'testing this description'
+        self.test_is_done = False

--- a/tests/tasks/test_api_complete_task.py
+++ b/tests/tasks/test_api_complete_task.py
@@ -1,0 +1,45 @@
+import unittest
+from flask import json
+
+from app.database.models.mentorship_relation import MentorshipRelationModel
+from tests.tasks.tasks_base_setup import TasksBaseTestCase
+from tests.test_utils import get_test_request_header
+
+
+class TestCompleteTaskApi(TasksBaseTestCase):
+
+    def test_complete_task_api_resource_non_auth(self):
+        expected_response = {'message': 'The authorization token is missing!'}
+        actual_response = self.client.put('/mentorship_relation/%s/task/%s/complete'
+                                             % (self.mentorship_relation_w_second_user.id, 2),
+                                             follow_redirects=True)
+
+        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_complete_task_api(self):
+
+        relation = MentorshipRelationModel.find_by_id(self.mentorship_relation_w_second_user.id)
+        incomplete_task = relation.tasks_list.find_task_by_id(1)
+        self.assertIsNotNone(incomplete_task)
+        self.assertIsNone(incomplete_task.get('completed_at'))
+        self.assertFalse(incomplete_task.get('is_done'))
+
+        auth_header = get_test_request_header(self.first_user.id)
+        expected_response = {"message": "Task was achieved successfully."}
+        actual_response = self.client.put('/mentorship_relation/%s/task/%s/complete'
+                                             % (self.mentorship_relation_w_second_user.id, 1),
+                                             follow_redirects=True, headers=auth_header)
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+        relation = MentorshipRelationModel.find_by_id(self.mentorship_relation_w_second_user.id)
+        complete_task = relation.tasks_list.find_task_by_id(1)
+        self.assertIsNotNone(complete_task)
+        self.assertIsNotNone(complete_task.get('completed_at'))
+        self.assertTrue(complete_task.get('is_done'))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tasks/test_api_create_task.py
+++ b/tests/tasks/test_api_create_task.py
@@ -1,0 +1,38 @@
+import unittest
+from flask import json
+from tests.tasks.tasks_base_setup import TasksBaseTestCase
+from tests.test_utils import get_test_request_header
+
+
+class TestCreateTaskApi(TasksBaseTestCase):
+
+    def test_create_task_api_resource_non_auth(self):
+        expected_response = {'message': 'The authorization token is missing!'}
+        actual_response = self.client.post('/mentorship_relation/%s/task' % self.mentorship_relation_w_second_user.id,
+                                           follow_redirects=True)
+
+        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_full_task_creation_api(self):
+
+        non_existent_task = self.tasks_list_1.find_task_by_id(3)
+        self.assertIsNone(non_existent_task)
+
+        auth_header = get_test_request_header(self.first_user.id)
+        expected_response = {"message": "Task was created successfully."}
+        actual_response = self.client.post('/mentorship_relation/%s/task' % self.mentorship_relation_w_second_user.id,
+                                           follow_redirects=True, headers=auth_header, content_type='application/json',
+                                           data=json.dumps(dict(description=self.test_description)))
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+        new_task = self.tasks_list_1.find_task_by_id(3)
+        self.assertIsNotNone(new_task)
+        self.assertEqual(self.test_description, new_task.get('description'))
+        self.assertEqual(self.test_is_done, new_task.get('is_done'))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tasks/test_api_delete_task.py
+++ b/tests/tasks/test_api_delete_task.py
@@ -1,0 +1,37 @@
+import unittest
+from flask import json
+from tests.tasks.tasks_base_setup import TasksBaseTestCase
+from tests.test_utils import get_test_request_header
+
+
+class TestDeleteTaskApi(TasksBaseTestCase):
+
+    def test_delete_task_api_resource_non_auth(self):
+        expected_response = {'message': 'The authorization token is missing!'}
+        actual_response = self.client.delete('/mentorship_relation/%s/task/%s'
+                                             % (self.mentorship_relation_w_second_user.id, 2),
+                                             follow_redirects=True)
+
+        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_full_task_deletion_api(self):
+
+        existent_task = self.tasks_list_1.find_task_by_id(2)
+        self.assertIsNotNone(existent_task)
+
+        auth_header = get_test_request_header(self.first_user.id)
+        expected_response = {"message": "Task was deleted successfully."}
+        actual_response = self.client.delete('/mentorship_relation/%s/task/%s'
+                                             % (self.mentorship_relation_w_second_user.id, 2),
+                                             follow_redirects=True, headers=auth_header)
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+        deleted_task = self.tasks_list_1.find_task_by_id(2)
+        self.assertIsNone(deleted_task)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tasks/test_api_list_tasks.py
+++ b/tests/tasks/test_api_list_tasks.py
@@ -1,0 +1,67 @@
+import unittest
+from flask import json
+from flask_restplus import marshal
+
+from app.api.models.mentorship_relation import list_tasks_response_body
+from tests.tasks.tasks_base_setup import TasksBaseTestCase
+from tests.test_utils import get_test_request_header
+
+
+class TestListTasksApi(TasksBaseTestCase):
+
+    def test_list_tasks_api_resource_non_auth(self):
+        expected_response = {'message': 'The authorization token is missing!'}
+        actual_response = self.client.get('/mentorship_relation/%s/tasks'
+                                          % self.mentorship_relation_w_second_user.id,
+                                          follow_redirects=True)
+
+        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_list_tasks_api_first_mentorship_relation(self):
+
+        auth_header = get_test_request_header(self.first_user.id)
+        expected_response = marshal(self.tasks_list_1.tasks, list_tasks_response_body)
+        actual_response = self.client.get('/mentorship_relation/%s/tasks'
+                                          % self.mentorship_relation_w_second_user.id,
+                                          follow_redirects=True, headers=auth_header)
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_list_tasks_api_second_mentorship_relation(self):
+
+        auth_header = get_test_request_header(self.first_user.id)
+        expected_response = marshal(self.tasks_list_2.tasks, list_tasks_response_body)
+        actual_response = self.client.get('/mentorship_relation/%s/tasks'
+                                          % self.mentorship_relation_w_admin_user.id,
+                                          follow_redirects=True, headers=auth_header)
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_list_tasks_api_w_user_not_belonging_to_mentorship_relation(self):
+
+        auth_header = get_test_request_header(self.second_user.id)
+        expected_response = {'message': 'You are not involved in this mentorship relation.'}
+        actual_response = self.client.get('/mentorship_relation/%s/tasks'
+                                          % self.mentorship_relation_w_admin_user.id,
+                                          follow_redirects=True, headers=auth_header)
+
+        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_list_tasks_api_mentorship_relation_without_tasks(self):
+
+        auth_header = get_test_request_header(self.second_user.id)
+        expected_response = []
+        actual_response = self.client.get('/mentorship_relation/%s/tasks'
+                                          % self.mentorship_relation_without_first_user.id,
+                                          follow_redirects=True, headers=auth_header)
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tasks/test_dao_complete_task.py
+++ b/tests/tasks/test_dao_complete_task.py
@@ -1,0 +1,42 @@
+import unittest
+
+from app.api.dao.task import TaskDAO
+from tests.tasks.tasks_base_setup import TasksBaseTestCase
+
+
+class TestCompleteTasksDao(TasksBaseTestCase):
+
+    def test_achieve_not_achieved_task(self):
+        self.assertFalse(self.tasks_list_1.find_task_by_id(1).get('is_done'))
+
+        expected_response = {'message': 'Task was achieved successfully.'}, 200
+        actual_response = TaskDAO.complete_task(self.first_user.id,
+                                               self.mentorship_relation_w_second_user.id,
+                                               1)
+
+        self.assertTrue(self.tasks_list_1.find_task_by_id(1).get('is_done'))
+        self.assertEqual(expected_response, actual_response)
+
+    def test_achieve_achieved_task(self):
+        self.assertTrue(self.tasks_list_1.find_task_by_id(2).get('is_done'))
+
+        expected_response = {'message': 'Task was already achieved.'}, 400
+        actual_response = TaskDAO.complete_task(self.first_user.id,
+                                               self.mentorship_relation_w_second_user.id,
+                                               2)
+
+        self.assertTrue(self.tasks_list_1.find_task_by_id(2).get('is_done'))
+        self.assertEqual(expected_response, actual_response)
+
+    def test_achieve_not_existent_task(self):
+
+        expected_response = {'message': 'Task does not exist.'}, 404
+        actual_response = TaskDAO.complete_task(self.first_user.id,
+                                               self.mentorship_relation_w_second_user.id,
+                                               123123)
+
+        self.assertEqual(expected_response, actual_response)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/tasks/test_dao_create_task.py
+++ b/tests/tasks/test_dao_create_task.py
@@ -1,0 +1,50 @@
+import unittest
+
+from app.api.dao.task import TaskDAO
+from app.utils.enum_utils import MentorshipRelationState
+from tests.tasks.tasks_base_setup import TasksBaseTestCase
+
+
+class TestListTasksDao(TasksBaseTestCase):
+
+    def test_create_task(self):
+
+        expected_response = {"message": "Task was created successfully."}, 200
+
+        non_existent_task = self.tasks_list_1.find_task_by_id(3)
+        self.assertIsNone(non_existent_task)
+
+        actual_response = TaskDAO.create_task(user_id=self.first_user.id,
+                                              mentorship_relation_id=self.mentorship_relation_w_second_user.id,
+                                              data=dict(description=self.test_description, is_done=self.test_is_done))
+        self.assertEqual(expected_response, actual_response)
+
+        new_task = self.tasks_list_1.find_task_by_id(3)
+        self.assertIsNotNone(new_task)
+        self.assertEqual(self.test_description, new_task.get('description'))
+        self.assertEqual(self.test_is_done, new_task.get('is_done'))
+
+    def test_create_task_with_non_existing_mentorship_relation(self):
+
+        expected_response = {'message': 'Mentorship relation does not exist.'}, 404
+
+        actual_response = TaskDAO.create_task(user_id=self.first_user.id,
+                                              mentorship_relation_id=123123,
+                                              data=dict(description=self.test_description, is_done=self.test_is_done))
+
+        self.assertEqual(expected_response, actual_response)
+
+    def test_create_task_with_mentorship_relation_non_accepted_state(self):
+
+        expected_response = {'message': 'Mentorship relation is not in the accepted state.'}, 400
+        self.mentorship_relation_w_second_user.state = MentorshipRelationState.CANCELLED
+
+        actual_response = TaskDAO.create_task(user_id=self.first_user.id,
+                                              mentorship_relation_id=self.mentorship_relation_w_second_user.id,
+                                              data=dict(description=self.test_description, is_done=self.test_is_done))
+
+        self.assertEqual(expected_response, actual_response)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/tasks/test_dao_delete_task.py
+++ b/tests/tasks/test_dao_delete_task.py
@@ -1,0 +1,36 @@
+import unittest
+
+from app.api.dao.task import TaskDAO
+from tests.tasks.tasks_base_setup import TasksBaseTestCase
+
+
+class TestDeleteTasksDao(TasksBaseTestCase):
+
+    def test_delete_existent_task(self):
+
+        expected_response = {'message': 'Task was deleted successfully.'}, 200
+        first_task_id = 1
+
+        not_deleted_yet_task = self.tasks_list_1.find_task_by_id(task_id=first_task_id)
+        self.assertIsNotNone(not_deleted_yet_task)
+
+        actual_response = TaskDAO.delete_task(self.first_user.id,
+                                              self.mentorship_relation_w_second_user.id,
+                                              first_task_id)
+        self.assertEqual(expected_response, actual_response)
+
+        deleted_task = self.tasks_list_1.find_task_by_id(task_id=first_task_id)
+        self.assertIsNone(deleted_task)
+
+    def test_delete_non_existent_task(self):
+
+        expected_response = {'message': 'Task does not exist.'}, 404
+        actual_response = TaskDAO.delete_task(self.first_user.id,
+                                              self.mentorship_relation_w_second_user.id,
+                                              123123)
+
+        self.assertEqual(expected_response, actual_response)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/tasks/test_dao_list_tasks.py
+++ b/tests/tasks/test_dao_list_tasks.py
@@ -1,0 +1,46 @@
+import unittest
+
+from app.api.dao.task import TaskDAO
+from tests.tasks.tasks_base_setup import TasksBaseTestCase
+
+
+class TestListTasksDao(TasksBaseTestCase):
+
+    def test_list_tasks(self):
+
+        expected_response = self.tasks_list_1.tasks
+        actual_response = TaskDAO.list_tasks(self.first_user.id, self.mentorship_relation_w_second_user.id)
+
+        self.assertEqual(expected_response, actual_response)
+
+    def test_list_empty_tasks(self):
+
+        expected_response = []
+        actual_response = TaskDAO.list_tasks(self.admin_user.id, self.mentorship_relation_without_first_user.id)
+
+        self.assertEqual(expected_response, actual_response)
+
+    def test_list_tasks_with_non_existent_relation(self):
+
+        expected_response = {'message': 'Mentorship relation does not exist.'}, 404
+        actual_response = TaskDAO.list_tasks(self.first_user.id, 123123)
+
+        self.assertEqual(expected_response, actual_response)
+
+    def test_list_tasks_with_non_existent_user(self):
+
+        expected_response = {'message': 'User does not exist.'}, 404
+        actual_response = TaskDAO.list_tasks(123123, self.mentorship_relation_w_second_user.id)
+
+        self.assertEqual(expected_response, actual_response)
+
+    def test_list_tasks_with_user_not_involved(self):
+
+        expected_response = {'message': 'You are not involved in this mentorship relation.'}, 401
+        actual_response = TaskDAO.list_tasks(self.admin_user.id, self.mentorship_relation_w_second_user.id)
+
+        self.assertEqual(expected_response, actual_response)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/tasks/test_tasks_list_database_model.py
+++ b/tests/tasks/test_tasks_list_database_model.py
@@ -1,0 +1,161 @@
+import unittest
+from datetime import datetime
+
+from app.database.models.tasks_list import TasksListModel
+from app.database.sqlalchemy_extension import db
+from tests.base_test_case import BaseTestCase
+
+
+class TestTasksListModel(BaseTestCase):
+
+    def setUp(self):
+        super(TestTasksListModel, self).setUp()
+
+        self.empty_tasks_list = TasksListModel()
+        self.tasks_list_1 = TasksListModel()
+        db.session.add(self.empty_tasks_list)
+        db.session.add(self.tasks_list_1)
+        db.session.commit()
+
+        self.now_timestamp = datetime.now().timestamp()
+        self.test_description_1 = 'test description number one'
+        self.test_description_2 = 'test description number two'
+
+        self.tasks_list_1.add_task(self.test_description_1, self.now_timestamp)
+
+    def test_tasks_list_creation(self):
+
+        tasks_list_one = TasksListModel.query.filter_by(id=1).first()
+
+        self.assertIsNotNone(tasks_list_one)
+        self.assertEqual([], tasks_list_one.tasks)
+        self.assertEqual(1, tasks_list_one.next_task_id)
+        self.assertEqual(1, tasks_list_one.id)
+
+    def test_add_task_to_tasks_list(self):
+
+        tasks_list_one = TasksListModel.query.filter_by(id=1).first()
+
+        self.assertEqual([], tasks_list_one.tasks)
+
+        tasks_list_one.add_task(self.test_description_1, self.now_timestamp)
+
+        expected_task_1 = dict(
+            completed_at=None,
+            created_at=self.now_timestamp,
+            description=self.test_description_1,
+            id=1,
+            is_done=False
+        )
+
+        self.assertEqual([expected_task_1], tasks_list_one.tasks)
+
+        tasks_list_one.add_task(self.test_description_1, self.now_timestamp)
+
+        expected_task_2 = dict(
+            completed_at=None,
+            created_at=self.now_timestamp,
+            description=self.test_description_1,
+            id=2,
+            is_done=False
+        )
+
+        self.assertEqual([expected_task_1, expected_task_2], tasks_list_one.tasks)
+
+    def test_remove_task_from_tasks_list(self):
+
+        tasks_list_one = TasksListModel.query.filter_by(id=1).first()
+
+        self.assertEqual([], tasks_list_one.tasks)
+
+        tasks_list_one.add_task(self.test_description_1, self.now_timestamp)
+
+        expected_task_1 = dict(
+            completed_at=None,
+            created_at=self.now_timestamp,
+            description=self.test_description_1,
+            id=1,
+            is_done=False
+        )
+
+        self.assertEqual([expected_task_1], tasks_list_one.tasks)
+
+        tasks_list_one.delete_task(task_id=1)
+
+        self.assertEqual([], tasks_list_one.tasks)
+
+    def test_remove_task_from_pre_filled_list(self):
+
+        tasks_list_two = TasksListModel.query.filter_by(id=2).first()
+
+        expected_task_1 = dict(
+            completed_at=None,
+            created_at=self.now_timestamp,
+            description=self.test_description_1,
+            id=1,
+            is_done=False
+        )
+
+        self.assertEqual([expected_task_1], tasks_list_two.tasks)
+        self.assertFalse(tasks_list_two.is_empty())
+
+        tasks_list_two.delete_task(task_id=1)
+
+        self.assertEqual([], tasks_list_two.tasks)
+        self.assertTrue(tasks_list_two.is_empty())
+
+    def test_empty_tasks_list_function(self):
+
+        tasks_list_one = TasksListModel.query.filter_by(id=1).first()
+        self.assertTrue(tasks_list_one.is_empty())
+
+    def test_find_task_by_id(self):
+
+        tasks_list_one = TasksListModel.query.filter_by(id=1).first()
+
+        expected_task_1 = dict(
+            completed_at=None,
+            created_at=self.now_timestamp,
+            description=self.test_description_1,
+            id=1,
+            is_done=False
+        )
+        expected_task_2 = dict(
+            completed_at=None,
+            created_at=self.now_timestamp,
+            description=self.test_description_2,
+            id=2,
+            is_done=False
+        )
+
+        tasks_list_one.add_task(self.test_description_1, self.now_timestamp)
+        tasks_list_one.add_task(self.test_description_2, self.now_timestamp)
+
+        found_task_1 = tasks_list_one.find_task_by_id(task_id=1)
+        self.assertIsNotNone(found_task_1)
+        self.assertEqual(expected_task_1, found_task_1)
+
+        found_task_2 = tasks_list_one.find_task_by_id(task_id=2)
+        self.assertIsNotNone(found_task_2)
+        self.assertEqual(expected_task_2, found_task_2)
+
+        found_task_3 = tasks_list_one.find_task_by_id(task_id=3)
+        self.assertIsNone(found_task_3)
+
+    def test_update_task(self):
+
+        tasks_list_one = TasksListModel.query.filter_by(id=2).first()
+        self.assertIsNotNone(tasks_list_one)
+
+        task_1 = tasks_list_one.find_task_by_id(task_id=1)
+        self.assertIsNotNone(task_1)
+        self.assertFalse(task_1.get('is_done'))
+
+        tasks_list_one.update_task(task_id=1, is_done=True)
+
+        new_task_1 = tasks_list_one.find_task_by_id(task_id=1)
+        self.assertTrue(new_task_1.get('is_done'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Description

Completed a simple version of the Tasks feature
Tasks feature is a JSON object part of TasksListModel which has a 1:1 relation with MentorshipRelationModel.
I'm not allowing for users to create a task which is already achieved.

A task entity will have the following format. This is the JSON response returned by the List all Tasks API:
```
[
  {
    "id": 3,
    "description": "sloa loa loag",
    "is_done": false,
    "created_at": 1534132997.472032,
    "completed_at": null
  },
]
```

Request Body:
```
{
    "description": "sample text"
}
```

New APIs:

![apis exceprt on Swagger](https://user-images.githubusercontent.com/11148726/44014609-c8baa9d0-9ec4-11e8-8856-d9315c8b3e47.png)

**Note**: You may notice that I deleted some repeated code from tests, this is related to the setup of Mentorship Relation tests, there was a lot of repeated setup that I moved to a file which has this common setup. I did this in this PR because I was already changing this files to adapt to the new changes on MentorshipRelationModel.

Fixes #82 

### Type of Change:

- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?

Created extensive tests for each module: DAO, database model and API
Tests can be still improved, although I think the ones I developed are enough for now.

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged
- [x] Update Swagger documentation and the exported file at /docs folder

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
