### PR TITLE
Fixed bug of updating mentor/mentee availability to false

### DIFF
--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -126,13 +126,11 @@ class UserDAO:
         if 'photo_url' in data and data['photo_url']:
             user.photo_url = data['photo_url']
 
-        if 'need_mentoring' in data and data['need_mentoring']:
+        if 'need_mentoring' in data:
             user.need_mentoring = data['need_mentoring']
 
-        if 'available_to_mentor' in data and data['available_to_mentor']:
+        if 'available_to_mentor' in data:
             user.available_to_mentor = data['available_to_mentor']
-
-        # print(data)
 
         user.save_to_db()
 

--- a/app/api/validations/user.py
+++ b/app/api/validations/user.py
@@ -156,6 +156,12 @@ def validate_update_profile_request_data(data):
         if not is_valid[0]:
             return is_valid[1]
 
+    if 'need_mentoring' in data and data['need_mentoring'] is None:
+        return {"message": "Field need_mentoring is not valid."}
+
+    if 'available_to_mentor' in data and data['available_to_mentor'] is None:
+        return {"message": "Field available_to_mentor is not valid."}
+
     return {}
 
 

--- a/tests/users/test_api_update_user.py
+++ b/tests/users/test_api_update_user.py
@@ -103,6 +103,76 @@ class TestUpdateUserApi(BaseTestCase):
         self.assertNotEqual(random_generated_username, self.first_user.username)
         self.assertEqual(user1['username'], self.first_user.username)
 
+    def test_update_availability_to_mentor_more_than_once(self):
+
+        self.first_user = UserModel(
+            name=user1['name'],
+            email=user1['email'],
+            username=user1['username'],
+            password=user1['password'],
+            terms_and_conditions_checked=user1['terms_and_conditions_checked']
+        )
+        self.first_user.is_email_verified = True
+
+        db.session.add(self.first_user)
+        db.session.commit()
+
+        expected_response = {"message": "User was updated successfully"}
+        test_mentor_availability = True
+        auth_header = get_test_request_header(self.first_user.id)
+
+        self.assertEqual(False, self.first_user.available_to_mentor)
+
+        actual_response = self.client.put('/user', follow_redirects=True,
+                                          headers=auth_header,
+                                          data=json.dumps(dict(available_to_mentor=test_mentor_availability)),
+                                          content_type='application/json')
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+        self.assertEqual(test_mentor_availability, self.first_user.available_to_mentor)
+
+        actual_response = self.client.put('/user', follow_redirects=True,
+                                          headers=auth_header,
+                                          data=json.dumps(dict(available_to_mentor=not test_mentor_availability)),
+                                          content_type='application/json')
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+        self.assertEqual(not test_mentor_availability, self.first_user.available_to_mentor)
+
+    def test_update_availability_to_be_mentee_to_false(self):
+
+        self.first_user = UserModel(
+            name=user1['name'],
+            email=user1['email'],
+            username=user1['username'],
+            password=user1['password'],
+            terms_and_conditions_checked=user1['terms_and_conditions_checked']
+        )
+        self.first_user.is_email_verified = True
+        self.first_user.need_mentoring = True
+
+        db.session.add(self.first_user)
+        db.session.commit()
+
+        expected_response = {"message": "User was updated successfully"}
+        test_need_mentoring = False
+        auth_header = get_test_request_header(self.first_user.id)
+
+        self.assertEqual(True, self.first_user.need_mentoring)
+
+        actual_response = self.client.put('/user', follow_redirects=True,
+                                          headers=auth_header,
+                                          data=json.dumps(dict(need_mentoring=test_need_mentoring)),
+                                          content_type='application/json')
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+        self.assertEqual(test_need_mentoring, self.first_user.need_mentoring)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description

Fixed the bug of the availability to be mentored and to mentor not being updated back to false

Fixes #137 

### Type of Change:
- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Added a new test for the API, where I toggled the available to mentor and need mentoring field.

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes