### PR TITLE
Add seek mentorship and availability to mentor fields to Register API

### DIFF
--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -27,6 +27,11 @@ class UserDAO:
                 return {"message": "A user with that email already exists"}, 400
 
         user = UserModel(name, username, password, email, terms_and_conditions_checked)
+        if 'need_mentoring' in data:
+            user.need_mentoring = data['need_mentoring']
+
+        if 'available_to_mentor' in data:
+            user.available_to_mentor = data['available_to_mentor']
 
         user.save_to_db()
 

--- a/app/api/models/user.py
+++ b/app/api/models/user.py
@@ -137,7 +137,9 @@ register_user_api_model = Model('User registration model', {
     'username': fields.String(required=True, description='User username'),
     'password': fields.String(required=True, description='User password'),
     'email': fields.String(required=True, description='User email'),
-    'terms_and_conditions_checked': fields.Boolean(required=True, description='User check Terms and Conditions value')
+    'terms_and_conditions_checked': fields.Boolean(required=True, description='User check Terms and Conditions value'),
+    'need_mentoring': fields.Boolean(required=False, description='User need mentoring indication'),
+    'available_to_mentor': fields.Boolean(required=False, description='User availability to mentor indication')
 })
 
 change_password_request_data_model = Model('Change password request data model', {

--- a/app/api/resources/user.py
+++ b/app/api/resources/user.py
@@ -154,7 +154,7 @@ class UserRegister(Resource):
     @classmethod
     @users_ns.doc('create_user')
     @users_ns.response(201, 'User successfully created.')
-    @users_ns.expect(register_user_api_model)
+    @users_ns.expect(register_user_api_model, validate=True)
     def post(cls):
         """
         Creates a new user.

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -12,7 +12,9 @@ user1 = dict(
     email="user1@email.com",
     username="user1",
     password="user1_pwd",
-    terms_and_conditions_checked=True
+    terms_and_conditions_checked=True,
+    available_to_mentor=True,
+    need_mentoring=True
 )
 user2 = dict(
     name="Userb",

--- a/tests/users/test_api_resources.py
+++ b/tests/users/test_api_resources.py
@@ -23,7 +23,7 @@ class TestUserRegistrationApi(BaseTestCase):
 
     # mocking mail.send function which connects with smtp server
     @patch('flask_mail._MailMixin.send', side_effect=mail_send_mocked)
-    def test_user_registration(self, send_email_function):
+    def test_user_registration_without_optional_fields(self, send_email_function):
         # Ensure user registration behaves correctly
 
         with self.client:
@@ -35,10 +35,7 @@ class TestUserRegistrationApi(BaseTestCase):
                 terms_and_conditions_checked=user1['terms_and_conditions_checked']
             )), follow_redirects=True, content_type='application/json')
 
-            # print(response)
-            # print(response.data)
             user = UserModel.query.filter_by(email=user1['email']).first()
-            # print(user.json())
             if user is None:
                 self.fail('POST /register failed to register Testing User! with error code = %d' % response.status_code)
             else:
@@ -48,6 +45,57 @@ class TestUserRegistrationApi(BaseTestCase):
                 self.assertEqual(user1['terms_and_conditions_checked'], user.terms_and_conditions_checked)
                 self.assertFalse(user.is_admin)
                 self.assertFalse(user.is_email_verified)
+                self.assertFalse(user.need_mentoring)
+                self.assertFalse(user.available_to_mentor)
+
+    @patch('flask_mail._MailMixin.send', side_effect=mail_send_mocked)
+    def test_user_registration_with_both_optional_fields(self, send_email_function):
+        with self.client:
+            self.client.post('/register', data=json.dumps(dict(
+                name=user1['name'],
+                username=user1['username'],
+                password=user1['password'],
+                email=user1['email'],
+                terms_and_conditions_checked=user1['terms_and_conditions_checked'],
+                available_to_mentor=user1['available_to_mentor'],
+                need_mentoring=user1['need_mentoring']
+            )), follow_redirects=True, content_type='application/json')
+
+            user = UserModel.query.filter_by(email=user1['email']).first()
+            self.assertTrue(user.need_mentoring)
+            self.assertTrue(user.available_to_mentor)
+
+    @patch('flask_mail._MailMixin.send', side_effect=mail_send_mocked)
+    def test_user_registration_mentor(self, send_email_function):
+        with self.client:
+            self.client.post('/register', data=json.dumps(dict(
+                name=user1['name'],
+                username=user1['username'],
+                password=user1['password'],
+                email=user1['email'],
+                terms_and_conditions_checked=user1['terms_and_conditions_checked'],
+                available_to_mentor=user1['available_to_mentor'],
+            )), follow_redirects=True, content_type='application/json')
+
+            user = UserModel.query.filter_by(email=user1['email']).first()
+            self.assertFalse(user.need_mentoring)
+            self.assertTrue(user.available_to_mentor)
+
+    @patch('flask_mail._MailMixin.send', side_effect=mail_send_mocked)
+    def test_user_registration_mentee(self, send_email_function):
+        with self.client:
+            self.client.post('/register', data=json.dumps(dict(
+                name=user1['name'],
+                username=user1['username'],
+                password=user1['password'],
+                email=user1['email'],
+                terms_and_conditions_checked=user1['terms_and_conditions_checked'],
+                need_mentoring=user1['need_mentoring']
+            )), follow_redirects=True, content_type='application/json')
+
+            user = UserModel.query.filter_by(email=user1['email']).first()
+            self.assertTrue(user.need_mentoring)
+            self.assertFalse(user.available_to_mentor)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description
Add optional mentor and mentee fields to the registration API.

Fixes #144 

### Type of Change:

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
- Added validations for the mentor and mentee fields and tests for these validations.
- Added a test for user registration with mentor and mentee fields.

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes