### PR TITLE
Add cancellation_reason field to cancel API

### DIFF
--- a/app/api/dao/mentorship_relation.py
+++ b/app/api/dao/mentorship_relation.py
@@ -191,7 +191,7 @@ class MentorshipRelationDAO:
         return {'message': 'Mentorship relation was rejected successfully.'}, 200
 
     @staticmethod
-    def cancel_relation(user_id, relation_id):
+    def cancel_relation(user_id, relation_id, data=None):
 
         user = UserModel.find_by_id(user_id)
 
@@ -215,6 +215,8 @@ class MentorshipRelationDAO:
 
         # All was checked
         request.state = MentorshipRelationState.CANCELLED
+        if data and 'cancellation_reason' in data:
+            request.cancellation_reason = data['cancellation_reason']
         request.save_to_db()
 
         return {'message': 'Mentorship relation was cancelled successfully.'}, 200

--- a/app/api/models/mentorship_relation.py
+++ b/app/api/models/mentorship_relation.py
@@ -9,7 +9,7 @@ def add_models_to_namespace(api_namespace):
     api_namespace.models[relation_user_response_body.name] = relation_user_response_body
     api_namespace.models[create_task_request_body.name] = create_task_request_body
     api_namespace.models[list_tasks_response_body.name] = list_tasks_response_body
-
+    api_namespace.models[mentorship_cancellation_request_body.name] = mentorship_cancellation_request_body
 
 send_mentorship_request_body = Model('Send mentorship relation request model', {
     'mentor_id': fields.Integer(required=True, description='Mentorship relation mentor ID'),
@@ -47,4 +47,8 @@ list_tasks_response_body = Model('List tasks response model', {
     'is_done': fields.Boolean(required=True, description='Mentorship relation task is done indication'),
     'created_at': fields.Float(required=True, description='Task creation date in UNIX timestamp format'),
     'completed_at': fields.Float(required=False, description='Task completion date in UNIX timestamp format')
+})
+
+mentorship_cancellation_request_body = Model('Mentorship cancellation request model', {
+    'cancellation_reason': fields.String(required=False, description='Mentorship cancellation reason.')
 })

--- a/app/api/resources/mentorship_relation.py
+++ b/app/api/resources/mentorship_relation.py
@@ -129,7 +129,7 @@ class CancelMentorshipRelation(Resource):
     @classmethod
     @jwt_required
     @mentorship_relation_ns.doc('cancel_mentorship_relation')
-    @mentorship_relation_ns.expect(auth_header_parser)
+    @mentorship_relation_ns.expect(auth_header_parser, mentorship_cancellation_request_body)
     @mentorship_relation_ns.response(200, 'Cancelled mentorship relations with success.')
     def put(cls, request_id):
         """
@@ -139,7 +139,8 @@ class CancelMentorshipRelation(Resource):
         # TODO check if user id is well parsed, if it is an integer
 
         user_id = get_jwt_identity()
-        response = DAO.cancel_relation(user_id=user_id, relation_id=request_id)
+        data = request.json
+        response = DAO.cancel_relation(user_id=user_id, relation_id=request_id, data=data)
 
         return response
 

--- a/app/database/models/mentorship_relation.py
+++ b/app/database/models/mentorship_relation.py
@@ -29,6 +29,7 @@ class MentorshipRelationModel(db.Model):
 
     state = db.Column(db.Enum(MentorshipRelationState), nullable=False)
     notes = db.Column(db.String(400))
+    cancellation_reason = db.Column(db.String(400))
 
     tasks_list_id = db.Column(db.Integer, db.ForeignKey('tasks_list.id'))
     tasks_list = db.relationship(TasksListModel, uselist=False, backref="mentorship_relation")

--- a/tests/mentorship_relation/test_dao_cancel_relation.py
+++ b/tests/mentorship_relation/test_dao_cancel_relation.py
@@ -41,7 +41,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
     def test_dao_cancel_non_existing_mentorship_request(self):
         DAO = MentorshipRelationDAO()
 
-        result = DAO.cancel_relation(self.first_user.id, 123)
+        result = DAO.cancel_relation(self.first_user.id, 123, 'Some reason to cancel the relation.')
 
         self.assertEqual(({'message': 'This mentorship relation request does not exist.'}, 404), result)
         self.assertEqual(MentorshipRelationState.PENDING, self.mentorship_relation.state)
@@ -49,7 +49,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
     def test_dao_sender_does_not_exist_mentorship_request(self):
         DAO = MentorshipRelationDAO()
 
-        result = DAO.cancel_relation(123, self.mentorship_relation.id)
+        result = DAO.cancel_relation(123, self.mentorship_relation.id, 'Some reason to cancel the relation.')
 
         self.assertEqual(({'message': 'User does not exist.'}, 404), result)
         self.assertEqual(MentorshipRelationState.PENDING, self.mentorship_relation.state)
@@ -60,7 +60,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         db.session.commit()
 
         DAO = MentorshipRelationDAO()
-        result = DAO.cancel_relation(self.second_user.id, self.mentorship_relation.id)
+        result = DAO.cancel_relation(self.second_user.id, self.mentorship_relation.id, 'Some reason to cancel the relation.')
 
         self.assertEqual(({'message': 'Mentorship relation was cancelled successfully.'}, 200), result)
         self.assertEqual(MentorshipRelationState.CANCELLED, self.mentorship_relation.state)
@@ -71,7 +71,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         db.session.commit()
 
         DAO = MentorshipRelationDAO()
-        result = DAO.cancel_relation(self.first_user.id, self.mentorship_relation.id)
+        result = DAO.cancel_relation(self.first_user.id, self.mentorship_relation.id, 'Some reason to cancel the relation.')
 
         self.assertEqual(({'message': 'Mentorship relation was cancelled successfully.'}, 200), result)
         self.assertEqual(MentorshipRelationState.CANCELLED, self.mentorship_relation.state)
@@ -83,26 +83,26 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
-        result = DAO.cancel_relation(self.second_user.id, self.mentorship_relation.id)
+        result = DAO.cancel_relation(self.second_user.id, self.mentorship_relation.id, 'Some reason to cancel the relation.')
         self.assertEqual(({'message': 'This mentorship relation is not in the accepted state.'}, 400), result)
 
         self.mentorship_relation.state = MentorshipRelationState.COMPLETED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
-        result = DAO.cancel_relation(self.second_user.id, self.mentorship_relation.id)
+        result = DAO.cancel_relation(self.second_user.id, self.mentorship_relation.id, 'Some reason to cancel the relation.')
         self.assertEqual(({'message': 'This mentorship relation is not in the accepted state.'}, 400), result)
 
         self.mentorship_relation.state = MentorshipRelationState.CANCELLED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
-        result = DAO.cancel_relation(self.second_user.id, self.mentorship_relation.id)
+        result = DAO.cancel_relation(self.second_user.id, self.mentorship_relation.id, 'Some reason to cancel the relation.')
         self.assertEqual(({'message': 'This mentorship relation is not in the accepted state.'}, 400), result)
 
         self.mentorship_relation.state = MentorshipRelationState.REJECTED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
-        result = DAO.cancel_relation(self.second_user.id, self.mentorship_relation.id)
+        result = DAO.cancel_relation(self.second_user.id, self.mentorship_relation.id, 'Some reason to cancel the relation.')
         self.assertEqual(({'message': 'This mentorship relation is not in the accepted state.'}, 400), result)


### PR DESCRIPTION


### Description

- Add cancellation_reason field to the mentorship_relation/cancel API to mention the reason for canceling the relation.
- Add new field in model 'cancellation_reason'
- Save to db in DAO

Fixes #66 

### Type of Change:

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
- N/A

### Checklist:

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 