### PR TITLE
feat: Add /home API for user stats

### DIFF
--- a/app/api/models/user.py
+++ b/app/api/models/user.py
@@ -1,4 +1,5 @@
 from flask_restplus import fields, Model
+from app.api.models.mentorship_relation import list_tasks_response_body
 
 
 def add_models_to_namespace(api_namespace):
@@ -10,6 +11,7 @@ def add_models_to_namespace(api_namespace):
     api_namespace.models[login_request_body_model.name] = login_request_body_model
     api_namespace.models[login_response_body_model.name] = login_response_body_model
     api_namespace.models[resend_email_request_body_model.name] = resend_email_request_body_model
+    api_namespace.models[home_response_body_model.name] = home_response_body_model
 
 
 public_user_api_model = Model('User list model', {
@@ -178,4 +180,14 @@ update_user_request_body_model = Model('Update User request data model', {
 
 resend_email_request_body_model = Model('Resend email request data model', {
     'email': fields.String(required=True, description='User\'s email'),
+})
+
+home_response_body_model = Model('Get statistics on the app usage of the current user', {
+    'name': fields.String(required=True, description='The name of the user'),
+    'pending_requests': fields.Integer(required=True, description='Number of pending requests'),
+    'accepted_requests': fields.Integer(required=True, description='Number of accepted requests'),
+    'completed_relations': fields.Integer(required=True, description='Number of completed relations'),
+    'cancelled_relations': fields.Integer(required=True, description='Number of cancelled relations'),
+    'rejected_requests': fields.Integer(required=True, description='Number of rejected relations'),
+    'achievements': fields.List(fields.Nested(list_tasks_response_body))
 })

--- a/app/api/resources/user.py
+++ b/app/api/resources/user.py
@@ -255,3 +255,24 @@ class LoginUser(Resource):
             'expiry': expiry.timestamp()
         }, 200
 
+
+@users_ns.route('home')
+@users_ns.expect(auth_header_parser, validate=True)
+@users_ns.response(200, home_response_body_model)
+@users_ns.response(404, 'User not found')
+class UserHomeStatistics(Resource):
+    @classmethod
+    @jwt_required
+    @users_ns.expect(auth_header_parser)
+    def get(cls):
+        """Get Statistics regarding the current user
+
+        Returns:
+            A dict containing user stats
+        """
+        user_id = get_jwt_identity()
+        stats = DAO.get_user_statistics(user_id)
+        if not stats:
+            return {'message': 'User not found'}, 404
+
+        return stats, 200

--- a/tests/users/test_api_home_statistics.py
+++ b/tests/users/test_api_home_statistics.py
@@ -1,0 +1,249 @@
+from datetime import datetime, timedelta
+from flask import json
+
+from app.database.models.mentorship_relation import MentorshipRelationModel
+from app.database.models.tasks_list import TasksListModel
+from app.database.models.user import UserModel
+from app.database.sqlalchemy_extension import db
+from app.utils.enum_utils import MentorshipRelationState
+from tests.base_test_case import BaseTestCase
+from tests.test_utils import get_test_request_header
+
+
+class TestHomeStatisticsApi(BaseTestCase):
+
+    def setUp(self):
+        super(TestHomeStatisticsApi, self).setUp()
+
+        self.user1 = UserModel("User1", "user1", "__test__", "test@email.com", True)
+        self.user2 = UserModel("User2", "user2", "__test__", "test2@email.com", True)
+        self.user1.available_to_mentor = True
+        self.user2.need_mentoring = True
+
+        db.session.add(self.user1)
+        db.session.add(self.user2)
+        db.session.commit()
+
+    def test_relations_non_auth(self):
+        expected_response = {'message': 'The authorization token is missing!'}
+        actual_response = self.client.get('/home', follow_redirects=True)
+        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_relations_invalid_id(self):
+        auth_header = get_test_request_header(None)  # Supply invalid user ID for the test
+        actual_response = self.client.get('/home', follow_redirects=True, headers=auth_header)
+        self.assertEqual(404, actual_response.status_code)
+        self.assertEqual({'message': 'User not found'}, json.loads(actual_response.data))
+
+    def test_pending_requests_auth(self):
+        start_date = datetime.now()
+        end_date = start_date + timedelta(weeks=4)
+        start_date = start_date.timestamp()
+        end_date = end_date.timestamp()
+        tasks_list = TasksListModel()
+
+        mentorship_relation = MentorshipRelationModel(action_user_id=self.user2.id,
+                                                      mentor_user=self.user1,
+                                                      mentee_user=self.user2,
+                                                      creation_date=start_date,
+                                                      end_date=end_date,
+                                                      state=MentorshipRelationState.PENDING,
+                                                      notes="",
+                                                      tasks_list=tasks_list)
+
+        db.session.add(mentorship_relation)
+        db.session.commit()
+        expected_response = {
+            'name': 'User1',
+            'pending_requests': 1,
+            'accepted_requests': 0,
+            'rejected_requests': 0,
+            'completed_relations': 0,
+            'cancelled_relations': 0,
+            'achievements': []
+        }
+        auth_header = get_test_request_header(self.user1.id)
+        actual_response = self.client.get('/home', follow_redirects=True, headers=auth_header)
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_accepted_requests_auth(self):
+        start_date = datetime.now()
+        end_date = start_date + timedelta(weeks=4)
+        start_date = start_date.timestamp()
+        end_date = end_date.timestamp()
+        tasks_list = TasksListModel()
+
+        mentorship_relation = MentorshipRelationModel(action_user_id=self.user2.id,
+                                                      mentor_user=self.user1,
+                                                      mentee_user=self.user2,
+                                                      creation_date=start_date,
+                                                      end_date=end_date,
+                                                      state=MentorshipRelationState.ACCEPTED,
+                                                      notes="",
+                                                      tasks_list=tasks_list)
+
+        db.session.add(mentorship_relation)
+        db.session.commit()
+        expected_response = {
+            'name': 'User1',
+            'pending_requests': 0,
+            'accepted_requests': 1,
+            'rejected_requests': 0,
+            'completed_relations': 0,
+            'cancelled_relations': 0,
+            'achievements': []
+        }
+        auth_header = get_test_request_header(self.user1.id)
+        actual_response = self.client.get('/home', follow_redirects=True, headers=auth_header)
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_rejected_requests(self):
+        start_date = datetime.now()
+        end_date = start_date + timedelta(weeks=4)
+        start_date = start_date.timestamp()
+        end_date = end_date.timestamp()
+        tasks_list = TasksListModel()
+
+        mentorship_relation = MentorshipRelationModel(action_user_id=self.user2.id,
+                                                      mentor_user=self.user1,
+                                                      mentee_user=self.user2,
+                                                      creation_date=start_date,
+                                                      end_date=end_date,
+                                                      state=MentorshipRelationState.REJECTED,
+                                                      notes="",
+                                                      tasks_list=tasks_list)
+
+        db.session.add(mentorship_relation)
+        db.session.commit()
+        expected_response = {
+            'name': 'User1',
+            'pending_requests': 0,
+            'accepted_requests': 0,
+            'rejected_requests': 1,
+            'completed_relations': 0,
+            'cancelled_relations': 0,
+            'achievements': []
+        }
+        auth_header = get_test_request_header(self.user1.id)
+        actual_response = self.client.get('/home', follow_redirects=True, headers=auth_header)
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_completed_relations(self):
+        start_date = datetime.now()
+        end_date = start_date + timedelta(weeks=4)
+        start_date = start_date.timestamp()
+        end_date = end_date.timestamp()
+        tasks_list = TasksListModel()
+
+        mentorship_relation = MentorshipRelationModel(action_user_id=self.user2.id,
+                                                      mentor_user=self.user1,
+                                                      mentee_user=self.user2,
+                                                      creation_date=start_date,
+                                                      end_date=end_date,
+                                                      state=MentorshipRelationState.COMPLETED,
+                                                      notes="",
+                                                      tasks_list=tasks_list)
+
+        db.session.add(mentorship_relation)
+        db.session.commit()
+        expected_response = {
+            'name': 'User1',
+            'pending_requests': 0,
+            'accepted_requests': 0,
+            'rejected_requests': 0,
+            'completed_relations': 1,
+            'cancelled_relations': 0,
+            'achievements': []
+        }
+        auth_header = get_test_request_header(self.user1.id)
+        actual_response = self.client.get('/home', follow_redirects=True, headers=auth_header)
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_cancelled_relations(self):
+        start_date = datetime.now()
+        end_date = start_date + timedelta(weeks=4)
+        start_date = start_date.timestamp()
+        end_date = end_date.timestamp()
+        tasks_list = TasksListModel()
+        mentorship_relation = MentorshipRelationModel(action_user_id=self.user2.id,
+                                                      mentor_user=self.user1,
+                                                      mentee_user=self.user2,
+                                                      creation_date=start_date,
+                                                      end_date=end_date,
+                                                      state=MentorshipRelationState.CANCELLED,
+                                                      notes="",
+                                                      tasks_list=tasks_list)
+
+        db.session.add(mentorship_relation)
+        db.session.commit()
+        expected_response = {
+            'name': 'User1',
+            'pending_requests': 0,
+            'accepted_requests': 0,
+            'rejected_requests': 0,
+            'completed_relations': 0,
+            'cancelled_relations': 1,
+            'achievements': []
+        }
+        auth_header = get_test_request_header(self.user1.id)
+        actual_response = self.client.get('/home', follow_redirects=True, headers=auth_header)
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_achievements(self):
+        start_date = datetime.now()
+        end_date = start_date + timedelta(weeks=4)
+        start_date = start_date.timestamp()
+        end_date = end_date.timestamp()
+
+        tasks_list = TasksListModel()
+        task_created_time = datetime.now().timestamp()
+        task_completed_time = task_created_time + 100
+        tasks_list.add_task(description='Test task',
+                            created_at=task_created_time,
+                            is_done=True,
+                            completed_at=task_completed_time)
+        tasks_list.add_task(description='Incomplete task: Should not appear in achievements',
+                            created_at=task_created_time,
+                            is_done=False,
+                            completed_at=task_completed_time)
+
+        db.session.add(tasks_list)
+        db.session.commit()
+
+        mentorship_relation = MentorshipRelationModel(action_user_id=self.user2.id,
+                                                      mentor_user=self.user1,
+                                                      mentee_user=self.user2,
+                                                      creation_date=start_date,
+                                                      end_date=end_date,
+                                                      state=MentorshipRelationState.ACCEPTED,
+                                                      notes="",
+                                                      tasks_list=tasks_list)
+
+        db.session.add(mentorship_relation)
+        db.session.commit()
+
+        expected_response = {
+            'name': 'User1',
+            'pending_requests': 0,
+            'accepted_requests': 1,
+            'rejected_requests': 0,
+            'completed_relations': 0,
+            'cancelled_relations': 0,
+            'achievements': [{
+                'completed_at': task_completed_time,
+                'created_at': task_created_time,
+                'description': 'Test task',
+                'id': 1,  # This is the only task in the list
+                'is_done': True
+            }]
+        }
+        auth_header = get_test_request_header(self.user1.id)
+        actual_response = self.client.get('/home', follow_redirects=True, headers=auth_header)
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))

--- a/tests/users/test_dao.py
+++ b/tests/users/test_dao.py
@@ -1,10 +1,14 @@
+import datetime
 import unittest
 from werkzeug.security import check_password_hash
 
 from app.api.email_utils import generate_confirmation_token
 from app.api.dao.user import UserDAO
+from app.database.models.mentorship_relation import MentorshipRelationModel
+from app.database.models.tasks_list import TasksListModel
 from app.database.sqlalchemy_extension import db
 from app.database.models.user import UserModel
+from app.utils.enum_utils import MentorshipRelationState
 from tests.base_test_case import BaseTestCase
 from tests.test_data import user2
 
@@ -137,6 +141,180 @@ class TestUserDao(BaseTestCase):
         self.assertEqual(1, after_delete_user.id)
         self.assertEqual(({"message": "You cannot delete your account, since you are the only Admin left."}, 400),
                          dao_result)
+
+    def test_get_achievements(self):
+        dao = UserDAO()
+
+        mentor = UserModel("Test mentor",
+                           "test_mentor",
+                           "test_password",
+                           "mentor@email.com",
+                           True)
+
+        mentee = UserModel("Test mentee",
+                           "test_mentee",
+                           "test_password",
+                           "mentee@email.com",
+                           True)
+
+        mentor.is_email_verified = True
+        mentor.available_to_mentor = True
+        mentee.is_email_verified = True
+        mentee.need_mentoring = True
+
+        db.session.add(mentor)
+        db.session.add(mentee)
+        db.session.commit()
+
+        start_date = datetime.datetime.now()
+        end_date = start_date + datetime.timedelta(weeks=4)
+
+        tasks_list = TasksListModel()
+        tasks_list.add_task(description="Test Task",
+                            created_at=start_date.timestamp(),
+                            is_done=True,
+                            completed_at=end_date.timestamp())
+        tasks_list.add_task(description="Test Task 2",
+                            created_at=start_date.timestamp(),
+                            is_done=True,
+                            completed_at=end_date.timestamp())
+
+        relation = MentorshipRelationModel(action_user_id=mentee.id,
+                                           mentor_user=mentor,
+                                           mentee_user=mentee,
+                                           creation_date=start_date.timestamp(),
+                                           end_date=end_date.timestamp(),
+                                           state=MentorshipRelationState.ACCEPTED,
+                                           tasks_list=tasks_list,
+                                           notes="Test Notes")
+
+        db.session.add(tasks_list)
+        db.session.add(relation)
+        db.session.commit()
+
+        achievements = dao.get_achievements(mentee.id)
+
+        self.assertEqual(2, len(achievements))
+
+        for achievement in achievements:
+            self.assertTrue(achievement.get("is_done"))
+
+    def test_get_user_statistics(self):
+        dao = UserDAO()
+
+        mentor = UserModel("Test mentor",
+                           "test_mentor",
+                           "__test__",
+                           "mentor@email.com",
+                           True)
+
+        mentee = UserModel("Test mentee",
+                           "test_mentee",
+                           "__test__",
+                           "mentee@email.com",
+                           True)
+
+        mentor.is_email_verified = True
+        mentor.available_to_mentor = True
+        mentee.is_email_verified = True
+        mentee.need_mentoring = True
+
+        db.session.add(mentor)
+        db.session.add(mentee)
+        db.session.commit()
+
+        start_date = datetime.datetime.now()
+        end_date = start_date + datetime.timedelta(weeks=4)
+
+        tasks_list = TasksListModel()
+
+        pending_relation = MentorshipRelationModel(action_user_id=mentee.id,
+                                                   mentor_user=mentor,
+                                                   mentee_user=mentee,
+                                                   creation_date=start_date.timestamp(),
+                                                   end_date=end_date.timestamp(),
+                                                   state=MentorshipRelationState.PENDING,
+                                                   tasks_list=tasks_list,
+                                                   notes="Test Notes")
+
+        db.session.add(tasks_list)
+        db.session.add(pending_relation)
+        db.session.commit()
+
+        # We first test pending relations
+        expected_response = {
+            'name': mentor.name,
+            'pending_requests': 1,
+            'accepted_requests': 0,
+            'rejected_requests': 0,
+            'completed_relations': 0,
+            'cancelled_relations': 0,
+            'achievements': []
+        }
+
+        actual_response = dao.get_user_statistics(mentor.id)
+        self.assertEqual(expected_response, actual_response)
+
+        # We now test accepted relations
+        pending_relation.state = MentorshipRelationState.ACCEPTED
+        expected_response['pending_requests'] = 0
+        expected_response['accepted_requests'] = 1
+
+        actual_response = dao.get_user_statistics(mentor.id)
+        self.assertEqual(expected_response, actual_response)
+
+        # We now test completed relations
+        pending_relation.state = MentorshipRelationState.COMPLETED
+        expected_response['accepted_requests'] = 0
+        expected_response['completed_relations'] = 1
+
+        actual_response = dao.get_user_statistics(mentor.id)
+        self.assertEqual(expected_response, actual_response)
+
+        # We now test rejected relations
+        pending_relation.state = MentorshipRelationState.REJECTED
+        expected_response['completed_relations'] = 0
+        expected_response['rejected_requests'] = 1
+
+        actual_response = dao.get_user_statistics(mentor.id)
+        self.assertEqual(expected_response, actual_response)
+
+        # We now test cancelled relations
+        pending_relation.state = MentorshipRelationState.CANCELLED
+        expected_response['rejected_requests'] = 0
+        expected_response['cancelled_relations'] = 1
+
+        actual_response = dao.get_user_statistics(mentor.id)
+        self.assertEqual(expected_response, actual_response)
+
+        # We now test achievements
+        pending_relation.state = MentorshipRelationState.ACCEPTED
+        tasks_list.add_task(description="Test Task",
+                            created_at=start_date.timestamp(),
+                            is_done=True,
+                            completed_at=end_date.timestamp())
+        tasks_list.add_task(description="Test Task 2",
+                            created_at=start_date.timestamp(),
+                            is_done=True,
+                            completed_at=end_date.timestamp())
+
+        expected_response['cancelled_relations'] = 0
+        expected_response['accepted_requests'] = 1
+        expected_response['achievements'] = [{
+            'completed_at': end_date.timestamp(),
+            'created_at': start_date.timestamp(),
+            'description': 'Test Task',
+            'id': 1,  # This is the first task in the list
+            'is_done': True
+        }, {
+            'completed_at': end_date.timestamp(),
+            'created_at': start_date.timestamp(),
+            'description': 'Test Task 2',
+            'id': 2,  # This is the second task in the list
+            'is_done': True
+        }]
+        actual_response = dao.get_user_statistics(mentor.id)
+        self.assertEqual(expected_response, actual_response)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This commit adds a /home endpoint which returns statistics regarding the
current user. Fixes Issue #120. Tests have been added as well.

### Description
I have added an endpoint in the User Resource. This endpoint triggers a scan of all the relations of the user, and counts the number of these relations in all of the possible states. It then returns a dictionary containing these counted values

Fixes #120 

### Type of Change:
**Delete irrelevant options.**

- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
I have tested the API using postman, and created my own unit tests as well.


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
