### PR TITLE
Implemented refresh tokens

### DIFF
--- a/app/api/jwt_extension.py
+++ b/app/api/jwt_extension.py
@@ -10,7 +10,7 @@ jwt._set_error_handler_callbacks(api)
 @jwt.expired_token_loader
 def my_expired_token_callback():
     return {
-               'message': 'The token has expired! Please, login again.'
+               'message': 'The token has expired! Please, login again or refresh it.'
            }, 401
 
 

--- a/app/api/models/user.py
+++ b/app/api/models/user.py
@@ -10,6 +10,7 @@ def add_models_to_namespace(api_namespace):
     api_namespace.models[update_user_request_body_model.name] = update_user_request_body_model
     api_namespace.models[login_request_body_model.name] = login_request_body_model
     api_namespace.models[login_response_body_model.name] = login_response_body_model
+    api_namespace.models[refresh_response_body_model.name] = refresh_response_body_model
     api_namespace.models[resend_email_request_body_model.name] = resend_email_request_body_model
     api_namespace.models[home_response_body_model.name] = home_response_body_model
 
@@ -154,9 +155,18 @@ login_request_body_model = Model('Login request data model', {
     'password': fields.String(required=True, description='User\'s password')
 })
 
+# TODO: Remove 'expiry' after the android app refactoring.
 login_response_body_model = Model('Login response data model', {
     'access_token': fields.String(required=True, description='User\'s access token'),
-    'expiry': fields.Float(required=True, description='Access token expiry UNIX timestamp')
+    'expiry': fields.Float(required=True, description='Access token expiry UNIX timestamp'),
+    'access_expiry': fields.Float(required=True, description='Access token expiry UNIX timestamp'),
+    'refresh_token': fields.String(required=True, description='User\'s refresh token'),
+    'refresh_expiry': fields.Float(required=True, description='Refresh token expiry UNIX timestamp')
+})
+
+refresh_response_body_model = Model('Refresh response data model', {
+    'access_token': fields.String(required=True, description='User\'s access token'),
+    'access_expiry': fields.Float(required=True, description='Access token expiry UNIX timestamp')
 })
 
 update_user_request_body_model = Model('Update User request data model', {

--- a/config.py
+++ b/config.py
@@ -12,6 +12,7 @@ class BaseConfig(object):
 
     # Flask JWT settings
     JWT_ACCESS_TOKEN_EXPIRES = timedelta(weeks=1)
+    JWT_REFRESH_TOKEN_EXPIRES = timedelta(weeks=4)
 
     # Security
     SECRET_KEY = os.getenv('SECRET_KEY', None)

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -25,6 +25,7 @@ class TestTestingConfig(TestCase):
 
         # testing JWT configurations
         self.assertEqual(timedelta(weeks=1), application.config['JWT_ACCESS_TOKEN_EXPIRES'])
+        self.assertEqual(timedelta(weeks=4), application.config['JWT_REFRESH_TOKEN_EXPIRES'])
 
 
 class TestDevelopmentConfig(TestCase):
@@ -45,6 +46,7 @@ class TestDevelopmentConfig(TestCase):
 
         # testing JWT configurations
         self.assertEqual(timedelta(weeks=1), application.config['JWT_ACCESS_TOKEN_EXPIRES'])
+        self.assertEqual(timedelta(weeks=4), application.config['JWT_REFRESH_TOKEN_EXPIRES'])
 
 
 class TestProductionConfig(TestCase):
@@ -65,6 +67,7 @@ class TestProductionConfig(TestCase):
 
         # testing JWT configurations
         self.assertEqual(timedelta(weeks=1), application.config['JWT_ACCESS_TOKEN_EXPIRES'])
+        self.assertEqual(timedelta(weeks=4), application.config['JWT_REFRESH_TOKEN_EXPIRES'])
 
 
 if __name__ == '__main__':

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,16 +1,20 @@
-from flask_jwt_extended import create_access_token
+from flask_jwt_extended import create_access_token, create_refresh_token
 
 
-def get_test_request_header(user_identity, token_expiration_delta=None):
+def get_test_request_header(user_identity, token_expiration_delta=None, refresh=False):
     """
     This function returns the header needed to access auth protected
     endpoints
     :param token_expiration_delta: time for the token to expire
     :param user_identity: identifier of the user
+    :param refresh: True if refresh token
     :return: header dict with Authorization field
     """
-    access_token = create_access_token(identity=user_identity, expires_delta=token_expiration_delta)
+    if refresh:
+        token = create_refresh_token(identity=user_identity, expires_delta=token_expiration_delta)
+    else:
+        token = create_access_token(identity=user_identity, expires_delta=token_expiration_delta)
     header = {
-        'Authorization': 'Bearer {}'.format(access_token)
+        'Authorization': 'Bearer {}'.format(token)
     }
     return header

--- a/tests/users/test_api_authentication.py
+++ b/tests/users/test_api_authentication.py
@@ -58,7 +58,7 @@ class TestProtectedApi(BaseTestCase):
 
     def test_user_profile_with_token_expired_api(self):
         auth_header = get_test_request_header(self.first_user.id, token_expiration_delta=timedelta(minutes=-5))
-        expected_response = {'message': 'The token has expired! Please, login again.'}
+        expected_response = {'message': 'The token has expired! Please, login again or refresh it.'}
         actual_response = self.client.get('/user', follow_redirects=True, headers=auth_header)
 
         self.assertEqual(401, actual_response.status_code)

--- a/tests/users/test_api_login.py
+++ b/tests/users/test_api_login.py
@@ -51,7 +51,9 @@ class TestUserLoginApi(BaseTestCase):
             )), follow_redirects=True, content_type='application/json')
 
             self.assertIsNone(response.json.get('access_token'))
-            self.assertIsNone(response.json.get('expiry'))
+            self.assertIsNone(response.json.get('access_expiry'))
+            self.assertIsNone(response.json.get('refresh_token'))
+            self.assertIsNone(response.json.get('refresh_expiry'))
             self.assertEqual(1, len(response.json))
             self.assertEqual('Please verify your email before login.', response.json.get('message', None))
             self.assertEqual(403, response.status_code)
@@ -63,8 +65,10 @@ class TestUserLoginApi(BaseTestCase):
                 password=user2['password']
             )), follow_redirects=True, content_type='application/json')
             self.assertIsNotNone(response.json.get('access_token'))
-            self.assertIsNotNone(response.json.get('expiry'))
-            self.assertEqual(2, len(response.json))
+            self.assertIsNotNone(response.json.get('access_expiry'))
+            self.assertIsNotNone(response.json.get('refresh_token'))
+            self.assertIsNotNone(response.json.get('refresh_expiry'))
+            self.assertEqual(4, len(response.json))
             self.assertEqual(200, response.status_code)
 
 

--- a/tests/users/test_api_refresh.py
+++ b/tests/users/test_api_refresh.py
@@ -1,0 +1,74 @@
+import unittest
+from datetime import timedelta
+
+from flask import json
+
+from app.database.sqlalchemy_extension import db
+from app.database.models.user import UserModel
+from tests.base_test_case import BaseTestCase
+from tests.test_data import user1
+from tests.test_utils import get_test_request_header
+
+
+class TestUserRefreshApi(BaseTestCase):
+
+    # User 1 which has email verified
+    def setUp(self):
+        super(TestUserRefreshApi, self).setUp()
+
+        self.first_user = UserModel(
+            name=user1['name'],
+            email=user1['email'],
+            username=user1['username'],
+            password=user1['password'],
+            terms_and_conditions_checked=user1['terms_and_conditions_checked']
+        )
+        self.first_user.is_email_verified = True
+
+        db.session.add(self.first_user)
+        db.session.commit()
+
+    def test_user_refresh(self):
+        with self.client:
+            refresh_header = get_test_request_header(user1['username'], refresh=True)
+            response = self.client.post('/refresh', headers=refresh_header, follow_redirects=True,
+                                        content_type='application/json')
+
+            self.assertIsNotNone(response.json.get('access_token'))
+            self.assertIsNotNone(response.json.get('access_expiry'))
+            self.assertEqual(2, len(response.json))
+            self.assertEqual(200, response.status_code)
+
+    def test_user_refresh_without_header(self):
+        expected_response = {'message': 'The authorization token is missing!'}
+        actual_response = self.client.post('/refresh', follow_redirects=True)
+
+        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_user_refresh_invalid_token(self):
+        with self.client:
+            refresh_token = 'invalid_token'
+            auth_header = {
+                'Authorization': 'Bearer {}'.format(refresh_token)
+            }
+            expected_response = {'message': 'The token is invalid!'}
+            actual_response = self.client.post('/refresh', headers=auth_header, follow_redirects=True,
+                                               content_type='application/json')
+
+            self.assertEqual(401, actual_response.status_code)
+            self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_user_refresh_expired_token(self):
+        auth_header = get_test_request_header(self.first_user.id, token_expiration_delta=timedelta(minutes=-5),
+                                              refresh=True)
+        expected_response = {'message': 'The token has expired! Please, login again or refresh it.'}
+        actual_response = self.client.post('/refresh', follow_redirects=True, headers=auth_header,
+                                           content_type='application/json')
+
+        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description
Access tokens expire and require the user to login again in order to receive a new one. With the use of refresh tokens, the user can request from the auth server new access tokens without having to logout and login again. Moreover, the life of a refresh token is much longer, but for this reason they need to be stored very securely.

Fixes #160


### Type of Change:

- Code

**Code/Quality Assurance Only**
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
I have not tested it properly yet.

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged
- [ ] Update Postman API at /docs folder

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
