### PR TITLE
Fixed missing description in /home API response Swagger docs

### DIFF
--- a/app/api/resources/user.py
+++ b/app/api/resources/user.py
@@ -261,7 +261,7 @@ class LoginUser(Resource):
 
 @users_ns.route('home')
 @users_ns.expect(auth_header_parser, validate=True)
-@users_ns.response(200, home_response_body_model)
+@users_ns.response(200, 'Successful response', home_response_body_model)
 @users_ns.response(404, 'User not found')
 class UserHomeStatistics(Resource):
     @classmethod


### PR DESCRIPTION
### Description

I fixed the bug of the Swagger not being generated. namespace.response annotation from flask-restplus was being wrongly used. There was a field missing: description.

Fixes #175 

### Type of Change:
- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I accessed on a Browser http://localhost:5000/ where Swagger UI is served.
Here's swagger ui for /Home API endpoint:

![swagger ui for /Home API endpoint](https://user-images.githubusercontent.com/11148726/50669193-b3b81f00-0fbb-11e9-8374-d97e5aff0407.png)

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
