### PR TITLE
Refactor: Replace hardcoded messages and errors with messages

### DIFF
--- a/app/api/dao/admin.py
+++ b/app/api/dao/admin.py
@@ -1,5 +1,5 @@
+from app import messages
 from app.database.models.user import UserModel
-
 
 class AdminDAO:
     """Data Access Object for Admin functionalities."""
@@ -21,21 +21,21 @@ class AdminDAO:
         new_admin_user_id = data['user_id']
 
         if assigner_user_id is new_admin_user_id:
-            return {"message": "You cannot assign yourself as an Admin."}, 403
+            return messages.USER_CANNOT_BE_ASSIGNED_ADMIN_BY_USER, 403
 
         new_admin_user = UserModel.find_by_id(new_admin_user_id)
 
         if new_admin_user:
 
             if new_admin_user.is_admin:
-                return {"message": "User is already an Admin."}, 400
+                return messages.USER_IS_ALREADY_AN_ADMIN, 400
 
             new_admin_user.is_admin = True
             new_admin_user.save_to_db()
 
-            return {"message": "User is now an Admin."}, 200
+            return messages.USER_IS_NOW_AN_ADMIN, 200
 
-        return {"message": "User does not exist."}, 404
+        return messages.USER_DOES_NOT_EXIST, 404
 
     @staticmethod
     def revoke_admin_user(revoker_user_id, data):
@@ -53,18 +53,18 @@ class AdminDAO:
         admin_user_id = data['user_id']
 
         if revoker_user_id is admin_user_id:
-            return {"message": "You cannot revoke your admin status."}, 403
+            return messages.USER_CANNOT_REVOKE_ADMIN_STATUS, 403
 
         new_admin_user = UserModel.find_by_id(admin_user_id)
 
         if new_admin_user:
 
             if not new_admin_user.is_admin:
-                return {"message": "User is not an Admin."}, 400
+                return messages.USER_IS_NOT_AN_ADMIN, 400
 
             new_admin_user.is_admin = False
             new_admin_user.save_to_db()
 
-            return {"message": "User admin status was revoked."}, 200
+            return messages.USER_ADMIN_STATUS_WAS_REVOKED, 200
 
-        return {"message": "User does not exist."}, 404
+        return messages.USER_DOES_NOT_EXIST, 404

--- a/app/api/dao/mentorship_relation.py
+++ b/app/api/dao/mentorship_relation.py
@@ -1,10 +1,10 @@
 from datetime import datetime, timedelta
 
+from app import messages
 from app.database.models.mentorship_relation import MentorshipRelationModel
 from app.database.models.tasks_list import TasksListModel
 from app.database.models.user import UserModel
 from app.utils.enum_utils import MentorshipRelationState
-
 
 class MentorshipRelationDAO:
 
@@ -21,44 +21,44 @@ class MentorshipRelationDAO:
         # user_id has to match either mentee_id or mentor_id
         is_valid_user_ids = action_user_id == mentor_id or action_user_id == mentee_id
         if not is_valid_user_ids:
-            return {'message': 'Your ID has to match either Mentor or Mentee IDs.'}, 400
+            return messages.MATCH_EITHER_MENTOR_OR_MENTEE, 400
 
         # mentor_id has to be different from mentee_id
         if mentor_id == mentee_id:
-            return {'message': 'You cannot have a mentorship relation with yourself.'}, 400
+            return messages.MENTOR_ID_SAME_AS_MENTEE_ID, 400
 
         end_date_datetime = datetime.fromtimestamp(end_date_timestamp)
 
         now_datetime = datetime.now()
         if end_date_datetime < now_datetime:
-            return {'message': 'End date is invalid since date has passed.'}, 400
+            return messages.END_TIME_BEFORE_PRESENT, 400
 
         # business logic constraints
 
         max_relation_duration = end_date_datetime - now_datetime
         if max_relation_duration > self.MAXIMUM_MENTORSHIP_DURATION:
-            return {'message': 'Mentorship relation maximum duration is 6 months.'}, 400
+            return messages.MENTOR_TIME_GREATER_THAN_MAX_TIME, 400
 
         if max_relation_duration < self.MINIMUM_MENTORSHIP_DURATION:
-            return {'message': 'Mentorship relation minimum duration is 4 week.'}, 400
+            return messages.MENTOR_TIME_LESS_THAN_MIN_TIME, 400
 
         # validate if mentor user exists
         mentor_user = UserModel.find_by_id(mentor_id)
         if mentor_user is None:
-            return {'message': 'Mentor user does not exist.'}, 404
+            return messages.MENTOR_DOES_NOT_EXIST, 404
 
         # validate if mentor is available to mentor
         if not mentor_user.available_to_mentor:
-            return {'message': 'Mentor user is not available to mentor.'}, 400
+            return messages.MENTOR_NOT_AVAILABLE_TO_MENTOR, 400
 
         # validate if mentee user exists
         mentee_user = UserModel.find_by_id(mentee_id)
         if mentee_user is None:
-            return {'message': 'Mentee user does not exist.'}, 404
+            return messages.MENTEE_DOES_NOT_EXIST, 404
 
         # validate if mentee is wants to be mentored
         if not mentee_user.need_mentoring:
-            return {'message': 'Mentee user is not available to be mentored.'}, 400
+            return messages.MENTEE_NOT_AVAIL_TO_BE_MENTORED, 400
 
 
         # TODO add tests for this portion
@@ -66,12 +66,12 @@ class MentorshipRelationDAO:
         all_mentor_relations = mentor_user.mentor_relations + mentor_user.mentee_relations
         for relation in all_mentor_relations:
             if relation.state is MentorshipRelationState.ACCEPTED:
-                return {'message': 'Mentor user is already in a relationship.'}, 400
+                return messages.MENTOR_IN_RELATION, 400
 
         all_mentee_relations = mentee_user.mentor_relations + mentee_user.mentee_relations
         for relation in all_mentee_relations:
             if relation.state is MentorshipRelationState.ACCEPTED:
-                return {'message': 'Mentee user is already in a relationship.'}, 400
+                return messages.MENTEE_ALREADY_IN_A_RELATION, 400
 
         # All validations were checked
 
@@ -89,25 +89,25 @@ class MentorshipRelationDAO:
 
         mentorship_relation.save_to_db()
 
-        return {'message': 'Mentorship relation was sent successfully.'}, 200
+        return messages.MENTORSHIP_RELATION_WAS_SENT_SUCCESSFULLY, 200
 
     @staticmethod
     def list_mentorship_relations(user_id=None, accepted=None, pending=None, completed=None, cancelled=None, rejected=None):
         if pending is not None:
-            return {'message': 'Not implemented.'}, 200
+            return messages.NOT_IMPLEMENTED, 200
         if completed is not None:
-            return {'message': 'Not implemented.'}, 200
+            return messages.NOT_IMPLEMENTED, 200
         if cancelled is not None:
-            return {'message': 'Not implemented.'}, 200
+            return messages.NOT_IMPLEMENTED, 200
         if accepted is not None:
-            return {'message': 'Not implemented.'}, 200
+            return messages.NOT_IMPLEMENTED, 200
         if rejected is not None:
-            return {'message': 'Not implemented.'}, 200
+            return messages.NOT_IMPLEMENTED, 200
 
         user = UserModel.find_by_id(user_id)
 
         if user is None:
-            return {'message': 'User does not exist.'}, 404
+            return messages.USER_DOES_NOT_EXIST, 404
 
         all_relations = user.mentor_relations + user.mentee_relations
 
@@ -124,38 +124,38 @@ class MentorshipRelationDAO:
 
         # verify if user exists
         if user is None:
-            return {'message': 'User does not exist.'}, 404
+            return messages.USER_DOES_NOT_EXIST, 404
 
         request = MentorshipRelationModel.find_by_id(request_id)
 
         # verify if request exists
         if request is None:
-            return {'message': 'This mentorship relation request does not exist.'}, 404
+            return messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, 404
 
         # verify if request is in pending state
         if request.state is not MentorshipRelationState.PENDING:
-            return {'message': 'This mentorship relation is not in the pending state.'}, 400
+            return messages.NOT_PENDING_STATE_RELATION, 400
 
         # verify if I'm the receiver of the request
         if request.action_user_id is user_id:
-            return {'message': 'You cannot accept a mentorship request sent by yourself.'}, 400
+            return messages.CANT_ACCEPT_MENTOR_REQ_SENT_BY_USER, 400
 
         # verify if I'm involved in this relation
         if not (request.mentee_id is user_id or request.mentor_id is user_id):
-            return {'message': 'You cannot accept a mentorship relation where you are not involved.'}, 400
+            return messages.CANT_ACCEPT_UNINVOLVED_MENTOR_RELATION, 400
 
         requests = user.mentee_relations + user.mentor_relations
 
         # verify if I'm on a current relation
         for request in requests:
             if request.state is MentorshipRelationState.ACCEPTED:
-                return {'message': 'You are currently involved in a mentorship relation.'}, 400
+                return messages.USER_IS_INVOLVED_IN_A_MENTORSHIP_RELATION, 400
 
         # All was checked
         request.state = MentorshipRelationState.ACCEPTED
         request.save_to_db()
 
-        return {'message': 'Mentorship relation was accepted successfully.'}, 200
+        return messages.MENTORSHIP_RELATION_WAS_ACCEPTED_SUCCESSFULLY, 200
 
     @staticmethod
     def reject_request(user_id, request_id):
@@ -164,31 +164,31 @@ class MentorshipRelationDAO:
 
         # verify if user exists
         if user is None:
-            return {'message': 'User does not exist.'}, 404
+            return messages.USER_DOES_NOT_EXIST, 404
 
         request = MentorshipRelationModel.find_by_id(request_id)
 
         # verify if request exists
         if request is None:
-            return {'message': 'This mentorship relation request does not exist.'}, 404
+            return messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, 404
 
         # verify if request is in pending state
         if request.state is not MentorshipRelationState.PENDING:
-            return {'message': 'This mentorship relation is not in the pending state.'}, 400
+            return messages.NOT_PENDING_STATE_RELATION, 400
 
         # verify if I'm the receiver of the request
         if request.action_user_id is user_id:
-            return {'message': 'You cannot reject a mentorship request sent by yourself.'}, 400
+            return messages.USER_CANT_REJECT_REQUEST_SENT_BY_USER, 400
 
         # verify if I'm involved in this relation
         if not (request.mentee_id is user_id or request.mentor_id is user_id):
-            return {'message': 'You cannot reject a mentorship relation where you are not involved.'}, 400
+            return messages.CANT_REJECT_UNINVOLVED_RELATION_REQUEST, 400
 
         # All was checked
         request.state = MentorshipRelationState.REJECTED
         request.save_to_db()
 
-        return {'message': 'Mentorship relation was rejected successfully.'}, 200
+        return messages.MENTORSHIP_RELATION_WAS_REJECTED_SUCCESSFULLY, 200
 
     @staticmethod
     def cancel_relation(user_id, relation_id):
@@ -197,27 +197,27 @@ class MentorshipRelationDAO:
 
         # verify if user exists
         if user is None:
-            return {'message': 'User does not exist.'}, 404
+            return messages.USER_DOES_NOT_EXIST, 404
 
         request = MentorshipRelationModel.find_by_id(relation_id)
 
         # verify if request exists
         if request is None:
-            return {'message': 'This mentorship relation request does not exist.'}, 404
+            return messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, 404
 
         # verify if request is in pending state
         if request.state is not MentorshipRelationState.ACCEPTED:
-            return {'message': 'This mentorship relation is not in the accepted state.'}, 400
+            return messages.UNACCEPTED_STATE_RELATION, 400
 
         # verify if I'm involved in this relation
         if not (request.mentee_id is user_id or request.mentor_id is user_id):
-            return {'message': 'You cannot cancel a mentorship relation where you are not involved.'}, 400
+            return messages.CANT_CANCEL_UNINVOLVED_REQUEST, 400
 
         # All was checked
         request.state = MentorshipRelationState.CANCELLED
         request.save_to_db()
 
-        return {'message': 'Mentorship relation was cancelled successfully.'}, 200
+        return messages.MENTORSHIP_RELATION_WAS_CANCELLED_SUCCESSFULLY, 200
 
     @staticmethod
     def delete_request(user_id, request_id):
@@ -226,26 +226,26 @@ class MentorshipRelationDAO:
 
         # verify if user exists
         if user is None:
-            return {'message': 'User does not exist.'}, 404
+            return messages.USER_DOES_NOT_EXIST, 404
 
         request = MentorshipRelationModel.find_by_id(request_id)
 
         # verify if request exists
         if request is None:
-            return {'message': 'This mentorship relation request does not exist.'}, 404
+            return messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, 404
 
         # verify if request is in pending state
         if request.state is not MentorshipRelationState.PENDING:
-            return {'message': 'This mentorship relation is not in the pending state.'}, 400
+            return messages.NOT_PENDING_STATE_RELATION, 400
 
         # verify if user created the mentorship request
         if request.action_user_id is not user_id:
-            return {'message': 'You cannot delete a mentorship request that you did not create.'}, 400
+            return messages.CANT_DELETE_UNINVOLVED_REQUEST, 400
 
         # All was checked
         request.delete_from_db()
 
-        return {'message': 'Mentorship relation was deleted successfully.'}, 200
+        return messages.MENTORSHIP_RELATION_WAS_DELETED_SUCCESSFULLY, 200
 
     @staticmethod
     def list_past_mentorship_relations(user_id):
@@ -254,7 +254,7 @@ class MentorshipRelationDAO:
 
         # verify if user exists
         if user is None:
-            return {'message': 'User does not exist.'}, 404
+            return messages.USER_DOES_NOT_EXIST, 404
 
         now_timestamp = datetime.now().timestamp()
         past_relations = []
@@ -274,7 +274,7 @@ class MentorshipRelationDAO:
 
         # verify if user exists
         if user is None:
-            return {'message': 'User does not exist.'}, 404
+            return messages.USER_DOES_NOT_EXIST, 404
 
         all_relations = user.mentor_relations + user.mentee_relations
 
@@ -283,7 +283,7 @@ class MentorshipRelationDAO:
                 setattr(relation, 'sent_by_me', relation.action_user_id == user_id)
                 return relation
 
-        return {'message': 'You are not in a current mentorship relation.'}, 200
+        return messages.NOT_IN_MENTORED_RELATION_CURRENTLY, 200
 
     @staticmethod
     def list_pending_mentorship_relations(user_id):
@@ -292,7 +292,7 @@ class MentorshipRelationDAO:
 
         # verify if user exists
         if user is None:
-            return {'message': 'User does not exist.'}, 404
+            return messages.USER_DOES_NOT_EXIST, 404
 
         now_timestamp = datetime.now().timestamp()
         pending_requests = []

--- a/app/api/dao/task.py
+++ b/app/api/dao/task.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from app import messages
 from app.database.models.mentorship_relation import MentorshipRelationModel
 from app.database.models.user import UserModel
 from app.utils.enum_utils import MentorshipRelationState
@@ -29,20 +30,20 @@ class TaskDAO:
 
         user = UserModel.find_by_id(user_id)
         if user is None:
-            return {'message': 'User does not exist.'}, 404
+            return messages.USER_DOES_NOT_EXIST, 404
 
         relation = MentorshipRelationModel.find_by_id(_id=mentorship_relation_id)
         if relation is None:
-            return {'message': 'Mentorship relation does not exist.'}, 404
+            return messages.MENTORSHIP_RELATION_DOES_NOT_EXIST, 404
 
         if relation.state is not MentorshipRelationState.ACCEPTED:
-            return {'message': 'Mentorship relation is not in the accepted state.'}, 400
+            return messages.MENTORSHIP_RELATION_NOT_IN_ACCEPT_STATE, 400
 
         now_timestamp = datetime.now().timestamp()
         relation.tasks_list.add_task(description=description, created_at=now_timestamp)
         relation.tasks_list.save_to_db()
 
-        return {"message": "Task was created successfully."}, 200
+        return messages.TASK_WAS_CREATED_SUCCESSFULLY, 200
 
     @staticmethod
     def list_tasks(user_id, mentorship_relation_id):
@@ -62,14 +63,14 @@ class TaskDAO:
 
         user = UserModel.find_by_id(user_id)
         if user is None:
-            return {'message': 'User does not exist.'}, 404
+            return messages.USER_DOES_NOT_EXIST, 404
 
         relation = MentorshipRelationModel.find_by_id(mentorship_relation_id)
         if relation is None:
-            return {'message': 'Mentorship relation does not exist.'}, 404
+            return messages.MENTORSHIP_RELATION_DOES_NOT_EXIST, 404
 
         if not (user_id is relation.mentee_id or user_id is relation.mentor_id):
-            return {'message': 'You are not involved in this mentorship relation.'}, 401
+            return messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION, 401
 
         all_tasks = relation.tasks_list.tasks
 
@@ -94,22 +95,22 @@ class TaskDAO:
 
         user = UserModel.find_by_id(user_id)
         if user is None:
-            return {'message': 'User does not exist.'}, 404
+            return messages.USER_DOES_NOT_EXIST, 404
 
         relation = MentorshipRelationModel.find_by_id(mentorship_relation_id)
         if relation is None:
-            return {'message': 'Mentorship relation does not exist.'}, 404
+            return messages.MENTORSHIP_RELATION_DOES_NOT_EXIST, 404
 
         task = relation.tasks_list.find_task_by_id(task_id)
         if task is None:
-            return {'message': 'Task does not exist.'}, 404
+            return messages.TASK_DOES_NOT_EXIST, 404
 
         if not (user_id is relation.mentee_id or user_id is relation.mentor_id):
-            return {'message': 'You are not involved in this mentorship relation.'}, 401
+            return messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION, 401
 
         relation.tasks_list.delete_task(task_id)
 
-        return {'message': 'Task was deleted successfully.'}, 200
+        return messages.TASK_WAS_DELETED_SUCCESSFULLY, 200
 
     @staticmethod
     def complete_task(user_id, mentorship_relation_id, task_id):
@@ -130,23 +131,23 @@ class TaskDAO:
 
         user = UserModel.find_by_id(user_id)
         if user is None:
-            return {'message': 'User does not exist.'}, 404
+            return messages.USER_DOES_NOT_EXIST, 404
 
         relation = MentorshipRelationModel.find_by_id(mentorship_relation_id)
         if relation is None:
-            return {'message': 'Mentorship relation does not exist.'}, 404
+            return messages.MENTORSHIP_RELATION_DOES_NOT_EXIST, 404
 
         if not (user_id is relation.mentee_id or user_id is relation.mentor_id):
-            return {'message': 'You are not involved in this mentorship relation.'}, 401
+            return messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION, 401
 
         task = relation.tasks_list.find_task_by_id(task_id)
         if task is None:
-            return {'message': 'Task does not exist.'}, 404
+            return messages.TASK_DOES_NOT_EXIST, 404
 
         if task.get('is_done'):
-            return {'message': 'Task was already achieved.'}, 400
+            return messages.TASK_WAS_ALREADY_ACHIEVED, 400
         else:
             relation.tasks_list.update_task(
                 task_id=task_id, is_done=True, completed_at=datetime.now().timestamp())
 
-        return {'message': 'Task was achieved successfully.'}, 200
+        return messages.TASK_WAS_ACHIEVED_SUCCESSFULLY, 200

--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -1,11 +1,11 @@
 from datetime import datetime
 from operator import itemgetter
 
+from app import messages
 from app.api.email_utils import confirm_token
 from app.database.models.user import UserModel
 from app.utils.enum_utils import MentorshipRelationState
 from app.utils.validation_utils import is_email_valid
-
 
 class UserDAO:
     FAIL_USER_ALREADY_EXISTS = "FAIL_USER_ALREADY_EXISTS"
@@ -22,11 +22,11 @@ class UserDAO:
 
         existing_user = UserModel.find_by_username(data['username'])
         if existing_user:
-            return {"message": "A user with that username already exists"}, 400
+            return messages.USER_USES_A_USERNAME_THAT_ALREADY_EXISTS, 400
         else:
             existing_user = UserModel.find_by_email(data['email'])
             if existing_user:
-                return {"message": "A user with that email already exists"}, 400
+                return messages.USER_USES_AN_EMAIL_ID_THAT_ALREADY_EXISTS, 400
 
         user = UserModel(name, username, password, email, terms_and_conditions_checked)
         if 'need_mentoring' in data:
@@ -37,9 +37,7 @@ class UserDAO:
 
         user.save_to_db()
 
-        return {"message": "User was created successfully. "
-                           "A confirmation email has been sent via email. "
-                           "After confirming your email you can login."}, 200
+        return messages.USER_WAS_CREATED_SUCCESSFULLY, 200
 
     @staticmethod
     def delete_user(user_id):
@@ -50,13 +48,13 @@ class UserDAO:
 
             admins_list_count = len(UserModel.get_all_admins())
             if admins_list_count <= UserDAO.MIN_NUMBER_OF_ADMINS:
-                return {"message": "You cannot delete your account, since you are the only Admin left."}, 400
+                return messages.USER_CANT_DELETE, 400
 
         if user:
             user.delete_from_db()
-            return {"message": "User was deleted successfully"}, 200
+            return messages.USER_SUCCESSFULLY_DELETED, 200
 
-        return {"message": "User does not exist"}, 404
+        return messages.USER_DOES_NOT_EXIST, 404
 
     @staticmethod
     def get_user(user_id):
@@ -88,7 +86,7 @@ class UserDAO:
 
         user = UserModel.find_by_id(user_id)
         if not user:
-            return {"message": "User does not exist"}, 404
+            return messages.USER_DOES_NOT_EXIST, 404
 
         username = data.get('username', None)
         if username:
@@ -96,7 +94,7 @@ class UserDAO:
 
             # username should be unique
             if user_with_same_username:
-                return {"message": "That username is already taken by another user."}, 400
+                return messages.USER_USES_A_USERNAME_THAT_ALREADY_EXISTS, 400
 
             user.username = username
 
@@ -141,7 +139,7 @@ class UserDAO:
 
         user.save_to_db()
 
-        return {"message": "User was updated successfully"}, 200
+        return messages.USER_SUCCESSFULLY_UPDATED, 200
 
     @staticmethod
     def change_password(user_id, data):
@@ -152,9 +150,9 @@ class UserDAO:
         if user.check_password(current_password):
             user.set_password(new_password)
             user.save_to_db()
-            return {"message": "Password was updated successfully."}, 201
+            return messages.PASSWORD_SUCCESSFULLY_UPDATED, 201
 
-        return {"message": "Current password is incorrect."}, 400
+        return messages.USER_ENTERED_INCORRECT_PASSWORD, 400
 
     @staticmethod
     def confirm_registration(token):
@@ -162,16 +160,16 @@ class UserDAO:
         email_from_token = confirm_token(token)
 
         if email_from_token is False or email_from_token is None:
-            return {'message': 'The confirmation link is invalid or the token has expired.'}, 400
+            return messages.EMAIL_EXPIRED_OR_TOKEN_IS_INVALID, 400
 
         user = UserModel.find_by_email(email_from_token)
         if user.is_email_verified:
-            return {'message': 'Account already confirmed.'}, 200
+            return messages.ACCOUNT_ALREADY_CONFIRMED, 200
         else:
             user.is_email_verified = True
             user.email_verification_date = datetime.now()
             user.save_to_db()
-            return {'message': 'You have confirmed your account. Thanks!'}, 200
+            return messages.ACCOUNT_ALREADY_CONFIRMED_AND_THANKS, 200
 
     @staticmethod
     def authenticate(username_or_email, password):

--- a/app/api/jwt_extension.py
+++ b/app/api/jwt_extension.py
@@ -1,4 +1,5 @@
 from flask_jwt_extended import JWTManager
+from app import messages
 from app.api.api_extension import api
 
 jwt = JWTManager()
@@ -9,20 +10,14 @@ jwt._set_error_handler_callbacks(api)
 
 @jwt.expired_token_loader
 def my_expired_token_callback():
-    return {
-               'message': 'The token has expired! Please, login again or refresh it.'
-           }, 401
+    return messages.TOKEN_HAS_EXPIRED, 401
 
 
 @jwt.invalid_token_loader
 def my_invalid_token_callback(error_message):
-    return {
-               'message': 'The token is invalid!'
-           }, 401
+    return messages.TOKEN_IS_INVALID, 401
 
 
 @jwt.unauthorized_loader
 def my_unauthorized_request_callback(error_message):
-    return {
-               'message': 'The authorization token is missing!'
-           }, 401
+    return messages.AUTHORISATION_TOKEN_IS_MISSING, 401

--- a/app/api/resources/admin.py
+++ b/app/api/resources/admin.py
@@ -2,6 +2,7 @@ from flask import request
 from flask_restplus import Resource, Namespace
 from flask_jwt_extended import jwt_required, get_jwt_identity
 
+from app import messages
 from app.api.dao.user import UserDAO
 from app.api.models.admin import *
 from app.api.dao.admin import AdminDAO
@@ -28,9 +29,7 @@ class AssignNewUserAdmin(Resource):
             return AdminDAO.assign_new_user(user.id, data)
 
         else:
-            return {
-                       "message": "You don't have admin status. You can't assign other user as admin."
-                   }, 403
+            return messages.USER_ASSIGN_NOT_ADMIN, 403
 
 
 @admin_ns.route('admin/remove')
@@ -50,6 +49,4 @@ class RevokeUserAdmin(Resource):
             return AdminDAO.revoke_admin_user(user.id, data)
 
         else:
-            return {
-                       "message": "You don't have admin status. You can't revoke other admin user."
-                   }, 403
+            return messages.USER_REVOKE_NOT_ADMIN, 403

--- a/app/api/resources/mentorship_relation.py
+++ b/app/api/resources/mentorship_relation.py
@@ -2,6 +2,7 @@ from flask import request
 from flask_restplus import Resource, Namespace, marshal
 from flask_jwt_extended import jwt_required, get_jwt_identity
 
+from app import messages
 from app.api.dao.task import TaskDAO
 from app.api.resources.common import auth_header_parser
 from app.api.dao.mentorship_relation import MentorshipRelationDAO
@@ -48,13 +49,13 @@ class SendRequest(Resource):
 
         # Verify if request body has required fields
         if 'mentor_id' not in data:
-            return {"message": "Mentor ID field is missing."}
+            return messages.MENTOR_ID_FIELD_IS_MISSING
         if 'mentee_id' not in data:
-            return {"message": "Mentee ID field is missing."}
+            return messages.MENTEE_ID_FIELD_IS_MISSING
         if 'end_date' not in data:
-            return {"message": "End date field is missing."}
+            return messages.END_DATE_FIELD_IS_MISSING
         if 'notes' not in data:
-            return {"message": "Notes field is missing."}
+            return messages.NOTES_FIELD_IS_MISSING
 
         return {}
 
@@ -261,7 +262,7 @@ class CreateTask(Resource):
     def is_valid_data(data):
 
         if 'description' not in data:
-            return {"message": "Description field is missing."}
+            return messages.DESCRIPTION_FIELD_IS_MISSING
 
         return {}
 

--- a/app/api/validations/user.py
+++ b/app/api/validations/user.py
@@ -1,3 +1,4 @@
+from app import messages
 from app.utils.validation_utils import is_name_valid, is_email_valid, is_username_valid, validate_length, get_stripped_string
 
 # Field character limit
@@ -22,15 +23,15 @@ SOCIALS_MAX_LENGTH = 400
 def validate_user_registration_request_data(data):
     # Verify if request body has required fields
     if 'name' not in data:
-        return {"message": "Name field is missing."}
+        return messages.NAME_FIELD_IS_MISSING
     if 'username' not in data:
-        return {"message": "Username field is missing."}
+        return messages.USERNAME_FIELD_IS_MISSING
     if 'password' not in data:
-        return {"message": "Password field is missing."}
+        return messages.PASSWORD_FIELD_IS_MISSING
     if 'email' not in data:
-        return {"message": "Email field is missing."}
+        return messages.EMAIL_FIELD_IS_MISSING
     if 'terms_and_conditions_checked' not in data:
-        return {"message": "Terms and conditions field is missing."}
+        return messages.TERMS_AND_CONDITIONS_FIELD_IS_MISSING
 
     name = data['name']
     username = data['username']
@@ -39,7 +40,7 @@ def validate_user_registration_request_data(data):
     terms_and_conditions_checked = data['terms_and_conditions_checked']
 
     if not (isinstance(name, str) and isinstance(username, str) and isinstance(password, str)):
-        return {"message": "Name, username and password must be in string format."}
+        return messages.NAME_USERNAME_AND_PASSWORD_NOT_IN_STRING_FORMAT
 
     is_valid = validate_length(len(get_stripped_string(name)), NAME_MIN_LENGTH, NAME_MAX_LENGTH, 'name')
     if not is_valid[0]:
@@ -55,16 +56,16 @@ def validate_user_registration_request_data(data):
 
     # Verify business logic of request body
     if terms_and_conditions_checked is False:
-        return {"message": "Terms and conditions are not checked."}
+        return messages.TERMS_AND_CONDITIONS_ARE_NOT_CHECKED
 
     if not is_name_valid(name):
-        return {"message": "Your name is invalid."}
+        return messages.NAME_INPUT_BY_USER_IS_INVALID
 
     if not is_email_valid(email):
-        return {"message": "Your email is invalid."}
+        return messages.EMAIL_INPUT_BY_USER_IS_INVALID
 
     if not is_username_valid(username):
-        return {"message": "Your username is invalid."}
+        return messages.USERNAME_INPUT_BY_USER_IS_INVALID
 
     return {}
 
@@ -72,11 +73,11 @@ def validate_user_registration_request_data(data):
 def validate_resend_email_request_data(data):
     # Verify if request body has required fields
     if 'email' not in data:
-        return {"message": "Email field is missing."}
+        return messages.EMAIL_FIELD_IS_MISSING
 
     email = data['email']
     if not is_email_valid(email):
-        return {"message": "Your email is invalid."}
+        return messages.EMAIL_INPUT_BY_USER_IS_INVALID
 
     return {}
 
@@ -85,7 +86,7 @@ def validate_update_profile_request_data(data):
     # todo this does not check if non expected fields are being sent
 
     if not data:
-        return {"message": "No data for updating profile was sent."}
+        return messages.NO_DATA_FOR_UPDATING_PROFILE_WAS_SENT
 
     username = data.get('username', None)
     if username:
@@ -95,7 +96,7 @@ def validate_update_profile_request_data(data):
             return is_valid[1]
 
         if not is_username_valid(username):
-            return {"message": "Your new username is invalid."}
+            return messages.NEW_USERNAME_INPUT_BY_USER_IS_INVALID
 
     name = data.get('name', None)
     if name:
@@ -104,7 +105,7 @@ def validate_update_profile_request_data(data):
             return is_valid[1]
 
         if not is_name_valid(name):
-            return {"message": "Your name is invalid."}
+            return messages.NAME_INPUT_BY_USER_IS_INVALID
 
     bio = data.get('bio', None)
     if bio:
@@ -157,24 +158,24 @@ def validate_update_profile_request_data(data):
             return is_valid[1]
 
     if 'need_mentoring' in data and data['need_mentoring'] is None:
-        return {"message": "Field need_mentoring is not valid."}
+        return messages.FIELD_NEED_MENTORING_IS_NOT_VALID
 
     if 'available_to_mentor' in data and data['available_to_mentor'] is None:
-        return {"message": "Field available_to_mentor is not valid."}
+        return messages.FIELD_AVAILABLE_TO_MENTOR_IS_INVALID
 
     return {}
 
 
 def validate_new_password(data):
     if 'current_password' not in data:
-        return {"message": "Current password field is missing."}
+        return messages.CURRENT_PASSWORD_FIELD_IS_MISSING
     if 'new_password' not in data:
-        return {"message": "New password field is missing."}
+        return messages.NEW_PASSWORD_FIELD_IS_MISSING
 
     new_password = data['new_password']
 
     if " " in new_password:
-        return {"message": "Password shouldn't contain spaces."}
+        return messages.USER_INPUTS_SPACE_IN_PASSWORD
 
     is_valid = validate_length(len(get_stripped_string(new_password)), PASSWORD_MIN_LENGTH, PASSWORD_MAX_LENGTH,
                                'new_password')

--- a/app/messages.py
+++ b/app/messages.py
@@ -1,0 +1,215 @@
+# Invalid fields
+NAME_INPUT_BY_USER_IS_INVALID = {"message": "Your name is invalid."}
+EMAIL_INPUT_BY_USER_IS_INVALID = {"message": "Your email is invalid."}
+USERNAME_INPUT_BY_USER_IS_INVALID = {"message": "Your username is invalid"}
+NEW_USERNAME_INPUT_BY_USER_IS_INVALID = {"message": "Your new username is"
+                                         " invalid."}
+TOKEN_IS_INVALID = {"message": "The token is invalid!"}
+USER_ID_IS_NOT_VALID = {"message": "User id is not valid."}
+FIELD_NEED_MENTORING_IS_NOT_VALID = {"message": "Field need_mentoring is"
+                                     " not valid."}
+FIELD_AVAILABLE_TO_MENTOR_IS_INVALID = {"message": "Field available_to_mentor"
+                                        " is not valid."}
+
+# Not found
+MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST = {"message": "This mentorship"
+                                              " relation request does not"
+                                              " exist."}
+MENTORSHIP_RELATION_DOES_NOT_EXIST = {"message": "Mentorship relation does not"
+                                      " exist."}
+USER_NOT_FOUND = {"message": "User not found."}
+MENTOR_DOES_NOT_EXIST = {"message": "Mentor user does not exist."}
+MENTEE_DOES_NOT_EXIST = {"message": "Mentee user does not exist."}
+TASK_DOES_NOT_EXIST = {"message": "Task does not exist."}
+USER_DOES_NOT_EXIST = {"message": "User does not exist"}
+
+# Missing fields
+MENTOR_ID_FIELD_IS_MISSING = {"message": "Mentor ID field is missing."}
+MENTEE_ID_FIELD_IS_MISSING = {"message": "Mentee ID field is missing."}
+END_DATE_FIELD_IS_MISSING = {"message": "End date field is missing."}
+NOTES_FIELD_IS_MISSING = {"message": "Notes field is missing."}
+USERNAME_FIELD_IS_MISSING = {"message": "The field username is missing."}
+PASSWORD_FIELD_IS_MISSING = {"message": "Password field is missing."}
+NAME_FIELD_IS_MISSING = {"message": "Name field is missing."}
+EMAIL_FIELD_IS_MISSING = {"message": "Email field is missing."}
+TERMS_AND_CONDITIONS_FIELD_IS_MISSING = {"message": "Terms and conditions"
+                                         " field is missing."}
+CURRENT_PASSWORD_FIELD_IS_MISSING = {"message": "Current password field is"
+                                     " missing."}
+NEW_PASSWORD_FIELD_IS_MISSING = {"message": "New password field is missing."}
+AUTHORISATION_TOKEN_IS_MISSING = {"message": "The authorization token is"
+                                  " missing!."}
+DESCRIPTION_FIELD_IS_MISSING = {"message": "Description field is missing"}
+
+# Admin
+USER_IS_ALREADY_AN_ADMIN = {"message": "User is already an Admin."}
+USER_CANNOT_BE_ASSIGNED_ADMIN_BY_USER = {"message": "You cannot assign"
+                                         " yourself as an Admin."}
+USER_IS_NOT_AN_ADMIN = {"message": "User is not an Admin."}
+USER_ADMIN_STATUS_WAS_REVOKED = {"message": "User admin status was revoked."}
+USER_CANT_DELETE = {"message": "You cannot delete your account, since you are"
+                    " the only Admin left."}
+USER_CANNOT_REVOKE_ADMIN_STATUS = {"message": "You cannot revoke your admin"
+                                   "status."}
+USER_ASSIGN_NOT_ADMIN = {"message": "You don't have admin status. You can't"
+                         " assign other user as admin."}
+USER_REVOKE_NOT_ADMIN = {"message": "You don't have admin status. You can't"
+                         " revoke other admin user."}
+USER_IS_NOW_AN_ADMIN = {"message": "User is now an Admin."}
+
+# Mentor availability
+MENTOR_NOT_AVAILABLE_TO_MENTOR = {"message": "Mentor user is not available to"
+                                  " mentor."}
+MENTOR_IN_RELATION = {"message": "Mentor user is already in a relationship."}
+
+# Mentee availability
+MENTEE_NOT_AVAIL_TO_BE_MENTORED = {"message": "Mentee user is not available"
+                                  " to be mentored."}
+MENTEE_ALREADY_IN_A_RELATION = {"message": "Mentee user is already in a"
+                                " relationship."}
+
+# Mismatch of fields
+MATCH_EITHER_MENTOR_OR_MENTEE = {"message": "Your ID has to match either"
+                                 " Mentor or Mentee IDs."}
+
+# Update
+NO_DATA_FOR_UPDATING_PROFILE_WAS_SENT = {"message": "No data for updating"
+                                         "profile was sent"}
+
+# Relation constraints
+MENTOR_ID_SAME_AS_MENTEE_ID = {"message": "You cannot have a mentorship"
+                               " relation with yourself."}
+END_TIME_BEFORE_PRESENT = {"message": "End date is invalid since date has"
+                           " passed."}
+MENTOR_TIME_GREATER_THAN_MAX_TIME = {"message": "Mentorship relation maximum"
+                                     " duration is 6 months."}
+MENTOR_TIME_LESS_THAN_MIN_TIME = {"message": "Mentorship relation minimum"
+                                  " duration is 4 week."}
+CANT_ACCEPT_MENTOR_REQ_SENT_BY_USER = {"message": "You cannot accept a"
+                                       " mentorship request sent by yourself."}
+CANT_ACCEPT_UNINVOLVED_MENTOR_RELATION = {"message": "You cannot accept a"
+                                          " mentorship relation where you are"
+                                          " not involved."}
+USER_CANT_REJECT_REQUEST_SENT_BY_USER = {"message": "You cannot reject a"
+                                       " mentorship request sent by yourself."}
+CANT_REJECT_UNINVOLVED_RELATION_REQUEST = {"message": "You cannot reject a"
+                                           " mentorship relation where you are"
+                                           " not involved."}
+CANT_CANCEL_UNINVOLVED_REQUEST = {"message": "You cannot cancel a mentorship"
+                                  " relation where you are not involved."}
+CANT_DELETE_UNINVOLVED_REQUEST = {"message": "You cannot delete a mentorship"
+                                  " request that you did not create."}
+NOT_IN_MENTORED_RELATION_CURRENTLY = {"message": "You are not in a current"
+                                      " mentorship relation."}
+USER_IS_INVOLVED_IN_A_MENTORSHIP_RELATION = {"message": "You are currently"
+                                             " involved in a"
+                                             " mentorship relation."}
+USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION = {"message": "You are not involved"
+                                             " in this mentorship relation."}
+USER_USES_A_USERNAME_THAT_ALREADY_EXISTS = {"message": "A user with that"
+                                            " username already exists."}
+USER_USES_AN_EMAIL_ID_THAT_ALREADY_EXISTS = {"message": "A user with that "
+                                             "email already exists."}
+USER_IS_NOT_REGISTERED_IN_THE_SYSTEM = {"message": "You are not registered in"
+                                        "the system."}
+NAME_LENGTH_GREATER_THAN_MAX_LIMIT = {"message": "The {field_name} field has"
+                                      " to be shorter than {max_limit}"
+                                      " characters."}
+NAME_LENGTH_LESSER_THAN_MAX_LIMIT = {"message": "The {field_name} field has to"
+                                     " be longer than {min_limit} characters"
+                                     " and shorter than {max_limit}"
+                                     " characters."}
+USER_INPUTS_INCORRECT_CONFIGURATION_VALUE = {"message": "The environment"
+                                             " config value has to be within"
+                                             " these values: prod,"
+                                             "dev, test."}
+
+# Mentorship state
+NOT_PENDING_STATE_RELATION = {"message": "This mentorship relation is not in"
+                              " the pending state."}
+UNACCEPTED_STATE_RELATION = {"message": "This mentorship relation status is"
+                             " not in the accepted state."}
+MENTORSHIP_RELATION_NOT_IN_ACCEPT_STATE = {"message": "Mentorship relation is"
+                                           " not in the accepted state."}
+
+
+# Login errors
+USER_ENTERED_INCORRECT_PASSWORD = {"message": "Current password is incorrect."}
+EMAIL_EXPIRED_OR_TOKEN_IS_INVALID = {"message": "The confirmation link is"
+                                     " invalid or the token has expired."}
+WRONG_USERNAME_OR_PASSWORD = {"message": "Username or password is wrong."}
+USER_HAS_NOT_VERIFIED_EMAIL_BEFORE_LOGIN = {"message": "Please verify your"
+                                            " email before login."}
+NAME_USERNAME_AND_PASSWORD_NOT_IN_STRING_FORMAT = {"message": "Name, username"
+                                                   " and password must be in"
+                                                   " string format."}
+TERMS_AND_CONDITIONS_ARE_NOT_CHECKED = {"message": "Terms and conditions are"
+                                        " not checked."}
+USER_INPUTS_SPACE_IN_PASSWORD = {"message": "Password shouldn't contain"
+                                 " spaces."}
+TOKEN_HAS_EXPIRED = {"message": "The token has expired! Please, login again or refresh it."}
+TOKEN_SENT_TO_EMAIL_OF_USER = {"message": "Token sent to the user's email."}
+EMAIL_VERIFICATION_MESSAGE = {"message": "Check your email, a new verification"
+                              " email was sent."}
+
+# Success messages
+TASK_WAS_ALREADY_ACHIEVED = {"message": "Task was already achieved."}
+MENTORSHIP_RELATION_WAS_SENT_SUCCESSFULLY = {"message": "Mentorship relation"
+                                             " was sent successfully."}
+MENTORSHIP_RELATION_WAS_ACCEPTED_SUCCESSFULLY = {"message": "Mentorship"
+                                                 " relation was accepted"
+                                                 " successfully."}
+MENTORSHIP_RELATION_WAS_DELETED_SUCCESSFULLY = {"message": "Mentorship"
+                                                " relation was deleted"
+                                                " successfully."}
+MENTORSHIP_RELATION_WAS_REJECTED_SUCCESSFULLY = {"message": "Mentorship"
+                                                 " relation was"
+                                                 " rejected successfully."}
+MENTORSHIP_RELATION_WAS_CANCELLED_SUCCESSFULLY = {"message": "Mentorship"
+                                                  " relation was "
+                                                  "cancelled successfully"}
+TASK_WAS_CREATED_SUCCESSFULLY = {"message": "Task was created successfully."}
+TASK_WAS_DELETED_SUCCESSFULLY = {"message": "Task was deleted successfully."}
+TASK_WAS_ACHIEVED_SUCCESSFULLY = {"message": "Task was achieved"
+                                          " successfully."}
+USER_WAS_CREATED_SUCCESSFULLY = {"message": "User was created successfully."
+                                 "A confirmation email has been sent via"
+                                 " email.After confirming your email you "
+                                 "can login."}
+ACCEPT_MENTORSHIP_RELATIONS_WITH_SUCCESS = {"message": "Accept mentorship"
+                                            " relations with success."}
+REJECTED_MENTORSHIP_RELATIONS_WITH_SUCCESS = {"message": "Rejected mentorship"
+                                              " relations with success."}
+CANCELLED_MENTORSHIP_RELATIONS_WITH_SUCCESS = {"message": "Cancelled"
+                                               " mentorship"
+                                               " relations with success."}
+DELETED_MENTORSHIP_RELATIONS_WITH_SUCCESS = {"message": "Deleted mentorship"
+                                             " relations with success."}
+RETURNED_PAST_MENTORSHIP_RELATIONS_WITH_SUCCESS = {"message": "Returned "
+                                                   "past mentorship "
+                                                   "relations with success."}
+RETURNED_CURRENT_MENTORSHIP_RELATIONS_WITH_SUCCESS = {"message": "Returned"
+                                                      " current mentorship"
+                                                      " relation"
+                                                      " with success."}
+RETURNED_PENDING_MENTORSHIP_RELATIONS_WITH_SUCCESS = {"message": "Returned"
+                                                      " pending mentorship"
+                                                      " relations"
+                                                      " with success."}
+DELETE_TASK_WITH_SUCCESS = {"message": "Delete task with success."}
+UPDATED_TASK_WITH_SUCCESS = {"message": "Updated task with success."}
+USER_SUCCESSFULLY_CREATED = {"message": "User successfully created."}
+USER_SUCCESSFULLY_DELETED = {"message": "User was deleted successfully"}
+USER_SUCCESSFULLY_UPDATED = {"message": "User was updated successfully."}
+PASSWORD_SUCCESSFULLY_UPDATED = {"message": "Password was updated "
+                                 "successfully"}
+
+# confimation
+ACCOUNT_ALREADY_CONFIRMED = {"message": "Account already confirmed"}
+USER_ALREADY_CONFIRMED_ACCOUNT = {"message": "You already confirm your email"}
+ACCOUNT_ALREADY_CONFIRMED_AND_THANKS = {"message": "You have confirmed your"
+                                        " account.Thanks!"}
+
+# Miscellaneous
+VALIDATION_ERROR = {"message": "Validation error."}
+NOT_IMPLEMENTED = {"message": "Not implemented."}

--- a/tests/admin/test_dao.py
+++ b/tests/admin/test_dao.py
@@ -2,6 +2,8 @@ import unittest
 
 from tests.base_test_case import BaseTestCase
 from tests.test_data import user1
+
+from app import messages
 from app.database.models.user import UserModel
 from app.api.dao.admin import AdminDAO
 from app.database.sqlalchemy_extension import db
@@ -55,7 +57,7 @@ class TestAdminDao(BaseTestCase):
 
         dao_result = dao.assign_new_user(2, data)
 
-        self.assertEqual(({"message": "You cannot assign yourself as an Admin."}, 403), dao_result)
+        self.assertEqual((messages.USER_CANNOT_BE_ASSIGNED_ADMIN_BY_USER, 403), dao_result)
 
     def test_dao_revoke_admin_role_to_valid_user(self):
         dao = AdminDAO()
@@ -92,7 +94,7 @@ class TestAdminDao(BaseTestCase):
 
         dao_result = dao.revoke_admin_user(1, data)
 
-        self.assertEqual(({"message": "User does not exist."}, 404), dao_result)
+        self.assertEqual((messages.USER_DOES_NOT_EXIST, 404), dao_result)
 
     def test_dao_revoke_admin_role_to_non_admin_user(self):
         dao = AdminDAO()
@@ -115,7 +117,7 @@ class TestAdminDao(BaseTestCase):
 
         dao_result = dao.revoke_admin_user(1, data)
 
-        self.assertEqual(({"message": "User is not an Admin."}, 400), dao_result)
+        self.assertEqual((messages.USER_IS_NOT_AN_ADMIN, 400), dao_result)
 
     def test_dao_revoke_admin_role_to_myself(self):
         dao = AdminDAO()
@@ -126,7 +128,7 @@ class TestAdminDao(BaseTestCase):
 
         dao_result = dao.revoke_admin_user(1, data)
 
-        self.assertEqual(({"message": "You cannot revoke your admin status."}, 403), dao_result)
+        self.assertEqual((messages.USER_CANNOT_REVOKE_ADMIN_STATUS, 403), dao_result)
 
 
 if __name__ == '__main__':

--- a/tests/mentorship_relation/test_api_accept_request.py
+++ b/tests/mentorship_relation/test_api_accept_request.py
@@ -2,13 +2,13 @@ import json
 import unittest
 from datetime import datetime, timedelta
 
+from app import messages
 from app.database.models.tasks_list import TasksListModel
 from app.database.sqlalchemy_extension import db
 from app.database.models.mentorship_relation import MentorshipRelationModel
 from app.utils.enum_utils import MentorshipRelationState
 from tests.mentorship_relation.relation_base_setup import MentorshipRelationBaseTestCase
 from tests.test_utils import get_test_request_header
-
 
 class TestAcceptMentorshipRequestApi(MentorshipRelationBaseTestCase):
 
@@ -44,7 +44,7 @@ class TestAcceptMentorshipRequestApi(MentorshipRelationBaseTestCase):
 
             self.assertEqual(200, response.status_code)
             self.assertEqual(MentorshipRelationState.ACCEPTED, self.mentorship_relation.state)
-            self.assertEqual({'message': 'Mentorship relation was accepted successfully.'},
+            self.assertDictEqual(messages.MENTORSHIP_RELATION_WAS_ACCEPTED_SUCCESSFULLY,
                              json.loads(response.data))
 
 

--- a/tests/mentorship_relation/test_api_cancel_relation.py
+++ b/tests/mentorship_relation/test_api_cancel_relation.py
@@ -2,6 +2,7 @@ import json
 import unittest
 from datetime import datetime, timedelta
 
+from app import messages
 from app.database.models.tasks_list import TasksListModel
 from app.database.sqlalchemy_extension import db
 from app.database.models.mentorship_relation import MentorshipRelationModel
@@ -47,7 +48,7 @@ class TestCancelMentorshipRelationApi(MentorshipRelationBaseTestCase):
 
             self.assertEqual(200, response.status_code)
             self.assertEqual(MentorshipRelationState.CANCELLED, self.mentorship_relation.state)
-            self.assertEqual({'message': 'Mentorship relation was cancelled successfully.'},
+            self.assertDictEqual(messages.MENTORSHIP_RELATION_WAS_CANCELLED_SUCCESSFULLY,
                              json.loads(response.data))
 
     def test__mentee_cancel_mentorship_relation(self):
@@ -58,7 +59,7 @@ class TestCancelMentorshipRelationApi(MentorshipRelationBaseTestCase):
 
             self.assertEqual(200, response.status_code)
             self.assertEqual(MentorshipRelationState.CANCELLED, self.mentorship_relation.state)
-            self.assertEqual({'message': 'Mentorship relation was cancelled successfully.'},
+            self.assertDictEqual(messages.MENTORSHIP_RELATION_WAS_CANCELLED_SUCCESSFULLY,
                              json.loads(response.data))
 
 

--- a/tests/mentorship_relation/test_api_delete_request.py
+++ b/tests/mentorship_relation/test_api_delete_request.py
@@ -2,6 +2,7 @@ import json
 import unittest
 from datetime import datetime, timedelta
 
+from app import messages
 from app.database.models.tasks_list import TasksListModel
 from app.database.sqlalchemy_extension import db
 from app.database.models.mentorship_relation import MentorshipRelationModel
@@ -49,7 +50,7 @@ class TestDeleteMentorshipRequestApi(MentorshipRelationBaseTestCase):
                                           headers=get_test_request_header(self.first_user.id))
 
         self.assertEqual(200, response.status_code)
-        self.assertEqual({'message': 'Mentorship relation was deleted successfully.'},
+        self.assertDictEqual(messages.MENTORSHIP_RELATION_WAS_DELETED_SUCCESSFULLY,
                          json.loads(response.data))
         self.assertIsNone(MentorshipRelationModel.query.filter_by(id=request_id).first())
 
@@ -64,7 +65,7 @@ class TestDeleteMentorshipRequestApi(MentorshipRelationBaseTestCase):
                                           headers=get_test_request_header(self.second_user.id))
 
         self.assertEqual(400, response.status_code)
-        self.assertEqual({'message': 'You cannot delete a mentorship request that you did not create.'},
+        self.assertDictEqual(messages.CANT_DELETE_UNINVOLVED_REQUEST,
                          json.loads(response.data))
         self.assertIsNotNone(MentorshipRelationModel.query.filter_by(id=request_id).first())
 

--- a/tests/mentorship_relation/test_api_reject_request.py
+++ b/tests/mentorship_relation/test_api_reject_request.py
@@ -2,6 +2,7 @@ import json
 import unittest
 from datetime import datetime, timedelta
 
+from app import messages
 from app.database.models.tasks_list import TasksListModel
 from app.database.sqlalchemy_extension import db
 from app.database.models.mentorship_relation import MentorshipRelationModel
@@ -46,7 +47,7 @@ class TestRejectMentorshipRequestApi(MentorshipRelationBaseTestCase):
 
             self.assertEqual(200, response.status_code)
             self.assertEqual(MentorshipRelationState.REJECTED, self.mentorship_relation.state)
-            self.assertEqual({'message': 'Mentorship relation was rejected successfully.'},
+            self.assertEqual(messages.MENTORSHIP_RELATION_WAS_REJECTED_SUCCESSFULLY,
                              json.loads(response.data))
 
 

--- a/tests/mentorship_relation/test_dao_accept_request.py
+++ b/tests/mentorship_relation/test_dao_accept_request.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 
+from app import messages
 from app.api.dao.mentorship_relation import MentorshipRelationDAO
 from app.database.models.mentorship_relation import MentorshipRelationModel
 from app.database.models.tasks_list import TasksListModel
@@ -44,7 +45,7 @@ class TestMentorshipRelationAcceptRequestDAO(MentorshipRelationBaseTestCase):
 
         result = DAO.accept_request(self.first_user.id, 123)
 
-        self.assertEqual(({'message': 'This mentorship relation request does not exist.'}, 404), result)
+        self.assertEqual((messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, 404), result)
         self.assertEqual(MentorshipRelationState.PENDING, self.mentorship_relation.state)
 
     def test_dao_requester_tries_to_accept_mentorship_request(self):
@@ -52,7 +53,7 @@ class TestMentorshipRelationAcceptRequestDAO(MentorshipRelationBaseTestCase):
 
         result = DAO.accept_request(self.first_user.id, self.mentorship_relation.id)
 
-        self.assertEqual(({'message': 'You cannot accept a mentorship request sent by yourself.'}, 400), result)
+        self.assertEqual((messages.CANT_ACCEPT_MENTOR_REQ_SENT_BY_USER, 400), result)
         self.assertEqual(MentorshipRelationState.PENDING, self.mentorship_relation.state)
 
     def test_dao_receiver_accepts_mentorship_request(self):
@@ -60,7 +61,7 @@ class TestMentorshipRelationAcceptRequestDAO(MentorshipRelationBaseTestCase):
 
         result = DAO.accept_request(self.second_user.id, self.mentorship_relation.id)
 
-        self.assertEqual(({'message': 'Mentorship relation was accepted successfully.'}, 200), result)
+        self.assertEqual((messages.MENTORSHIP_RELATION_WAS_ACCEPTED_SUCCESSFULLY, 200), result)
         self.assertEqual(MentorshipRelationState.ACCEPTED, self.mentorship_relation.state)
 
     def test_dao_sender_does_not_exist_mentorship_request(self):
@@ -68,7 +69,7 @@ class TestMentorshipRelationAcceptRequestDAO(MentorshipRelationBaseTestCase):
 
         result = DAO.accept_request(123, self.mentorship_relation.id)
 
-        self.assertEqual(({'message': 'User does not exist.'}, 404), result)
+        self.assertEqual((messages.USER_DOES_NOT_EXIST, 404), result)
         self.assertEqual(MentorshipRelationState.PENDING, self.mentorship_relation.state)
 
     def test_dao_mentorship_request_is_not_in_pending_state(self):
@@ -79,25 +80,25 @@ class TestMentorshipRelationAcceptRequestDAO(MentorshipRelationBaseTestCase):
         db.session.commit()
 
         result = DAO.accept_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual(({'message': 'This mentorship relation is not in the pending state.'}, 400), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 400), result)
 
         self.mentorship_relation.state = MentorshipRelationState.COMPLETED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.accept_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual(({'message': 'This mentorship relation is not in the pending state.'}, 400), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 400), result)
 
         self.mentorship_relation.state = MentorshipRelationState.CANCELLED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.accept_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual(({'message': 'This mentorship relation is not in the pending state.'}, 400), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 400), result)
 
         self.mentorship_relation.state = MentorshipRelationState.REJECTED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.accept_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual(({'message': 'This mentorship relation is not in the pending state.'}, 400), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 400), result)

--- a/tests/mentorship_relation/test_dao_cancel_relation.py
+++ b/tests/mentorship_relation/test_dao_cancel_relation.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 
+from app import messages
 from app.api.dao.mentorship_relation import MentorshipRelationDAO
 from app.database.models.tasks_list import TasksListModel
 from app.utils.enum_utils import MentorshipRelationState
@@ -43,7 +44,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
 
         result = DAO.cancel_relation(self.first_user.id, 123)
 
-        self.assertEqual(({'message': 'This mentorship relation request does not exist.'}, 404), result)
+        self.assertEqual((messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, 404), result)
         self.assertEqual(MentorshipRelationState.PENDING, self.mentorship_relation.state)
 
     def test_dao_sender_does_not_exist_mentorship_request(self):
@@ -51,7 +52,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
 
         result = DAO.cancel_relation(123, self.mentorship_relation.id)
 
-        self.assertEqual(({'message': 'User does not exist.'}, 404), result)
+        self.assertEqual((messages.USER_DOES_NOT_EXIST, 404), result)
         self.assertEqual(MentorshipRelationState.PENDING, self.mentorship_relation.state)
 
     def test_dao_receiver_cancel_mentorship_request(self):
@@ -62,7 +63,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         DAO = MentorshipRelationDAO()
         result = DAO.cancel_relation(self.second_user.id, self.mentorship_relation.id)
 
-        self.assertEqual(({'message': 'Mentorship relation was cancelled successfully.'}, 200), result)
+        self.assertEqual((messages.MENTORSHIP_RELATION_WAS_CANCELLED_SUCCESSFULLY, 200), result)
         self.assertEqual(MentorshipRelationState.CANCELLED, self.mentorship_relation.state)
 
     def test_dao_sender_cancel_mentorship_request(self):
@@ -73,7 +74,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         DAO = MentorshipRelationDAO()
         result = DAO.cancel_relation(self.first_user.id, self.mentorship_relation.id)
 
-        self.assertEqual(({'message': 'Mentorship relation was cancelled successfully.'}, 200), result)
+        self.assertEqual((messages.MENTORSHIP_RELATION_WAS_CANCELLED_SUCCESSFULLY, 200), result)
         self.assertEqual(MentorshipRelationState.CANCELLED, self.mentorship_relation.state)
 
     def test_dao_mentorship_cancel_relation_not_in_accepted_state(self):
@@ -84,25 +85,25 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         db.session.commit()
 
         result = DAO.cancel_relation(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual(({'message': 'This mentorship relation is not in the accepted state.'}, 400), result)
+        self.assertEqual((messages.UNACCEPTED_STATE_RELATION, 400), result)
 
         self.mentorship_relation.state = MentorshipRelationState.COMPLETED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.cancel_relation(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual(({'message': 'This mentorship relation is not in the accepted state.'}, 400), result)
+        self.assertEqual((messages.UNACCEPTED_STATE_RELATION, 400), result)
 
         self.mentorship_relation.state = MentorshipRelationState.CANCELLED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.cancel_relation(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual(({'message': 'This mentorship relation is not in the accepted state.'}, 400), result)
+        self.assertEqual((messages.UNACCEPTED_STATE_RELATION, 400), result)
 
         self.mentorship_relation.state = MentorshipRelationState.REJECTED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.cancel_relation(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual(({'message': 'This mentorship relation is not in the accepted state.'}, 400), result)
+        self.assertEqual((messages.UNACCEPTED_STATE_RELATION, 400), result)

--- a/tests/mentorship_relation/test_dao_creation.py
+++ b/tests/mentorship_relation/test_dao_creation.py
@@ -1,6 +1,7 @@
 import unittest
 from datetime import datetime, timedelta
 
+from app import messages
 from app.api.dao.mentorship_relation import MentorshipRelationDAO
 from app.database.models.mentorship_relation import MentorshipRelationModel
 from app.database.models.tasks_list import TasksListModel
@@ -34,7 +35,7 @@ class TestMentorshipRelationCreationDAO(MentorshipRelationBaseTestCase):
 
         result = dao.create_mentorship_relation(self.first_user.id, data)
 
-        self.assertEqual({'message': 'Mentorship relation was sent successfully.'}, result[0])
+        self.assertEqual(messages.MENTORSHIP_RELATION_WAS_SENT_SUCCESSFULLY, result[0])
 
         query_mentorship_relation = MentorshipRelationModel.query.first()
 
@@ -78,7 +79,7 @@ class TestMentorshipRelationCreationDAO(MentorshipRelationBaseTestCase):
 
         result = dao.create_mentorship_relation(self.second_user.id, data)
 
-        self.assertEqual({'message': 'Mentorship relation was sent successfully.'}, result[0])
+        self.assertEqual(messages.MENTORSHIP_RELATION_WAS_SENT_SUCCESSFULLY, result[0])
 
         query_mentorship_relation = MentorshipRelationModel.query.first()
 
@@ -123,7 +124,7 @@ class TestMentorshipRelationCreationDAO(MentorshipRelationBaseTestCase):
 
         result = dao.create_mentorship_relation(1234, data)
 
-        self.assertEqual({'message': 'Mentor user does not exist.'}, result[0])
+        self.assertDictEqual(messages.MENTOR_DOES_NOT_EXIST, result[0])
 
         query_mentorship_relation = MentorshipRelationModel.query.first()
 
@@ -143,7 +144,7 @@ class TestMentorshipRelationCreationDAO(MentorshipRelationBaseTestCase):
 
         result = dao.create_mentorship_relation(self.first_user.id, data)
 
-        self.assertEqual({'message': 'Mentee user does not exist.'}, result[0])
+        self.assertDictEqual(messages.MENTEE_DOES_NOT_EXIST, result[0])
 
         query_mentorship_relation = MentorshipRelationModel.query.first()
 
@@ -177,7 +178,7 @@ class TestMentorshipRelationCreationDAO(MentorshipRelationBaseTestCase):
 
         result = dao.create_mentorship_relation(self.first_user.id, data)
 
-        self.assertEqual(({'message': 'Mentee user is already in a relationship.'}, 400), result)
+        self.assertEqual((messages.MENTEE_ALREADY_IN_A_RELATION, 400), result)
 
         query_mentorship_relations = MentorshipRelationModel.query.all()
 
@@ -212,7 +213,7 @@ class TestMentorshipRelationCreationDAO(MentorshipRelationBaseTestCase):
 
         result = dao.create_mentorship_relation(self.second_user.id, data)
 
-        self.assertEqual(({'message': 'Mentor user is already in a relationship.'}, 400), result)
+        self.assertEqual((messages.MENTOR_IN_RELATION, 400), result)
 
         query_mentorship_relations = MentorshipRelationModel.query.all()
 

--- a/tests/mentorship_relation/test_dao_delete_request.py
+++ b/tests/mentorship_relation/test_dao_delete_request.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 
+from app import messages
 from app.api.dao.mentorship_relation import MentorshipRelationDAO
 from app.database.models.tasks_list import TasksListModel
 from app.utils.enum_utils import MentorshipRelationState
@@ -68,21 +69,21 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
 
         result = MentorshipRelationDAO.delete_request(self.first_user.id, 123)
 
-        self.assertEqual(({'message': 'This mentorship relation request does not exist.'}, 404), result)
+        self.assertEqual((messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, 404), result)
         self.assertIsNotNone(MentorshipRelationModel.query.filter_by(id=self.mentorship_relation.id).first())
 
     def test_dao_sender_does_not_exist(self):
 
         result = MentorshipRelationDAO.delete_request(123, self.mentorship_relation.id)
 
-        self.assertEqual(({'message': 'User does not exist.'}, 404), result)
+        self.assertEqual((messages.USER_DOES_NOT_EXIST, 404), result)
         self.assertIsNotNone(MentorshipRelationModel.query.filter_by(id=self.mentorship_relation.id).first())
 
     def test_dao_receiver_tries_to_delete_mentorship_request(self):
 
         result = MentorshipRelationDAO.delete_request(self.second_user.id, self.mentorship_relation.id)
 
-        self.assertEqual(({'message': 'You cannot delete a mentorship request that you did not create.'}, 400), result)
+        self.assertEqual((messages.CANT_DELETE_UNINVOLVED_REQUEST, 400), result)
         self.assertIsNotNone(MentorshipRelationModel.query.filter_by(id=self.mentorship_relation.id).first())
 
     def test_dao_sender_delete_mentorship_request(self):
@@ -91,7 +92,7 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
         self.assertIsNotNone(MentorshipRelationModel.query.filter_by(id=relation_id).first())
 
         result = MentorshipRelationDAO.delete_request(self.first_user.id, relation_id)
-        self.assertEqual(({'message': 'Mentorship relation was deleted successfully.'}, 200), result)
+        self.assertEqual((messages.MENTORSHIP_RELATION_WAS_DELETED_SUCCESSFULLY, 200), result)
 
         self.assertIsNone(MentorshipRelationModel.query.filter_by(id=relation_id).first())
 
@@ -99,7 +100,7 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
 
         result = MentorshipRelationDAO.delete_request(self.admin_user.id, self.mentorship_relation.id)
 
-        self.assertEqual(({'message': 'You cannot delete a mentorship request that you did not create.'}, 400), result)
+        self.assertEqual((messages.CANT_DELETE_UNINVOLVED_REQUEST, 400), result)
         self.assertIsNotNone(MentorshipRelationModel.query.filter_by(id=self.mentorship_relation.id).first())
 
     def test_dao_mentorship_delete_request_not_in_pending_state(self):
@@ -110,7 +111,7 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
         db.session.commit()
 
         result = MentorshipRelationDAO.delete_request(self.first_user.id, self.mentorship_relation.id)
-        self.assertEqual(({'message': 'This mentorship relation is not in the pending state.'}, 400), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 400), result)
         self.assertIsNotNone(MentorshipRelationModel.query.filter_by(id=relation_id).first())
 
         self.mentorship_relation.state = MentorshipRelationState.COMPLETED
@@ -118,7 +119,7 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
         db.session.commit()
 
         result = MentorshipRelationDAO.delete_request(self.first_user.id, self.mentorship_relation.id)
-        self.assertEqual(({'message': 'This mentorship relation is not in the pending state.'}, 400), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 400), result)
         self.assertIsNotNone(MentorshipRelationModel.query.filter_by(id=relation_id).first())
 
         self.mentorship_relation.state = MentorshipRelationState.CANCELLED
@@ -126,7 +127,7 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
         db.session.commit()
 
         result = MentorshipRelationDAO.delete_request(self.first_user.id, self.mentorship_relation.id)
-        self.assertEqual(({'message': 'This mentorship relation is not in the pending state.'}, 400), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 400), result)
         self.assertIsNotNone(MentorshipRelationModel.query.filter_by(id=relation_id).first())
 
         self.mentorship_relation.state = MentorshipRelationState.REJECTED
@@ -134,5 +135,5 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
         db.session.commit()
 
         result = MentorshipRelationDAO.delete_request(self.first_user.id, self.mentorship_relation.id)
-        self.assertEqual(({'message': 'This mentorship relation is not in the pending state.'}, 400), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 400), result)
         self.assertIsNotNone(MentorshipRelationModel.query.filter_by(id=relation_id).first())

--- a/tests/mentorship_relation/test_dao_list_relations.py
+++ b/tests/mentorship_relation/test_dao_list_relations.py
@@ -1,6 +1,7 @@
 import unittest
 from datetime import datetime, timedelta
 
+from app import messages
 from app.api.dao.mentorship_relation import MentorshipRelationDAO
 from app.database.models.mentorship_relation import MentorshipRelationModel
 from app.database.models.tasks_list import TasksListModel
@@ -78,7 +79,7 @@ class TestListMentorshipRelationsDAO(MentorshipRelationBaseTestCase):
 
     def test_dao_list_non_existing_current_mentorship_relation(self):
         result = MentorshipRelationDAO.list_current_mentorship_relation(user_id=self.admin_user.id)
-        expected_response = ({'message': 'You are not in a current mentorship relation.'}, 200)
+        expected_response = (messages.NOT_IN_MENTORED_RELATION_CURRENTLY, 200)
 
         self.assertEqual(expected_response, result)
 

--- a/tests/mentorship_relation/test_dao_listing.py
+++ b/tests/mentorship_relation/test_dao_listing.py
@@ -1,6 +1,7 @@
 import unittest
 from datetime import datetime, timedelta
 
+from app import messages
 from app.api.dao.mentorship_relation import MentorshipRelationDAO
 from app.database.models.mentorship_relation import MentorshipRelationModel
 from app.database.models.tasks_list import TasksListModel
@@ -46,7 +47,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
 
         result = DAO.list_mentorship_relations(user_id=self.first_user.id, accepted=True)
 
-        self.assertEqual(({'message': 'Not implemented.'}, 200), result)
+        self.assertEqual((messages.NOT_IMPLEMENTED, 200), result)
 
     def test_dao_list_mentorship_relation_cancelled(self):
         DAO = MentorshipRelationDAO()
@@ -57,7 +58,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
 
         result = DAO.list_mentorship_relations(user_id=self.first_user.id, cancelled=True)
 
-        self.assertEqual(({'message': 'Not implemented.'}, 200), result)
+        self.assertEqual((messages.NOT_IMPLEMENTED, 200), result)
 
     def test_dao_list_mentorship_relation_rejected(self):
         DAO = MentorshipRelationDAO()
@@ -68,7 +69,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
 
         result = DAO.list_mentorship_relations(user_id=self.first_user.id, rejected=True)
 
-        self.assertEqual(({'message': 'Not implemented.'}, 200), result)
+        self.assertEqual((messages.NOT_IMPLEMENTED, 200), result)
 
     def test_dao_list_mentorship_relation_completed(self):
         DAO = MentorshipRelationDAO()
@@ -79,7 +80,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
 
         result = DAO.list_mentorship_relations(user_id=self.first_user.id, completed=True)
 
-        self.assertEqual(({'message': 'Not implemented.'}, 200), result)
+        self.assertEqual((messages.NOT_IMPLEMENTED, 200), result)
 
     def test_dao_list_mentorship_relation_pending(self):
         DAO = MentorshipRelationDAO()
@@ -90,7 +91,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
 
         result = DAO.list_mentorship_relations(user_id=self.first_user.id, pending=True)
 
-        self.assertEqual(({'message': 'Not implemented.'}, 200), result)
+        self.assertEqual((messages.NOT_IMPLEMENTED, 200), result)
 
     def test_dao_list_mentorship_relation_all(self):
         DAO = MentorshipRelationDAO()

--- a/tests/mentorship_relation/test_dao_reject_mentorship_request.py
+++ b/tests/mentorship_relation/test_dao_reject_mentorship_request.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 
+from app import messages
 from app.api.dao.mentorship_relation import MentorshipRelationDAO
 from app.database.models.mentorship_relation import MentorshipRelationModel
 from app.database.models.tasks_list import TasksListModel
@@ -43,7 +44,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
 
         result = DAO.reject_request(self.first_user.id, 123)
 
-        self.assertEqual(({'message': 'This mentorship relation request does not exist.'}, 404), result)
+        self.assertEqual((messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, 404), result)
         self.assertEqual(MentorshipRelationState.PENDING, self.mentorship_relation.state)
 
     def test_dao_sender_does_not_exist_mentorship_request(self):
@@ -51,7 +52,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
 
         result = DAO.reject_request(123, self.mentorship_relation.id)
 
-        self.assertEqual(({'message': 'User does not exist.'}, 404), result)
+        self.assertEqual((messages.USER_DOES_NOT_EXIST, 404), result)
         self.assertEqual(MentorshipRelationState.PENDING, self.mentorship_relation.state)
 
     def test_dao_requester_tries_to_reject_mentorship_request(self):
@@ -59,7 +60,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
 
         result = DAO.reject_request(self.first_user.id, self.mentorship_relation.id)
 
-        self.assertEqual(({'message': 'You cannot reject a mentorship request sent by yourself.'}, 400), result)
+        self.assertEqual((messages.USER_CANT_REJECT_REQUEST_SENT_BY_USER, 400), result)
         self.assertEqual(MentorshipRelationState.PENDING, self.mentorship_relation.state)
 
     def test_dao_receiver_rejects_mentorship_request(self):
@@ -67,7 +68,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
 
         result = DAO.reject_request(self.second_user.id, self.mentorship_relation.id)
 
-        self.assertEqual(({'message': 'Mentorship relation was rejected successfully.'}, 200), result)
+        self.assertEqual((messages.MENTORSHIP_RELATION_WAS_REJECTED_SUCCESSFULLY, 200), result)
         self.assertEqual(MentorshipRelationState.REJECTED, self.mentorship_relation.state)
 
     def test_dao_mentorship_request_is_not_in_pending_state(self):
@@ -78,25 +79,25 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         db.session.commit()
 
         result = DAO.reject_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual(({'message': 'This mentorship relation is not in the pending state.'}, 400), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 400), result)
 
         self.mentorship_relation.state = MentorshipRelationState.COMPLETED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.reject_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual(({'message': 'This mentorship relation is not in the pending state.'}, 400), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 400), result)
 
         self.mentorship_relation.state = MentorshipRelationState.CANCELLED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.reject_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual(({'message': 'This mentorship relation is not in the pending state.'}, 400), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 400), result)
 
         self.mentorship_relation.state = MentorshipRelationState.REJECTED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.reject_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual(({'message': 'This mentorship relation is not in the pending state.'}, 400), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 400), result)

--- a/tests/tasks/test_api_complete_task.py
+++ b/tests/tasks/test_api_complete_task.py
@@ -1,6 +1,7 @@
 import unittest
 from flask import json
 
+from app import messages
 from app.database.models.mentorship_relation import MentorshipRelationModel
 from tests.tasks.tasks_base_setup import TasksBaseTestCase
 from tests.test_utils import get_test_request_header
@@ -9,13 +10,13 @@ from tests.test_utils import get_test_request_header
 class TestCompleteTaskApi(TasksBaseTestCase):
 
     def test_complete_task_api_resource_non_auth(self):
-        expected_response = {'message': 'The authorization token is missing!'}
+        expected_response = messages.AUTHORISATION_TOKEN_IS_MISSING
         actual_response = self.client.put('/mentorship_relation/%s/task/%s/complete'
                                              % (self.mentorship_relation_w_second_user.id, 2),
                                              follow_redirects=True)
 
         self.assertEqual(401, actual_response.status_code)
-        self.assertEqual(expected_response, json.loads(actual_response.data))
+        self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_complete_task_api(self):
 
@@ -26,13 +27,13 @@ class TestCompleteTaskApi(TasksBaseTestCase):
         self.assertFalse(incomplete_task.get('is_done'))
 
         auth_header = get_test_request_header(self.first_user.id)
-        expected_response = {"message": "Task was achieved successfully."}
+        expected_response = messages.TASK_WAS_ACHIEVED_SUCCESSFULLY
         actual_response = self.client.put('/mentorship_relation/%s/task/%s/complete'
                                              % (self.mentorship_relation_w_second_user.id, 1),
                                              follow_redirects=True, headers=auth_header)
 
         self.assertEqual(200, actual_response.status_code)
-        self.assertEqual(expected_response, json.loads(actual_response.data))
+        self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
         relation = MentorshipRelationModel.find_by_id(self.mentorship_relation_w_second_user.id)
         complete_task = relation.tasks_list.find_task_by_id(1)

--- a/tests/tasks/test_api_create_task.py
+++ b/tests/tasks/test_api_create_task.py
@@ -1,5 +1,7 @@
 import unittest
 from flask import json
+
+from app import messages
 from tests.tasks.tasks_base_setup import TasksBaseTestCase
 from tests.test_utils import get_test_request_header
 
@@ -7,12 +9,12 @@ from tests.test_utils import get_test_request_header
 class TestCreateTaskApi(TasksBaseTestCase):
 
     def test_create_task_api_resource_non_auth(self):
-        expected_response = {'message': 'The authorization token is missing!'}
+        expected_response = messages.AUTHORISATION_TOKEN_IS_MISSING
         actual_response = self.client.post('/mentorship_relation/%s/task' % self.mentorship_relation_w_second_user.id,
                                            follow_redirects=True)
 
         self.assertEqual(401, actual_response.status_code)
-        self.assertEqual(expected_response, json.loads(actual_response.data))
+        self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_full_task_creation_api(self):
 
@@ -20,13 +22,13 @@ class TestCreateTaskApi(TasksBaseTestCase):
         self.assertIsNone(non_existent_task)
 
         auth_header = get_test_request_header(self.first_user.id)
-        expected_response = {"message": "Task was created successfully."}
+        expected_response = messages.TASK_WAS_CREATED_SUCCESSFULLY
         actual_response = self.client.post('/mentorship_relation/%s/task' % self.mentorship_relation_w_second_user.id,
                                            follow_redirects=True, headers=auth_header, content_type='application/json',
                                            data=json.dumps(dict(description=self.test_description)))
 
         self.assertEqual(200, actual_response.status_code)
-        self.assertEqual(expected_response, json.loads(actual_response.data))
+        self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
         new_task = self.tasks_list_1.find_task_by_id(3)
         self.assertIsNotNone(new_task)

--- a/tests/tasks/test_api_delete_task.py
+++ b/tests/tasks/test_api_delete_task.py
@@ -1,19 +1,20 @@
 import unittest
 from flask import json
+
+from app import messages
 from tests.tasks.tasks_base_setup import TasksBaseTestCase
 from tests.test_utils import get_test_request_header
-
 
 class TestDeleteTaskApi(TasksBaseTestCase):
 
     def test_delete_task_api_resource_non_auth(self):
-        expected_response = {'message': 'The authorization token is missing!'}
+        expected_response = messages.AUTHORISATION_TOKEN_IS_MISSING
         actual_response = self.client.delete('/mentorship_relation/%s/task/%s'
                                              % (self.mentorship_relation_w_second_user.id, 2),
                                              follow_redirects=True)
 
         self.assertEqual(401, actual_response.status_code)
-        self.assertEqual(expected_response, json.loads(actual_response.data))
+        self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_full_task_deletion_api(self):
 
@@ -21,13 +22,13 @@ class TestDeleteTaskApi(TasksBaseTestCase):
         self.assertIsNotNone(existent_task)
 
         auth_header = get_test_request_header(self.first_user.id)
-        expected_response = {"message": "Task was deleted successfully."}
+        expected_response = messages.TASK_WAS_DELETED_SUCCESSFULLY
         actual_response = self.client.delete('/mentorship_relation/%s/task/%s'
                                              % (self.mentorship_relation_w_second_user.id, 2),
                                              follow_redirects=True, headers=auth_header)
 
         self.assertEqual(200, actual_response.status_code)
-        self.assertEqual(expected_response, json.loads(actual_response.data))
+        self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
         deleted_task = self.tasks_list_1.find_task_by_id(2)
         self.assertIsNone(deleted_task)

--- a/tests/tasks/test_api_list_tasks.py
+++ b/tests/tasks/test_api_list_tasks.py
@@ -2,6 +2,7 @@ import unittest
 from flask import json
 from flask_restplus import marshal
 
+from app import messages
 from app.api.models.mentorship_relation import list_tasks_response_body
 from tests.tasks.tasks_base_setup import TasksBaseTestCase
 from tests.test_utils import get_test_request_header
@@ -10,13 +11,13 @@ from tests.test_utils import get_test_request_header
 class TestListTasksApi(TasksBaseTestCase):
 
     def test_list_tasks_api_resource_non_auth(self):
-        expected_response = {'message': 'The authorization token is missing!'}
+        expected_response = messages.AUTHORISATION_TOKEN_IS_MISSING
         actual_response = self.client.get('/mentorship_relation/%s/tasks'
                                           % self.mentorship_relation_w_second_user.id,
                                           follow_redirects=True)
 
         self.assertEqual(401, actual_response.status_code)
-        self.assertEqual(expected_response, json.loads(actual_response.data))
+        self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_tasks_api_first_mentorship_relation(self):
 
@@ -43,13 +44,13 @@ class TestListTasksApi(TasksBaseTestCase):
     def test_list_tasks_api_w_user_not_belonging_to_mentorship_relation(self):
 
         auth_header = get_test_request_header(self.second_user.id)
-        expected_response = {'message': 'You are not involved in this mentorship relation.'}
+        expected_response = messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION
         actual_response = self.client.get('/mentorship_relation/%s/tasks'
                                           % self.mentorship_relation_w_admin_user.id,
                                           follow_redirects=True, headers=auth_header)
 
         self.assertEqual(401, actual_response.status_code)
-        self.assertEqual(expected_response, json.loads(actual_response.data))
+        self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_tasks_api_mentorship_relation_without_tasks(self):
 

--- a/tests/tasks/test_dao_complete_task.py
+++ b/tests/tasks/test_dao_complete_task.py
@@ -1,15 +1,15 @@
 import unittest
 
+from app import messages
 from app.api.dao.task import TaskDAO
 from tests.tasks.tasks_base_setup import TasksBaseTestCase
-
 
 class TestCompleteTasksDao(TasksBaseTestCase):
 
     def test_achieve_not_achieved_task(self):
         self.assertFalse(self.tasks_list_1.find_task_by_id(1).get('is_done'))
 
-        expected_response = {'message': 'Task was achieved successfully.'}, 200
+        expected_response = messages.TASK_WAS_ACHIEVED_SUCCESSFULLY, 200
         actual_response = TaskDAO.complete_task(self.first_user.id,
                                                self.mentorship_relation_w_second_user.id,
                                                1)
@@ -20,7 +20,7 @@ class TestCompleteTasksDao(TasksBaseTestCase):
     def test_achieve_achieved_task(self):
         self.assertTrue(self.tasks_list_1.find_task_by_id(2).get('is_done'))
 
-        expected_response = {'message': 'Task was already achieved.'}, 400
+        expected_response = messages.TASK_WAS_ALREADY_ACHIEVED, 400
         actual_response = TaskDAO.complete_task(self.first_user.id,
                                                self.mentorship_relation_w_second_user.id,
                                                2)
@@ -30,7 +30,7 @@ class TestCompleteTasksDao(TasksBaseTestCase):
 
     def test_achieve_not_existent_task(self):
 
-        expected_response = {'message': 'Task does not exist.'}, 404
+        expected_response = messages.TASK_DOES_NOT_EXIST, 404
         actual_response = TaskDAO.complete_task(self.first_user.id,
                                                self.mentorship_relation_w_second_user.id,
                                                123123)

--- a/tests/tasks/test_dao_create_task.py
+++ b/tests/tasks/test_dao_create_task.py
@@ -1,5 +1,6 @@
 import unittest
 
+from app import messages
 from app.api.dao.task import TaskDAO
 from app.utils.enum_utils import MentorshipRelationState
 from tests.tasks.tasks_base_setup import TasksBaseTestCase
@@ -9,7 +10,7 @@ class TestListTasksDao(TasksBaseTestCase):
 
     def test_create_task(self):
 
-        expected_response = {"message": "Task was created successfully."}, 200
+        expected_response = messages.TASK_WAS_CREATED_SUCCESSFULLY, 200
 
         non_existent_task = self.tasks_list_1.find_task_by_id(3)
         self.assertIsNone(non_existent_task)
@@ -26,7 +27,7 @@ class TestListTasksDao(TasksBaseTestCase):
 
     def test_create_task_with_non_existing_mentorship_relation(self):
 
-        expected_response = {'message': 'Mentorship relation does not exist.'}, 404
+        expected_response = messages.MENTORSHIP_RELATION_DOES_NOT_EXIST, 404
 
         actual_response = TaskDAO.create_task(user_id=self.first_user.id,
                                               mentorship_relation_id=123123,
@@ -36,7 +37,7 @@ class TestListTasksDao(TasksBaseTestCase):
 
     def test_create_task_with_mentorship_relation_non_accepted_state(self):
 
-        expected_response = {'message': 'Mentorship relation is not in the accepted state.'}, 400
+        expected_response = messages.MENTORSHIP_RELATION_NOT_IN_ACCEPT_STATE, 400
         self.mentorship_relation_w_second_user.state = MentorshipRelationState.CANCELLED
 
         actual_response = TaskDAO.create_task(user_id=self.first_user.id,

--- a/tests/tasks/test_dao_delete_task.py
+++ b/tests/tasks/test_dao_delete_task.py
@@ -1,5 +1,6 @@
 import unittest
 
+from app import messages
 from app.api.dao.task import TaskDAO
 from tests.tasks.tasks_base_setup import TasksBaseTestCase
 
@@ -8,7 +9,7 @@ class TestDeleteTasksDao(TasksBaseTestCase):
 
     def test_delete_existent_task(self):
 
-        expected_response = {'message': 'Task was deleted successfully.'}, 200
+        expected_response = messages.TASK_WAS_DELETED_SUCCESSFULLY, 200
         first_task_id = 1
 
         not_deleted_yet_task = self.tasks_list_1.find_task_by_id(task_id=first_task_id)
@@ -24,7 +25,7 @@ class TestDeleteTasksDao(TasksBaseTestCase):
 
     def test_delete_non_existent_task(self):
 
-        expected_response = {'message': 'Task does not exist.'}, 404
+        expected_response = messages.TASK_DOES_NOT_EXIST, 404
         actual_response = TaskDAO.delete_task(self.first_user.id,
                                               self.mentorship_relation_w_second_user.id,
                                               123123)

--- a/tests/tasks/test_dao_list_tasks.py
+++ b/tests/tasks/test_dao_list_tasks.py
@@ -1,5 +1,6 @@
 import unittest
 
+from app import messages
 from app.api.dao.task import TaskDAO
 from tests.tasks.tasks_base_setup import TasksBaseTestCase
 
@@ -22,21 +23,21 @@ class TestListTasksDao(TasksBaseTestCase):
 
     def test_list_tasks_with_non_existent_relation(self):
 
-        expected_response = {'message': 'Mentorship relation does not exist.'}, 404
+        expected_response = messages.MENTORSHIP_RELATION_DOES_NOT_EXIST, 404
         actual_response = TaskDAO.list_tasks(self.first_user.id, 123123)
 
         self.assertEqual(expected_response, actual_response)
 
     def test_list_tasks_with_non_existent_user(self):
 
-        expected_response = {'message': 'User does not exist.'}, 404
+        expected_response = messages.USER_DOES_NOT_EXIST, 404
         actual_response = TaskDAO.list_tasks(123123, self.mentorship_relation_w_second_user.id)
 
         self.assertEqual(expected_response, actual_response)
 
     def test_list_tasks_with_user_not_involved(self):
 
-        expected_response = {'message': 'You are not involved in this mentorship relation.'}, 401
+        expected_response = messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION, 401
         actual_response = TaskDAO.list_tasks(self.admin_user.id, self.mentorship_relation_w_second_user.id)
 
         self.assertEqual(expected_response, actual_response)

--- a/tests/users/test_api_authentication.py
+++ b/tests/users/test_api_authentication.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from flask import json
 from flask_restplus import marshal
 
+from app import messages
 from app.api.models.user import full_user_api_model
 from app.database.sqlalchemy_extension import db
 from app.database.models.user import UserModel
@@ -39,30 +40,30 @@ class TestProtectedApi(BaseTestCase):
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_user_profile_without_header_api(self):
-        expected_response = {'message': 'The authorization token is missing!'}
+        expected_response = messages.AUTHORISATION_TOKEN_IS_MISSING
         actual_response = self.client.get('/user', follow_redirects=True)
 
         self.assertEqual(401, actual_response.status_code)
-        self.assertEqual(expected_response, json.loads(actual_response.data))
+        self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_user_profile_incomplete_token_api(self):
         access_token = 'invalid_token'
         auth_header = {
             'Authorization': 'Bearer {}'.format(access_token)
         }
-        expected_response = {'message': 'The token is invalid!'}
+        expected_response = messages.TOKEN_IS_INVALID
         actual_response = self.client.get('/user', follow_redirects=True, headers=auth_header)
 
         self.assertEqual(401, actual_response.status_code)
-        self.assertEqual(expected_response, json.loads(actual_response.data))
+        self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_user_profile_with_token_expired_api(self):
         auth_header = get_test_request_header(self.first_user.id, token_expiration_delta=timedelta(minutes=-5))
-        expected_response = {'message': 'The token has expired! Please, login again or refresh it.'}
+        expected_response = messages.TOKEN_HAS_EXPIRED
         actual_response = self.client.get('/user', follow_redirects=True, headers=auth_header)
 
         self.assertEqual(401, actual_response.status_code)
-        self.assertEqual(expected_response, json.loads(actual_response.data))
+        self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
 
 if __name__ == "__main__":

--- a/tests/users/test_api_home_statistics.py
+++ b/tests/users/test_api_home_statistics.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 from flask import json
 
+from app import messages
 from app.database.models.mentorship_relation import MentorshipRelationModel
 from app.database.models.tasks_list import TasksListModel
 from app.database.models.user import UserModel
@@ -25,16 +26,16 @@ class TestHomeStatisticsApi(BaseTestCase):
         db.session.commit()
 
     def test_relations_non_auth(self):
-        expected_response = {'message': 'The authorization token is missing!'}
+        expected_response = messages.AUTHORISATION_TOKEN_IS_MISSING
         actual_response = self.client.get('/home', follow_redirects=True)
         self.assertEqual(401, actual_response.status_code)
-        self.assertEqual(expected_response, json.loads(actual_response.data))
+        self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_relations_invalid_id(self):
         auth_header = get_test_request_header(None)  # Supply invalid user ID for the test
         actual_response = self.client.get('/home', follow_redirects=True, headers=auth_header)
         self.assertEqual(404, actual_response.status_code)
-        self.assertEqual({'message': 'User not found'}, json.loads(actual_response.data))
+        self.assertEqual(messages.USER_NOT_FOUND, json.loads(actual_response.data))
 
     def test_pending_requests_auth(self):
         start_date = datetime.now()

--- a/tests/users/test_api_list_users.py
+++ b/tests/users/test_api_list_users.py
@@ -1,6 +1,8 @@
 import unittest
 from flask import json
 from flask_restplus import marshal
+
+from app import messages
 from app.api.models.user import public_user_api_model
 from app.database.models.user import UserModel
 from app.database.sqlalchemy_extension import db
@@ -34,11 +36,11 @@ class TestListUsersApi(BaseTestCase):
         db.session.commit()
 
     def test_list_users_api_resource_non_auth(self):
-        expected_response = {'message': 'The authorization token is missing!'}
+        expected_response = messages.AUTHORISATION_TOKEN_IS_MISSING
         actual_response = self.client.get('/users', follow_redirects=True)
 
         self.assertEqual(401, actual_response.status_code)
-        self.assertEqual(expected_response, json.loads(actual_response.data))
+        self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_resource_auth(self):
         auth_header = get_test_request_header(self.admin_user.id)

--- a/tests/users/test_api_login.py
+++ b/tests/users/test_api_login.py
@@ -2,6 +2,7 @@ import unittest
 
 from flask import json
 
+from app import messages
 from app.database.sqlalchemy_extension import db
 from tests.base_test_case import BaseTestCase
 from app.database.models.user import UserModel
@@ -55,7 +56,7 @@ class TestUserLoginApi(BaseTestCase):
             self.assertIsNone(response.json.get('refresh_token'))
             self.assertIsNone(response.json.get('refresh_expiry'))
             self.assertEqual(1, len(response.json))
-            self.assertEqual('Please verify your email before login.', response.json.get('message', None))
+            self.assertEqual(messages.USER_HAS_NOT_VERIFIED_EMAIL_BEFORE_LOGIN, response.json)
             self.assertEqual(403, response.status_code)
 
     def test_user_login_verified_user(self):

--- a/tests/users/test_api_refresh.py
+++ b/tests/users/test_api_refresh.py
@@ -3,12 +3,12 @@ from datetime import timedelta
 
 from flask import json
 
+from app import messages
 from app.database.sqlalchemy_extension import db
 from app.database.models.user import UserModel
 from tests.base_test_case import BaseTestCase
 from tests.test_data import user1
 from tests.test_utils import get_test_request_header
-
 
 class TestUserRefreshApi(BaseTestCase):
 
@@ -40,7 +40,7 @@ class TestUserRefreshApi(BaseTestCase):
             self.assertEqual(200, response.status_code)
 
     def test_user_refresh_without_header(self):
-        expected_response = {'message': 'The authorization token is missing!'}
+        expected_response = messages.AUTHORISATION_TOKEN_IS_MISSING
         actual_response = self.client.post('/refresh', follow_redirects=True)
 
         self.assertEqual(401, actual_response.status_code)
@@ -52,7 +52,7 @@ class TestUserRefreshApi(BaseTestCase):
             auth_header = {
                 'Authorization': 'Bearer {}'.format(refresh_token)
             }
-            expected_response = {'message': 'The token is invalid!'}
+            expected_response = messages.TOKEN_IS_INVALID
             actual_response = self.client.post('/refresh', headers=auth_header, follow_redirects=True,
                                                content_type='application/json')
 
@@ -62,7 +62,7 @@ class TestUserRefreshApi(BaseTestCase):
     def test_user_refresh_expired_token(self):
         auth_header = get_test_request_header(self.first_user.id, token_expiration_delta=timedelta(minutes=-5),
                                               refresh=True)
-        expected_response = {'message': 'The token has expired! Please, login again or refresh it.'}
+        expected_response = messages.TOKEN_HAS_EXPIRED
         actual_response = self.client.post('/refresh', follow_redirects=True, headers=auth_header,
                                            content_type='application/json')
 

--- a/tests/users/test_api_update_user.py
+++ b/tests/users/test_api_update_user.py
@@ -4,6 +4,7 @@ from string import ascii_lowercase
 
 from flask import json
 
+from app import messages
 from app.api.validations.user import USERNAME_MAX_LENGTH, USERNAME_MIN_LENGTH
 from app.database.models.user import UserModel
 from app.database.sqlalchemy_extension import db
@@ -16,11 +17,11 @@ from tests.test_utils import get_test_request_header
 class TestUpdateUserApi(BaseTestCase):
 
     def test_update_user_api_resource_non_auth(self):
-        expected_response = {'message': 'The authorization token is missing!'}
+        expected_response = messages.AUTHORISATION_TOKEN_IS_MISSING
         actual_response = self.client.put('/user', follow_redirects=True)
 
         self.assertEqual(401, actual_response.status_code)
-        self.assertEqual(expected_response, json.loads(actual_response.data))
+        self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_update_username_already_taken(self):
 
@@ -37,14 +38,14 @@ class TestUpdateUserApi(BaseTestCase):
         db.session.commit()
 
         auth_header = get_test_request_header(self.first_user.id)
-        expected_response = {"message": "That username is already taken by another user."}
+        expected_response = messages.USER_USES_A_USERNAME_THAT_ALREADY_EXISTS
         actual_response = self.client.put('/user', follow_redirects=True,
                                           headers=auth_header,
                                           data=json.dumps(dict(username=self.admin_user.username)),
                                           content_type='application/json')
 
         self.assertEqual(400, actual_response.status_code)
-        self.assertEqual(expected_response, json.loads(actual_response.data))
+        self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_update_username_not_taken(self):
 
@@ -62,14 +63,14 @@ class TestUpdateUserApi(BaseTestCase):
 
         user1_new_username = "new_username"
         auth_header = get_test_request_header(self.first_user.id)
-        expected_response = {"message": "User was updated successfully"}
+        expected_response = messages.USER_SUCCESSFULLY_UPDATED
         actual_response = self.client.put('/user', follow_redirects=True,
                                           headers=auth_header,
                                           data=json.dumps(dict(username=user1_new_username)),
                                           content_type='application/json')
 
         self.assertEqual(200, actual_response.status_code)
-        self.assertEqual(expected_response, json.loads(actual_response.data))
+        self.assertDictEqual(expected_response, json.loads(actual_response.data))
         self.assertEqual(user1_new_username, self.first_user.username)
 
     def test_update_username_invalid_length(self):
@@ -117,7 +118,7 @@ class TestUpdateUserApi(BaseTestCase):
         db.session.add(self.first_user)
         db.session.commit()
 
-        expected_response = {"message": "User was updated successfully"}
+        expected_response = messages.USER_SUCCESSFULLY_UPDATED
         test_mentor_availability = True
         auth_header = get_test_request_header(self.first_user.id)
 
@@ -158,7 +159,7 @@ class TestUpdateUserApi(BaseTestCase):
         db.session.add(self.first_user)
         db.session.commit()
 
-        expected_response = {"message": "User was updated successfully"}
+        expected_response = messages.USER_SUCCESSFULLY_UPDATED
         test_need_mentoring = False
         auth_header = get_test_request_header(self.first_user.id)
 
@@ -170,7 +171,7 @@ class TestUpdateUserApi(BaseTestCase):
                                           content_type='application/json')
 
         self.assertEqual(200, actual_response.status_code)
-        self.assertEqual(expected_response, json.loads(actual_response.data))
+        self.assertDictEqual(expected_response, json.loads(actual_response.data))
         self.assertEqual(test_need_mentoring, self.first_user.need_mentoring)
 
 

--- a/tests/users/test_dao.py
+++ b/tests/users/test_dao.py
@@ -2,6 +2,7 @@ import datetime
 import unittest
 from werkzeug.security import check_password_hash
 
+from app import messages
 from app.api.email_utils import generate_confirmation_token
 from app.api.dao.user import UserDAO
 from app.database.models.mentorship_relation import MentorshipRelationModel
@@ -65,8 +66,7 @@ class TestUserDao(BaseTestCase):
 
         self.assertTrue(user.is_email_verified)
         self.assertIsNotNone(user.email_verification_date)
-        self.assertEqual(({'message': 'You have confirmed your account. Thanks!'}, 200),
-                         actual_result)
+        self.assertEqual((messages.ACCOUNT_ALREADY_CONFIRMED_AND_THANKS, 200), actual_result)
 
     def test_dao_confirm_registration_bad_token(self):
         dao = UserDAO()
@@ -94,8 +94,7 @@ class TestUserDao(BaseTestCase):
 
         self.assertFalse(user.is_email_verified)
         self.assertIsNone(user.email_verification_date)
-        self.assertEqual(({'message': 'The confirmation link is invalid or the token has expired.'}, 400),
-                         actual_result)
+        self.assertEqual((messages.EMAIL_EXPIRED_OR_TOKEN_IS_INVALID, 400), actual_result)
 
     def test_dao_confirm_registration_of_already_verified_user(self):
         dao = UserDAO()
@@ -122,8 +121,7 @@ class TestUserDao(BaseTestCase):
         actual_result = dao.confirm_registration(good_token)
 
         self.assertTrue(user.is_email_verified)
-        self.assertEqual(({'message': 'Account already confirmed.'}, 200),
-                         actual_result)
+        self.assertEqual((messages.ACCOUNT_ALREADY_CONFIRMED, 200), actual_result)
 
     def test_dao_delete_only_user_admin(self):
         dao = UserDAO()
@@ -139,8 +137,7 @@ class TestUserDao(BaseTestCase):
         self.assertTrue(after_delete_user.is_admin)
         self.assertIsNotNone(after_delete_user)
         self.assertEqual(1, after_delete_user.id)
-        self.assertEqual(({"message": "You cannot delete your account, since you are the only Admin left."}, 400),
-                         dao_result)
+        self.assertEqual((messages.USER_CANT_DELETE, 400), dao_result)
 
     def test_get_achievements(self):
         dao = UserDAO()

--- a/tests/users/test_validation_request_data.py
+++ b/tests/users/test_validation_request_data.py
@@ -2,6 +2,7 @@ import unittest
 from random import SystemRandom
 from string import ascii_lowercase
 
+from app import messages
 from app.api.validations.user import validate_user_registration_request_data, NAME_MIN_LENGTH, NAME_MAX_LENGTH, \
     USERNAME_MIN_LENGTH, USERNAME_MAX_LENGTH, PASSWORD_MAX_LENGTH, PASSWORD_MIN_LENGTH, validate_new_password
 from app.utils.validation_utils import get_length_validation_error_message
@@ -23,7 +24,7 @@ class TestUserApiRequestDataValidation(unittest.TestCase):
         self.assertEqual(expected_result, actual_result)
 
     def test_user_registration_request_data_missing_name_field(self):
-        expected_result = {"message": "Name field is missing."}
+        expected_result = messages.NAME_FIELD_IS_MISSING
         request_body = dict(
                 username=user1['username'],
                 password=user1['password'],
@@ -31,10 +32,10 @@ class TestUserApiRequestDataValidation(unittest.TestCase):
                 terms_and_conditions_checked=user1['terms_and_conditions_checked'])
         actual_result = validate_user_registration_request_data(request_body)
 
-        self.assertEqual(expected_result, actual_result)
+        self.assertDictEqual(expected_result, actual_result)
 
     def test_user_registration_request_data_missing_username_field(self):
-        expected_result = {"message": "Username field is missing."}
+        expected_result = messages.USERNAME_FIELD_IS_MISSING
         request_body = dict(
             name=user1['name'],
             password=user1['password'],
@@ -42,10 +43,10 @@ class TestUserApiRequestDataValidation(unittest.TestCase):
             terms_and_conditions_checked=user1['terms_and_conditions_checked'])
         actual_result = validate_user_registration_request_data(request_body)
 
-        self.assertEqual(expected_result, actual_result)
+        self.assertDictEqual(expected_result, actual_result)
 
     def test_user_registration_request_data_missing_password_field(self):
-        expected_result = {"message": "Password field is missing."}
+        expected_result = messages.PASSWORD_FIELD_IS_MISSING
         request_body = dict(
             name=user1['name'],
             username=user1['username'],
@@ -53,10 +54,10 @@ class TestUserApiRequestDataValidation(unittest.TestCase):
             terms_and_conditions_checked=user1['terms_and_conditions_checked'])
         actual_result = validate_user_registration_request_data(request_body)
 
-        self.assertEqual(expected_result, actual_result)
+        self.assertDictEqual(expected_result, actual_result)
 
     def test_user_registration_request_data_missing_email_field(self):
-        expected_result = {"message": "Email field is missing."}
+        expected_result = messages.EMAIL_FIELD_IS_MISSING
         request_body = dict(
             name=user1['name'],
             username=user1['username'],
@@ -64,10 +65,10 @@ class TestUserApiRequestDataValidation(unittest.TestCase):
             terms_and_conditions_checked=user1['terms_and_conditions_checked'])
         actual_result = validate_user_registration_request_data(request_body)
 
-        self.assertEqual(expected_result, actual_result)
+        self.assertDictEqual(expected_result, actual_result)
 
     def test_user_registration_request_data_missing_terms_and_conditions_field(self):
-        expected_result = {"message": "Terms and conditions field is missing."}
+        expected_result = messages.TERMS_AND_CONDITIONS_FIELD_IS_MISSING
         request_body = dict(
             name=user1['name'],
             username=user1['username'],
@@ -75,10 +76,10 @@ class TestUserApiRequestDataValidation(unittest.TestCase):
             email=user1['email'])
         actual_result = validate_user_registration_request_data(request_body)
 
-        self.assertEqual(expected_result, actual_result)
+        self.assertDictEqual(expected_result, actual_result)
 
     def test_user_registration_request_data_with_terms_unchecked(self):
-        expected_result = {"message": "Terms and conditions are not checked."}
+        expected_result = messages.TERMS_AND_CONDITIONS_ARE_NOT_CHECKED
         request_body = dict(
                 name=user1['name'],
                 username=user1['username'],
@@ -87,7 +88,7 @@ class TestUserApiRequestDataValidation(unittest.TestCase):
                 terms_and_conditions_checked=False)
         actual_result = validate_user_registration_request_data(request_body)
 
-        self.assertEqual(expected_result, actual_result)
+        self.assertDictEqual(expected_result, actual_result)
 
     def test_user_registration_request_data_name_inferior_to_limit(self):
         secure_random = SystemRandom()

--- a/tests/users/test_validation_update_user_request_data.py
+++ b/tests/users/test_validation_update_user_request_data.py
@@ -2,19 +2,21 @@ import unittest
 from random import SystemRandom
 from string import ascii_lowercase
 
+from app import messages
 from app.api.validations.user import validate_update_profile_request_data, OCCUPATION_MAX_LENGTH, \
     ORGANIZATION_MAX_LENGTH, USERNAME_MAX_LENGTH, USERNAME_MIN_LENGTH
 from app.utils.validation_utils import get_length_validation_error_message
+
 
 
 class TestUpdateUserApiRequestDataValidation(unittest.TestCase):
 
     def test_update_user_request_data_validation_with_no_data(self):
         request_body = dict()
-        expected_result = {"message": "No data for updating profile was sent."}
+        expected_result = messages.NO_DATA_FOR_UPDATING_PROFILE_WAS_SENT
         actual_result = validate_update_profile_request_data(request_body)
 
-        self.assertEqual(expected_result, actual_result)
+        self.assertDictEqual(expected_result, actual_result)
 
     def test_update_user_occupation_request_data_validation(self):
         secure_random = SystemRandom()


### PR DESCRIPTION
### Description
This PR changes the hardcoded errors and messages with constants.

I created a `constants.py` file in which messages have been assigned to variables. I preferred this choice over arrays as in arrays , it is need to keep track of indexes for particular messages or every time search for the message required.This approach can make the system slow as searching over arrays is time-consuming task.
I didn't use dictionary to store the data as it would have again lead to hardcoding of strings when accessing the key in the dictionary.

Having all the constants stored in a constants file makes it easier to maintain and use the constants and also faster as it's only importing the specific variable only. I looked in other orgs to find how they handle this problem and found that they are also using constants for hardcoded strings.

I have made changes in test files as the tests were failing due to mismatch in hardcoded sentences 
```
test file = "This mentorship relation was not accepted"
other files = "The mentorship relation was not accepted"
```

Fixes #116

### Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance
- User Interface
- Outreach
- Documentation

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Describe the tests you ran to verify your changes. Provide instructions or GIFs so we can reproduce. List any relevant details for your test.


### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
