### PR TITLE
Validating if a User has email verified before allowing any action using this user (updated)

### DIFF
--- a/app/api/dao/admin.py
+++ b/app/api/dao/admin.py
@@ -1,17 +1,19 @@
 from app import messages
 from app.database.models.user import UserModel
+from app.utils.decorator_utils import email_verification_required
 
 class AdminDAO:
     """Data Access Object for Admin functionalities."""
 
     @staticmethod
-    def assign_new_user(assigner_user_id, data):
+    @email_verification_required
+    def assign_new_user(user_id, data):
         """Creates a new admin.
 
         Creates a new admin if the assigned user exists and is assigned by another user. Otherwise returns a message.
 
         Args:
-            assigner_user_id: The user id of the assigner.
+            user_id: The user id of the assigner.
             data: A list containing the details of the assigned user.
 
         Returns:
@@ -20,7 +22,7 @@ class AdminDAO:
 
         new_admin_user_id = data['user_id']
 
-        if assigner_user_id is new_admin_user_id:
+        if user_id is new_admin_user_id:
             return messages.USER_CANNOT_BE_ASSIGNED_ADMIN_BY_USER, 403
 
         new_admin_user = UserModel.find_by_id(new_admin_user_id)
@@ -38,13 +40,14 @@ class AdminDAO:
         return messages.USER_DOES_NOT_EXIST, 404
 
     @staticmethod
-    def revoke_admin_user(revoker_user_id, data):
+    @email_verification_required
+    def revoke_admin_user(user_id, data):
         """Revokes the admin status of an user.
 
         Revokes the admin status of an user if the user exists, is an admin and another user requests for this action. Otherwise returns a message.
 
         Args:
-            revoker_user_id: The user id of the revoker.
+            user_id: The user id of the revoker.
             data: A list containing the details of the user whose admin status is to be revoked.
 
         Returns:
@@ -52,7 +55,7 @@ class AdminDAO:
         """
         admin_user_id = data['user_id']
 
-        if revoker_user_id is admin_user_id:
+        if user_id is admin_user_id:
             return messages.USER_CANNOT_REVOKE_ADMIN_STATUS, 403
 
         new_admin_user = UserModel.find_by_id(admin_user_id)

--- a/app/api/dao/mentorship_relation.py
+++ b/app/api/dao/mentorship_relation.py
@@ -86,12 +86,12 @@ class MentorshipRelationDAO:
         all_mentor_relations = mentor_user.mentor_relations + mentor_user.mentee_relations
         for relation in all_mentor_relations:
             if relation.state == MentorshipRelationState.ACCEPTED:
-                return {'message': 'Mentor user is already in a relationship.'}, 400
+                return messages.MENTOR_IN_RELATION, 400
 
         all_mentee_relations = mentee_user.mentor_relations + mentee_user.mentee_relations
         for relation in all_mentee_relations:
             if relation.state == MentorshipRelationState.ACCEPTED:
-                return {'message': 'Mentee user is already in a relationship.'}, 400
+                return messages.MENTEE_ALREADY_IN_A_RELATION, 400
 
         # All validations were checked
 
@@ -166,22 +166,22 @@ class MentorshipRelationDAO:
 
         # verify if request is in pending state
         if request.state != MentorshipRelationState.PENDING:
-            return {'message': 'This mentorship relation is not in the pending state.'}, 400
+            return messages.NOT_PENDING_STATE_RELATION, 400
 
         # verify if I'm the receiver of the request
         if request.action_user_id == user_id:
-            return {'message': 'You cannot accept a mentorship request sent by yourself.'}, 400
+            return messages.CANT_ACCEPT_MENTOR_REQ_SENT_BY_USER, 400
 
         # verify if I'm involved in this relation
         if not (request.mentee_id == user_id or request.mentor_id == user_id):
-            return {'message': 'You cannot accept a mentorship relation where you are not involved.'}, 400
+            return CANT_ACCEPT_UNINVOLVED_MENTOR_RELATION, 400
 
         requests = user.mentee_relations + user.mentor_relations
 
         # verify if I'm on a current relation
         for request in requests:
             if request.state == MentorshipRelationState.ACCEPTED:
-                return {'message': 'You are currently involved in a mentorship relation.'}, 400
+                return messages.USER_IS_INVOLVED_IN_A_MENTORSHIP_RELATION, 400
 
         # All was checked
         request.state = MentorshipRelationState.ACCEPTED
@@ -211,15 +211,15 @@ class MentorshipRelationDAO:
 
         # verify if request is in pending state
         if request.state != MentorshipRelationState.PENDING:
-            return {'message': 'This mentorship relation is not in the pending state.'}, 400
+            return messages.NOT_PENDING_STATE_RELATION, 400
 
         # verify if I'm the receiver of the request
         if request.action_user_id == user_id:
-            return {'message': 'You cannot reject a mentorship request sent by yourself.'}, 400
+            return messages.USER_CANT_REJECT_REQUEST_SENT_BY_USER, 400
 
         # verify if I'm involved in this relation
         if not (request.mentee_id == user_id or request.mentor_id == user_id):
-            return {'message': 'You cannot reject a mentorship relation where you are not involved.'}, 400
+            return messages.CANT_REJECT_UNINVOLVED_RELATION_REQUEST, 400
 
         # All was checked
         request.state = MentorshipRelationState.REJECTED
@@ -253,7 +253,7 @@ class MentorshipRelationDAO:
 
         # verify if I'm involved in this relation
         if not (request.mentee_id == user_id or request.mentor_id == user_id):
-            return {'message': 'You cannot cancel a mentorship relation where you are not involved.'}, 400
+            return messages.CANT_CANCEL_UNINVOLVED_REQUEST, 400
 
         # All was checked
         request.state = MentorshipRelationState.CANCELLED
@@ -285,11 +285,11 @@ class MentorshipRelationDAO:
 
         # verify if request is in pending state
         if request.state != MentorshipRelationState.PENDING:
-            return {'message': 'This mentorship relation is not in the pending state.'}, 400
+            return messages.NOT_PENDING_STATE_RELATION, 400
 
         # verify if user created the mentorship request
         if request.action_user_id != user_id:
-            return {'message': 'You cannot delete a mentorship request that you did not create.'}, 400
+            return messages.CANT_DELETE_UNINVOLVED_REQUEST, 400
 
         # All was checked
         request.delete_from_db()

--- a/app/api/dao/mentorship_relation.py
+++ b/app/api/dao/mentorship_relation.py
@@ -4,6 +4,7 @@ from app import messages
 from app.database.models.mentorship_relation import MentorshipRelationModel
 from app.database.models.tasks_list import TasksListModel
 from app.database.models.user import UserModel
+from app.utils.decorator_utils import email_verification_required
 from app.utils.enum_utils import MentorshipRelationState
 
 class MentorshipRelationDAO:
@@ -84,13 +85,13 @@ class MentorshipRelationDAO:
 
         all_mentor_relations = mentor_user.mentor_relations + mentor_user.mentee_relations
         for relation in all_mentor_relations:
-            if relation.state is MentorshipRelationState.ACCEPTED:
-                return messages.MENTOR_IN_RELATION, 400
+            if relation.state == MentorshipRelationState.ACCEPTED:
+                return {'message': 'Mentor user is already in a relationship.'}, 400
 
         all_mentee_relations = mentee_user.mentor_relations + mentee_user.mentee_relations
         for relation in all_mentee_relations:
-            if relation.state is MentorshipRelationState.ACCEPTED:
-                return messages.MENTEE_ALREADY_IN_A_RELATION, 400
+            if relation.state == MentorshipRelationState.ACCEPTED:
+                return {'message': 'Mentee user is already in a relationship.'}, 400
 
         # All validations were checked
 
@@ -111,6 +112,7 @@ class MentorshipRelationDAO:
         return messages.MENTORSHIP_RELATION_WAS_SENT_SUCCESSFULLY, 200
 
     @staticmethod
+    @email_verification_required
     def list_mentorship_relations(user_id=None, accepted=None, pending=None, completed=None, cancelled=None, rejected=None):
         """Lists all relationships of a given user.
 
@@ -134,10 +136,6 @@ class MentorshipRelationDAO:
             return messages.NOT_IMPLEMENTED, 200
 
         user = UserModel.find_by_id(user_id)
-
-        if user is None:
-            return messages.USER_DOES_NOT_EXIST, 404
-
         all_relations = user.mentor_relations + user.mentee_relations
 
         # add extra field for api response
@@ -147,6 +145,7 @@ class MentorshipRelationDAO:
         return all_relations, 200
 
     @staticmethod
+    @email_verification_required
     def accept_request(user_id, request_id):
         """Allows a mentorship request.
 
@@ -159,11 +158,6 @@ class MentorshipRelationDAO:
         """
 
         user = UserModel.find_by_id(user_id)
-
-        # verify if user exists
-        if user is None:
-            return messages.USER_DOES_NOT_EXIST, 404
-
         request = MentorshipRelationModel.find_by_id(request_id)
 
         # verify if request exists
@@ -171,23 +165,23 @@ class MentorshipRelationDAO:
             return messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, 404
 
         # verify if request is in pending state
-        if request.state is not MentorshipRelationState.PENDING:
-            return messages.NOT_PENDING_STATE_RELATION, 400
+        if request.state != MentorshipRelationState.PENDING:
+            return {'message': 'This mentorship relation is not in the pending state.'}, 400
 
         # verify if I'm the receiver of the request
-        if request.action_user_id is user_id:
-            return messages.CANT_ACCEPT_MENTOR_REQ_SENT_BY_USER, 400
+        if request.action_user_id == user_id:
+            return {'message': 'You cannot accept a mentorship request sent by yourself.'}, 400
 
         # verify if I'm involved in this relation
-        if not (request.mentee_id is user_id or request.mentor_id is user_id):
-            return messages.CANT_ACCEPT_UNINVOLVED_MENTOR_RELATION, 400
+        if not (request.mentee_id == user_id or request.mentor_id == user_id):
+            return {'message': 'You cannot accept a mentorship relation where you are not involved.'}, 400
 
         requests = user.mentee_relations + user.mentor_relations
 
         # verify if I'm on a current relation
         for request in requests:
-            if request.state is MentorshipRelationState.ACCEPTED:
-                return messages.USER_IS_INVOLVED_IN_A_MENTORSHIP_RELATION, 400
+            if request.state == MentorshipRelationState.ACCEPTED:
+                return {'message': 'You are currently involved in a mentorship relation.'}, 400
 
         # All was checked
         request.state = MentorshipRelationState.ACCEPTED
@@ -196,6 +190,7 @@ class MentorshipRelationDAO:
         return messages.MENTORSHIP_RELATION_WAS_ACCEPTED_SUCCESSFULLY, 200
 
     @staticmethod
+    @email_verification_required
     def reject_request(user_id, request_id):
         """Rejects a mentorship request.
 
@@ -208,11 +203,6 @@ class MentorshipRelationDAO:
         """
 
         user = UserModel.find_by_id(user_id)
-
-        # verify if user exists
-        if user is None:
-            return messages.USER_DOES_NOT_EXIST, 404
-
         request = MentorshipRelationModel.find_by_id(request_id)
 
         # verify if request exists
@@ -220,16 +210,16 @@ class MentorshipRelationDAO:
             return messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, 404
 
         # verify if request is in pending state
-        if request.state is not MentorshipRelationState.PENDING:
-            return messages.NOT_PENDING_STATE_RELATION, 400
+        if request.state != MentorshipRelationState.PENDING:
+            return {'message': 'This mentorship relation is not in the pending state.'}, 400
 
         # verify if I'm the receiver of the request
-        if request.action_user_id is user_id:
-            return messages.USER_CANT_REJECT_REQUEST_SENT_BY_USER, 400
+        if request.action_user_id == user_id:
+            return {'message': 'You cannot reject a mentorship request sent by yourself.'}, 400
 
         # verify if I'm involved in this relation
-        if not (request.mentee_id is user_id or request.mentor_id is user_id):
-            return messages.CANT_REJECT_UNINVOLVED_RELATION_REQUEST, 400
+        if not (request.mentee_id == user_id or request.mentor_id == user_id):
+            return {'message': 'You cannot reject a mentorship relation where you are not involved.'}, 400
 
         # All was checked
         request.state = MentorshipRelationState.REJECTED
@@ -238,6 +228,7 @@ class MentorshipRelationDAO:
         return messages.MENTORSHIP_RELATION_WAS_REJECTED_SUCCESSFULLY, 200
 
     @staticmethod
+    @email_verification_required
     def cancel_relation(user_id, relation_id):
         """Allows a given user to terminate a particular relationship.
 
@@ -250,11 +241,6 @@ class MentorshipRelationDAO:
         """
 
         user = UserModel.find_by_id(user_id)
-
-        # verify if user exists
-        if user is None:
-            return messages.USER_DOES_NOT_EXIST, 404
-
         request = MentorshipRelationModel.find_by_id(relation_id)
 
         # verify if request exists
@@ -262,12 +248,12 @@ class MentorshipRelationDAO:
             return messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, 404
 
         # verify if request is in pending state
-        if request.state is not MentorshipRelationState.ACCEPTED:
+        if request.state != MentorshipRelationState.ACCEPTED:
             return messages.UNACCEPTED_STATE_RELATION, 400
 
         # verify if I'm involved in this relation
-        if not (request.mentee_id is user_id or request.mentor_id is user_id):
-            return messages.CANT_CANCEL_UNINVOLVED_REQUEST, 400
+        if not (request.mentee_id == user_id or request.mentor_id == user_id):
+            return {'message': 'You cannot cancel a mentorship relation where you are not involved.'}, 400
 
         # All was checked
         request.state = MentorshipRelationState.CANCELLED
@@ -276,6 +262,7 @@ class MentorshipRelationDAO:
         return messages.MENTORSHIP_RELATION_WAS_CANCELLED_SUCCESSFULLY, 200
 
     @staticmethod
+    @email_verification_required
     def delete_request(user_id, request_id):
         """Deletes a mentorship request.
 
@@ -290,11 +277,6 @@ class MentorshipRelationDAO:
         """
 
         user = UserModel.find_by_id(user_id)
-
-        # verify if user exists
-        if user is None:
-            return messages.USER_DOES_NOT_EXIST, 404
-
         request = MentorshipRelationModel.find_by_id(request_id)
 
         # verify if request exists
@@ -302,12 +284,12 @@ class MentorshipRelationDAO:
             return messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, 404
 
         # verify if request is in pending state
-        if request.state is not MentorshipRelationState.PENDING:
-            return messages.NOT_PENDING_STATE_RELATION, 400
+        if request.state != MentorshipRelationState.PENDING:
+            return {'message': 'This mentorship relation is not in the pending state.'}, 400
 
         # verify if user created the mentorship request
-        if request.action_user_id is not user_id:
-            return messages.CANT_DELETE_UNINVOLVED_REQUEST, 400
+        if request.action_user_id != user_id:
+            return {'message': 'You cannot delete a mentorship request that you did not create.'}, 400
 
         # All was checked
         request.delete_from_db()
@@ -315,6 +297,7 @@ class MentorshipRelationDAO:
         return messages.MENTORSHIP_RELATION_WAS_DELETED_SUCCESSFULLY, 200
 
     @staticmethod
+    @email_verification_required
     def list_past_mentorship_relations(user_id):
         """Lists past mentorship relation details.
 
@@ -326,11 +309,6 @@ class MentorshipRelationDAO:
         """
 
         user = UserModel.find_by_id(user_id)
-
-        # verify if user exists
-        if user is None:
-            return messages.USER_DOES_NOT_EXIST, 404
-
         now_timestamp = datetime.now().timestamp()
         past_relations = []
         all_relations = user.mentor_relations + user.mentee_relations
@@ -343,6 +321,7 @@ class MentorshipRelationDAO:
         return past_relations, 200
 
     @staticmethod
+    @email_verification_required
     def list_current_mentorship_relation(user_id):
         """Lists current mentorship relation details.
 
@@ -354,21 +333,17 @@ class MentorshipRelationDAO:
         """
 
         user = UserModel.find_by_id(user_id)
-
-        # verify if user exists
-        if user is None:
-            return messages.USER_DOES_NOT_EXIST, 404
-
         all_relations = user.mentor_relations + user.mentee_relations
 
         for relation in all_relations:
-            if relation.state is MentorshipRelationState.ACCEPTED:
+            if relation.state == MentorshipRelationState.ACCEPTED:
                 setattr(relation, 'sent_by_me', relation.action_user_id == user_id)
                 return relation
 
         return messages.NOT_IN_MENTORED_RELATION_CURRENTLY, 200
 
     @staticmethod
+    @email_verification_required
     def list_pending_mentorship_relations(user_id):
         """Lists mentorship requests in pending state.
 
@@ -380,17 +355,12 @@ class MentorshipRelationDAO:
         """
 
         user = UserModel.find_by_id(user_id)
-
-        # verify if user exists
-        if user is None:
-            return messages.USER_DOES_NOT_EXIST, 404
-
         now_timestamp = datetime.now().timestamp()
         pending_requests = []
         all_relations = user.mentor_relations + user.mentee_relations
 
         for relation in all_relations:
-            if relation.state is MentorshipRelationState.PENDING and relation.end_date > now_timestamp:
+            if relation.state == MentorshipRelationState.PENDING and relation.end_date > now_timestamp:
                 setattr(relation, 'sent_by_me', relation.action_user_id == user_id)
                 pending_requests += [relation]
 

--- a/app/api/dao/task.py
+++ b/app/api/dao/task.py
@@ -36,7 +36,7 @@ class TaskDAO:
             return messages.MENTORSHIP_RELATION_DOES_NOT_EXIST, 404
 
         if relation.state != MentorshipRelationState.ACCEPTED:
-            return {'message': 'Mentorship relation is not in the accepted state.'}, 400
+            return messages.UNACCEPTED_STATE_RELATION, 400
 
         now_timestamp = datetime.now().timestamp()
         relation.tasks_list.add_task(description=description, created_at=now_timestamp)

--- a/app/api/dao/task.py
+++ b/app/api/dao/task.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from app import messages
 from app.database.models.mentorship_relation import MentorshipRelationModel
 from app.database.models.user import UserModel
+from app.utils.decorator_utils import email_verification_required
 from app.utils.enum_utils import MentorshipRelationState
 
 
@@ -10,6 +11,7 @@ class TaskDAO:
     """Data Access Object for Task functionalities."""
 
     @staticmethod
+    @email_verification_required
     def create_task(user_id, mentorship_relation_id, data):
         """Creates a new task.
 
@@ -29,15 +31,12 @@ class TaskDAO:
         description = data['description']
 
         user = UserModel.find_by_id(user_id)
-        if user is None:
-            return messages.USER_DOES_NOT_EXIST, 404
-
         relation = MentorshipRelationModel.find_by_id(_id=mentorship_relation_id)
         if relation is None:
             return messages.MENTORSHIP_RELATION_DOES_NOT_EXIST, 404
 
-        if relation.state is not MentorshipRelationState.ACCEPTED:
-            return messages.MENTORSHIP_RELATION_NOT_IN_ACCEPT_STATE, 400
+        if relation.state != MentorshipRelationState.ACCEPTED:
+            return {'message': 'Mentorship relation is not in the accepted state.'}, 400
 
         now_timestamp = datetime.now().timestamp()
         relation.tasks_list.add_task(description=description, created_at=now_timestamp)
@@ -46,6 +45,7 @@ class TaskDAO:
         return messages.TASK_WAS_CREATED_SUCCESSFULLY, 200
 
     @staticmethod
+    @email_verification_required
     def list_tasks(user_id, mentorship_relation_id):
         """Retrieves all tasks of a user in a mentorship relation.
 
@@ -62,9 +62,6 @@ class TaskDAO:
         """
 
         user = UserModel.find_by_id(user_id)
-        if user is None:
-            return messages.USER_DOES_NOT_EXIST, 404
-
         relation = MentorshipRelationModel.find_by_id(mentorship_relation_id)
         if relation is None:
             return messages.MENTORSHIP_RELATION_DOES_NOT_EXIST, 404
@@ -77,6 +74,7 @@ class TaskDAO:
         return all_tasks
 
     @staticmethod
+    @email_verification_required
     def delete_task(user_id, mentorship_relation_id, task_id):
         """Deletes a specified task from a mentorship relation.
 
@@ -94,9 +92,6 @@ class TaskDAO:
         """
 
         user = UserModel.find_by_id(user_id)
-        if user is None:
-            return messages.USER_DOES_NOT_EXIST, 404
-
         relation = MentorshipRelationModel.find_by_id(mentorship_relation_id)
         if relation is None:
             return messages.MENTORSHIP_RELATION_DOES_NOT_EXIST, 404
@@ -113,6 +108,7 @@ class TaskDAO:
         return messages.TASK_WAS_DELETED_SUCCESSFULLY, 200
 
     @staticmethod
+    @email_verification_required
     def complete_task(user_id, mentorship_relation_id, task_id):
         """Marks a task as completed.
 
@@ -130,9 +126,6 @@ class TaskDAO:
         """
 
         user = UserModel.find_by_id(user_id)
-        if user is None:
-            return messages.USER_DOES_NOT_EXIST, 404
-
         relation = MentorshipRelationModel.find_by_id(mentorship_relation_id)
         if relation is None:
             return messages.MENTORSHIP_RELATION_DOES_NOT_EXIST, 404

--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -4,6 +4,7 @@ from operator import itemgetter
 from app import messages
 from app.api.email_utils import confirm_token
 from app.database.models.user import UserModel
+from app.utils.decorator_utils import email_verification_required
 from app.utils.enum_utils import MentorshipRelationState
 from app.utils.validation_utils import is_email_valid
 
@@ -40,6 +41,7 @@ class UserDAO:
         return messages.USER_WAS_CREATED_SUCCESSFULLY, 200
 
     @staticmethod
+    @email_verification_required
     def delete_user(user_id):
         user = UserModel.find_by_id(user_id)
 
@@ -57,6 +59,7 @@ class UserDAO:
         return messages.USER_DOES_NOT_EXIST, 404
 
     @staticmethod
+    @email_verification_required
     def get_user(user_id):
         return UserModel.find_by_id(user_id)
 
@@ -82,6 +85,7 @@ class UserDAO:
         return list_of_users, 200
 
     @staticmethod
+    @email_verification_required
     def update_user_profile(user_id, data):
 
         user = UserModel.find_by_id(user_id)
@@ -142,6 +146,7 @@ class UserDAO:
         return messages.USER_SUCCESSFULLY_UPDATED, 200
 
     @staticmethod
+    @email_verification_required
     def change_password(user_id, data):
         current_password = data['current_password']
         new_password = data['new_password']
@@ -190,6 +195,7 @@ class UserDAO:
         return None
 
     @staticmethod
+    @email_verification_required
     def get_achievements(user_id):
         """Shows a subset of the user's achievements
 

--- a/app/utils/decorator_utils.py
+++ b/app/utils/decorator_utils.py
@@ -1,0 +1,43 @@
+"""
+This module is used to define decorators for the app
+"""
+from app import messages
+
+from app.database.models.user import UserModel
+
+
+def email_verification_required(user_function):
+    """
+    This function is used to validate the
+    input function i.e. user_function
+    It will check if the user given as a
+    parameter to user_function
+    exists and have its email verified
+    """
+
+    def check_verification(*args, **kwargs):
+        """
+        Function to validate the input function ie user_function
+        - It will return error 404 if user doesn't exist
+        - It will return error 400 if user hasn't verified email
+
+        Parameters:
+        Function to be validated can have any type of argument
+        - list
+        - dict
+        """
+
+        if kwargs:
+            user = UserModel.find_by_id(kwargs['user_id'])
+        else:
+            user = UserModel.find_by_id(args[0])
+
+        # verify if user exists
+        if user:
+            if not user.is_email_verified:
+                return  messages.USER_HAS_NOT_VERIFIED_EMAIL_BEFORE_LOGIN, 403
+            return user_function(*args, **kwargs)
+        else:
+            return messages.USER_DOES_NOT_EXIST, 404
+
+    return check_verification

--- a/tests/admin/test_dao.py
+++ b/tests/admin/test_dao.py
@@ -46,6 +46,7 @@ class TestAdminDao(BaseTestCase):
             password=user1['password'],
             terms_and_conditions_checked=user1['terms_and_conditions_checked']
         )
+        user.is_email_verified = True
         user.save_to_db()
 
         user = UserModel.query.filter_by(id=2).first()

--- a/tests/mentorship_relation/relation_base_setup.py
+++ b/tests/mentorship_relation/relation_base_setup.py
@@ -30,8 +30,10 @@ class MentorshipRelationBaseTestCase(BaseTestCase):
         # making sure both are available to be mentor or mentee
         self.first_user.need_mentoring = True
         self.first_user.available_to_mentor = True
+        self.first_user.is_email_verified = True
         self.second_user.need_mentoring = True
         self.second_user.available_to_mentor = True
+        self.second_user.is_email_verified = True
 
         db.session.add(self.first_user)
         db.session.add(self.second_user)

--- a/tests/mentorship_relation/test_dao_delete_request.py
+++ b/tests/mentorship_relation/test_dao_delete_request.py
@@ -37,8 +37,10 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
         # making sure both are available to be mentor or mentee
         self.first_user.need_mentoring = True
         self.first_user.available_to_mentor = True
+        self.first_user.is_email_verified = True
         self.second_user.need_mentoring = True
         self.second_user.available_to_mentor = True
+        self.second_user.is_email_verified = True
 
         self.notes_example = 'description of a good mentorship relation'
 

--- a/tests/tasks/tasks_base_setup.py
+++ b/tests/tasks/tasks_base_setup.py
@@ -35,9 +35,11 @@ class TasksBaseTestCase(BaseTestCase):
         # making sure both are available to be mentor or mentee
         self.first_user.need_mentoring = True
         self.first_user.available_to_mentor = True
+        self.first_user.is_email_verified = True
         self.second_user.need_mentoring = True
         self.second_user.available_to_mentor = True
-
+        self.second_user.is_email_verified = True
+        
         self.notes_example = 'description of a good mentorship relation'
 
         self.now_datetime = datetime.now()

--- a/tests/tasks/test_dao_create_task.py
+++ b/tests/tasks/test_dao_create_task.py
@@ -37,7 +37,7 @@ class TestListTasksDao(TasksBaseTestCase):
 
     def test_create_task_with_mentorship_relation_non_accepted_state(self):
 
-        expected_response = messages.MENTORSHIP_RELATION_NOT_IN_ACCEPT_STATE, 400
+        expected_response = messages.UNACCEPTED_STATE_RELATION, 400
         self.mentorship_relation_w_second_user.state = MentorshipRelationState.CANCELLED
 
         actual_response = TaskDAO.create_task(user_id=self.first_user.id,

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,25 +1,25 @@
+test_admin_user = {
+    "name": "Admin",
+    "email": "admin@email.com",
+    "username": "admin_username",
+    "password": "admin_pwd",
+    "terms_and_conditions_checked": True
+}
 
-test_admin_user = dict(
-    name="Admin",
-    email="admin@email.com",
-    username="admin_username",
-    password="admin_pwd",
-    terms_and_conditions_checked=True
-)
+user1 = {
+    "name": "User",
+    "email": "user1@email.com",
+    "username": "user1",
+    "password": "user1_pwd",
+    "terms_and_conditions_checked": True,
+    "available_to_mentor": True,
+    "need_mentoring": True
+}
 
-user1 = dict(
-    name="User",
-    email="user1@email.com",
-    username="user1",
-    password="user1_pwd",
-    terms_and_conditions_checked=True,
-    available_to_mentor=True,
-    need_mentoring=True
-)
-user2 = dict(
-    name="Userb",
-    email="user2@email.com",
-    username="user2",
-    password="user2_pwd",
-    terms_and_conditions_checked=True
-)
+user2 = {
+    "name": "Userb",
+    "email": "user2@email.com",
+    "username": "user2",
+    "password": "user2_pwd",
+    "terms_and_conditions_checked": True
+}

--- a/tests/users/test_api_home_statistics.py
+++ b/tests/users/test_api_home_statistics.py
@@ -19,7 +19,9 @@ class TestHomeStatisticsApi(BaseTestCase):
         self.user1 = UserModel("User1", "user1", "__test__", "test@email.com", True)
         self.user2 = UserModel("User2", "user2", "__test__", "test2@email.com", True)
         self.user1.available_to_mentor = True
+        self.user1.is_email_verified = True
         self.user2.need_mentoring = True
+        self.user2.is_email_verified = True
 
         db.session.add(self.user1)
         db.session.add(self.user2)

--- a/tests/users/test_database_model.py
+++ b/tests/users/test_database_model.py
@@ -1,5 +1,4 @@
 import unittest
-import datetime
 from werkzeug.security import check_password_hash
 
 from tests.base_test_case import BaseTestCase


### PR DESCRIPTION
Old PR reference: [190](https://github.com/systers/mentorship-backend/pull/190)
### Description
Made a decorator to check if the user whose details will be updated has verified their email.

Fixes #117

### Type of Change:

- Code

**Code/Quality Assurance Only**
- Bug fixed - Now a user's profile can only be updated after they have verified their email

### How Has This Been Tested?

Checked using tests.

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] Any dependent changes have been published in downstream modules
