### PR TITLE
Fix #206 : Add tests for Assigning/Revoking admin DAO

### DIFF
--- a/app/api/dao/admin.py
+++ b/app/api/dao/admin.py
@@ -24,7 +24,6 @@ class AdminDAO:
         if user_id is new_admin_user_id:
             return messages.USER_CANNOT_BE_ASSIGNED_ADMIN_BY_USER, 403
 
-        #For test purposes
         admin_user = UserModel.find_by_id(user_id)
 
         if admin_user: 
@@ -69,12 +68,11 @@ class AdminDAO:
 
         new_admin_user = UserModel.find_by_id(admin_user_id)
 
-        #For test purposes
         admin_user = UserModel.find_by_id(user_id)
 
         if admin_user: 
             if not admin_user.is_admin:
-                return messages.USER_ASSIGN_NOT_ADMIN, 403
+                return messages.USER_REVOKE_NOT_ADMIN, 403
         else:
             return messages.USER_NOT_FOUND, 404
 

--- a/app/api/dao/admin.py
+++ b/app/api/dao/admin.py
@@ -19,11 +19,20 @@ class AdminDAO:
         Returns:
             message: A message corresponding to the completed action.
         """
-
         new_admin_user_id = data['user_id']
 
         if user_id is new_admin_user_id:
             return messages.USER_CANNOT_BE_ASSIGNED_ADMIN_BY_USER, 403
+
+        #For test purposes
+        admin_user = UserModel.find_by_id(user_id)
+
+        if admin_user: 
+            if not admin_user.is_admin:
+                return messages.USER_ASSIGN_NOT_ADMIN, 403
+        else:
+            return messages.USER_NOT_FOUND, 404
+        
 
         new_admin_user = UserModel.find_by_id(new_admin_user_id)
 
@@ -59,6 +68,15 @@ class AdminDAO:
             return messages.USER_CANNOT_REVOKE_ADMIN_STATUS, 403
 
         new_admin_user = UserModel.find_by_id(admin_user_id)
+
+        #For test purposes
+        admin_user = UserModel.find_by_id(user_id)
+
+        if admin_user: 
+            if not admin_user.is_admin:
+                return messages.USER_ASSIGN_NOT_ADMIN, 403
+        else:
+            return messages.USER_NOT_FOUND, 404
 
         if new_admin_user:
 

--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -102,37 +102,37 @@ class UserDAO:
 
             user.username = username
 
-        if 'name' in data:
+        if 'name' in data and data['name']:
             user.name = data['name']
 
-        if 'bio' in data:
+        if 'bio' in data and data['bio']:
             user.bio = data['bio']
 
-        if 'location' in data:
+        if 'location' in data and data['location']:
             user.location = data['location']
 
-        if 'occupation' in data:
+        if 'occupation' in data and data['occupation']:
             user.occupation = data['occupation']
 
-        if 'organization' in data:
+        if 'organization' in data and data['organization']:
             user.organization = data['organization']
 
-        if 'slack_username' in data:
+        if 'slack_username' in data and data['slack_username']:
             user.slack_username = data['slack_username']
 
-        if 'social_media_links' in data:
+        if 'social_media_links' in data and data['social_media_links']:
             user.social_media_links = data['social_media_links']
 
-        if 'skills' in data:
+        if 'skills' in data and data['skills']:
             user.skills = data['skills']
 
-        if 'interests' in data:
+        if 'interests' in data and data['interests']:
             user.interests = data['interests']
 
-        if 'resume_url' in data:
+        if 'resume_url' in data and data['resume_url']:
             user.resume_url = data['resume_url']
 
-        if 'photo_url' in data:
+        if 'photo_url' in data and data['photo_url']:
             user.photo_url = data['photo_url']
 
         if 'need_mentoring' in data:

--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -102,37 +102,37 @@ class UserDAO:
 
             user.username = username
 
-        if 'name' in data and data['name']:
+        if 'name' in data:
             user.name = data['name']
 
-        if 'bio' in data and data['bio']:
+        if 'bio' in data:
             user.bio = data['bio']
 
-        if 'location' in data and data['location']:
+        if 'location' in data:
             user.location = data['location']
 
-        if 'occupation' in data and data['occupation']:
+        if 'occupation' in data:
             user.occupation = data['occupation']
 
-        if 'organization' in data and data['organization']:
+        if 'organization' in data:
             user.organization = data['organization']
 
-        if 'slack_username' in data and data['slack_username']:
+        if 'slack_username' in data:
             user.slack_username = data['slack_username']
 
-        if 'social_media_links' in data and data['social_media_links']:
+        if 'social_media_links' in data:
             user.social_media_links = data['social_media_links']
 
-        if 'skills' in data and data['skills']:
+        if 'skills' in data:
             user.skills = data['skills']
 
-        if 'interests' in data and data['interests']:
+        if 'interests' in data:
             user.interests = data['interests']
 
-        if 'resume_url' in data and data['resume_url']:
+        if 'resume_url' in data:
             user.resume_url = data['resume_url']
 
-        if 'photo_url' in data and data['photo_url']:
+        if 'photo_url' in data:
             user.photo_url = data['photo_url']
 
         if 'need_mentoring' in data:

--- a/tests/admin/test_dao.py
+++ b/tests/admin/test_dao.py
@@ -49,15 +49,6 @@ class TestAdminDao(BaseTestCase):
         
         dao = AdminDAO()
 
-        user = UserModel(
-            name=user1['name'],
-            username=user1['username'],
-            email=user1['email'],
-            password=user1['password'],
-            terms_and_conditions_checked=user1['terms_and_conditions_checked']
-        )
-        user.save_to_db()
-
         data = dict(
             user_id=123
         )

--- a/tests/admin/test_dao.py
+++ b/tests/admin/test_dao.py
@@ -41,6 +41,34 @@ class TestAdminDao(BaseTestCase):
         user = UserModel.query.filter_by(id=2).first()
         self.assertTrue(user.is_admin)
 
+    """
+    Checks wheather a new admin can be assigned by normal user.
+    """
+    def test_dao_assign_new_admin_by_normal_user(self):
+        
+        dao = AdminDAO()
+
+        user = UserModel(
+            name=user1['name'],
+            username=user1['username'],
+            email=user1['email'],
+            password=user1['password'],
+            terms_and_conditions_checked=user1['terms_and_conditions_checked']
+        )
+        user.is_email_verified = True
+        user.save_to_db()
+
+        user = UserModel.query.filter_by(id=2).first()
+
+        self.assertFalse(user.is_admin)
+
+        data = dict(
+            user_id=1
+        )
+        dao_result = dao.assign_new_user(2, data)
+
+        self.assertEqual((messages.USER_ASSIGN_NOT_ADMIN, 403), dao_result)
+
 
     """
     Checks whether a user tries to assign admin rights to a non existing user.
@@ -148,6 +176,33 @@ class TestAdminDao(BaseTestCase):
 
         user = UserModel.query.filter_by(id=2).first()
         self.assertFalse(user.is_admin)
+
+    
+    """
+    Checks whether a user is trying to revoke other user's admin priviledges. 
+    """
+    def test_dao_revoke_admin_role_by_non_admin_user(self):
+        
+        dao = AdminDAO()
+
+        user = UserModel(
+            name=user1['name'],
+            username=user1['username'],
+            email=user1['email'],
+            password=user1['password'],
+            terms_and_conditions_checked=user1['terms_and_conditions_checked']
+        )
+        user.is_email_verified = True
+        user.save_to_db()
+        user = UserModel.query.filter_by(id=2).first()
+        self.assertFalse(user.is_admin)
+        
+        data = dict(
+            user_id=1
+        )
+        dao_result = dao.revoke_admin_user(2, data)
+
+        self.assertEqual((messages.USER_ASSIGN_NOT_ADMIN, 403), dao_result)
 
 
     """

--- a/tests/admin/test_dao.py
+++ b/tests/admin/test_dao.py
@@ -9,7 +9,12 @@ from app.database.sqlalchemy_extension import db
 
 class TestAdminDao(BaseTestCase):
 
+
+    """
+    Checks wheather a new admin can be assigned by existing admin.
+    """
     def test_dao_assign_new_admin_valid_user(self):
+        
         dao = AdminDAO()
 
         user = UserModel(
@@ -34,7 +39,69 @@ class TestAdminDao(BaseTestCase):
         user = UserModel.query.filter_by(id=2).first()
         self.assertTrue(user.is_admin)
 
+
+    """
+    Checks whether a user tries to assign admin rights to a non existing user.
+    """
+    def test_dao_assign_admin_role_to_non_existing_user(self):
+        
+        dao = AdminDAO()
+
+        user = UserModel(
+            name=user1['name'],
+            username=user1['username'],
+            email=user1['email'],
+            password=user1['password'],
+            terms_and_conditions_checked=user1['terms_and_conditions_checked']
+        )
+        user.save_to_db()
+
+        data = dict(
+            user_id=123
+        )
+
+        dao_result = dao.assign_new_user(1, data)
+
+        self.assertEqual(({"message": "User does not exist."}, 404), dao_result) 
+
+
+    """
+    Checks whether a user tries to assign admin rights to existing admin user.
+    """
+    def test_dao_assign_admin_role_to_admin_user(self):
+
+        dao = AdminDAO()
+
+        user = UserModel(
+            name=user1['name'],
+            username=user1['username'],
+            email=user1['email'],
+            password=user1['password'],
+            terms_and_conditions_checked=user1['terms_and_conditions_checked']
+        )
+
+        user.save_to_db()
+
+        user = UserModel.query.filter_by(id=2).first()
+        self.assertFalse(user.is_admin)
+        user.is_admin = True
+        user.save_to_db()
+        self.assertTrue(user.is_admin)
+        
+        data = dict(
+            user_id=2
+        )
+
+        dao_result = dao.assign_new_user(1, data)
+
+        self.assertEqual(({"message": "User is already an Admin."}, 400), dao_result)
+
+
+    """
+    Checks if a user tries to assign admin role to (him/her)self. 
+    """
     def test_dao_assign_admin_role_to_myself(self):
+
         dao = AdminDAO()
 
         user = UserModel(
@@ -57,7 +124,12 @@ class TestAdminDao(BaseTestCase):
 
         self.assertEqual(({"message": "You cannot assign yourself as an Admin."}, 403), dao_result)
 
+
+    """
+    Checks whether a user is trying to revoke other user's admin priviledges. 
+    """
     def test_dao_revoke_admin_role_to_valid_user(self):
+        
         dao = AdminDAO()
 
         user = UserModel(
@@ -83,7 +155,12 @@ class TestAdminDao(BaseTestCase):
         user = UserModel.query.filter_by(id=2).first()
         self.assertFalse(user.is_admin)
 
+
+    """
+    Checks whether a user tries to revoke admin rights from a non existing user.
+    """
     def test_dao_revoke_admin_role_to_non_existing_user(self):
+
         dao = AdminDAO()
 
         data = dict(
@@ -94,7 +171,12 @@ class TestAdminDao(BaseTestCase):
 
         self.assertEqual(({"message": "User does not exist."}, 404), dao_result)
 
+
+    """
+    Checks whether a user tries to revoke admin rights of a non admin user.
+    """
     def test_dao_revoke_admin_role_to_non_admin_user(self):
+        
         dao = AdminDAO()
 
         user = UserModel(
@@ -105,7 +187,6 @@ class TestAdminDao(BaseTestCase):
             terms_and_conditions_checked=user1['terms_and_conditions_checked']
         )
         user.save_to_db()
-
         user = UserModel.query.filter_by(id=2).first()
         self.assertFalse(user.is_admin)
 
@@ -117,6 +198,9 @@ class TestAdminDao(BaseTestCase):
 
         self.assertEqual(({"message": "User is not an Admin."}, 400), dao_result)
 
+    """
+    Checks whether a user tries to revoke their own admin status.
+    """
     def test_dao_revoke_admin_role_to_myself(self):
         dao = AdminDAO()
 

--- a/tests/admin/test_dao.py
+++ b/tests/admin/test_dao.py
@@ -13,7 +13,7 @@ class TestAdminDao(BaseTestCase):
 
 
     """
-    Checks wheather a new admin can be assigned by existing admin.
+    Checks whether a new admin can be assigned by existing admin.
     """
     def test_dao_assign_new_admin_valid_user(self):
         
@@ -42,7 +42,7 @@ class TestAdminDao(BaseTestCase):
         self.assertTrue(user.is_admin)
 
     """
-    Checks wheather a new admin can be assigned by normal user.
+    Checks whether a new admin can be assigned by normal user.
     """
     def test_dao_assign_new_admin_by_normal_user(self):
         
@@ -119,7 +119,7 @@ class TestAdminDao(BaseTestCase):
 
 
     """
-    Checks if a user tries to assign admin role to (him/her)self. 
+    Checks if a user tries to self-assign admin role.  
     """
     def test_dao_assign_admin_role_to_myself(self):
 
@@ -179,7 +179,7 @@ class TestAdminDao(BaseTestCase):
 
     
     """
-    Checks whether a user is trying to revoke other user's admin priviledges. 
+    Checks whether a user is trying to revoke other user's admin privileges. 
     """
     def test_dao_revoke_admin_role_by_non_admin_user(self):
         
@@ -202,7 +202,7 @@ class TestAdminDao(BaseTestCase):
         )
         dao_result = dao.revoke_admin_user(2, data)
 
-        self.assertEqual((messages.USER_ASSIGN_NOT_ADMIN, 403), dao_result)
+        self.assertEqual((messages.USER_REVOKE_NOT_ADMIN, 403), dao_result)
 
 
     """

--- a/tests/admin/test_dao.py
+++ b/tests/admin/test_dao.py
@@ -55,7 +55,7 @@ class TestAdminDao(BaseTestCase):
 
         dao_result = dao.assign_new_user(1, data)
 
-        self.assertEqual(({"message": "User does not exist."}, 404), dao_result) 
+        self.assertEqual((messages.USER_DOES_NOT_EXIST, 404), dao_result) 
 
 
     """
@@ -87,7 +87,7 @@ class TestAdminDao(BaseTestCase):
 
         dao_result = dao.assign_new_user(1, data)
 
-        self.assertEqual(({"message": "User is already an Admin."}, 400), dao_result)
+        self.assertEqual((messages.USER_IS_ALREADY_AN_ADMIN, 400), dao_result)
 
 
     """


### PR DESCRIPTION
### Description
##### Added the following tests to existing admin tests: in `tests/admin/test_dao.py`
- Assigning a user which is already an admin -> should receive a message saying that the user is already an admin
- Assigning a user as an admin, when the current user is not an admin -> should receive an error message
- Assigning a non-existent user -> should receive error message
- Revoking a user as an admin, when the current user is not an admin -> should receive an error message

#### Added error messages in `app/api/dao/admin.py`
- Added Error Message if a non admin user tries to assign someone as new admin.
- Added Error Message if a non admin user tries to revoke admin status of someone.


Fixes #206

### Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance
- Documentation

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
`python -m unittest discover tests`

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
