### PR TITLE
feat: created simple bash script to make env setup easier

### DIFF
--- a/export.sh
+++ b/export.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Easy setup - change only what's unique to you
+
+export FLASK_ENVIRONMENT_CONFIG=dev
+export SECRET_KEY='some random key'
+export SECURITY_PASSWORD_SALT='some password salt'
+export MAIL_DEFAULT_SENDER='username@gmail.com' # replace with the Gmail account address that you created
+export MAIL_SERVER='smtp.gmail.com'
+export APP_MAIL_USERNAME='username' # replace with the part of the email before "@"
+export APP_MAIL_PASSWORD='password' # replace with password to the email


### PR DESCRIPTION
### Description
When dealing with the setup of this server, I had to export env variables. Then I closed my terminal and opened it again, and all me env vars vanished because they're session-specific. So I created this simple script that you use like this:

- copy `export.sh` and rename the copy - to, for example, `my_export.sh` *
- customize the script file (the copied one) - replace values in code with your own values for email address, password, etc.
- run it: `source ./my_export.sh`


*You should do that because everybody has theirs own emails. Also, don't add that copy to `git`.

### Type of Change:
A little thing that may make somebody's life easier.

- Code

**Code/Quality Assurance Only**
- New feature



### How Has This Been Tested?
I've tested it with my clean project installation, works fine.


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
