### PR TITLE
style: fix typo on line 11 of deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -8,7 +8,7 @@ fi
 
 # Travis build triggered by a PR
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-    echo "Skip publising, just a PR."
+    echo "Skip publishing, just a PR."
     exit 0
 fi
 


### PR DESCRIPTION
### Description
Fixed a typo on line 11 of deploy.sh: "publising" -> "publishing"

Fixes #231

### Type of Change:

- Code

**Code/Quality Assurance Only**

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My PR follows the style guidelines of this project

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
