### PR TITLE
style: fix typo on line 11 of deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -8,7 +8,7 @@ fi
 
 # Travis build triggered by a PR
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-    echo "Skip publising, just a PR."
+    echo "Skip publishing, just a PR."
     exit 0
 fi
 


### PR DESCRIPTION
### Description 
Fixed the typo on line 11 of deploy.sh: "publising" to "publishing" 

Fixes #231

 ### Type of Change:
 - Code 

**Code/Quality Assurance Only** 

- Bug fix (non-breaking change which fixes an issue) 

### Checklist: 
- [ ] My PR follows the style guidelines of this project 
- [ ] I have performed a self-review of my own code or materials 

**Code/Quality Assurance Only** 
- [ ] My changes generate no new warnings