### PR TITLE
fix: Fix typo in user creation success message

### DIFF
--- a/app/messages.py
+++ b/app/messages.py
@@ -174,7 +174,7 @@ TASK_WAS_ACHIEVED_SUCCESSFULLY = {"message": "Task was achieved"
                                           " successfully."}
 USER_WAS_CREATED_SUCCESSFULLY = {"message": "User was created successfully."
                                  "A confirmation email has been sent via"
-                                 " email.After confirming your email you "
+                                 " email. After confirming your email you "
                                  "can login."}
 ACCEPT_MENTORSHIP_RELATIONS_WITH_SUCCESS = {"message": "Accept mentorship"
                                             " relations with success."}


### PR DESCRIPTION
### Description
Space was added between second and third sentences of USER_WAS_CREATED_SUCCESSFULLY variable in app/messages.py. 

Fixes #225 

### Type of Change:
**Delete irrelevant options.**

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
1. Performed unit test
```sh
python -m unittest discover tests
```
2. Tested output by creating new user.
![image](https://user-images.githubusercontent.com/50169911/70030389-2320ff00-15cf-11ea-9bc9-15e16910f832.png)

### Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials


**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
