### PR TITLE
[Program: GCI] style: Remove pep8 warnings in task.py

### DIFF
--- a/app/api/dao/task.py
+++ b/app/api/dao/task.py
@@ -15,7 +15,8 @@ class TaskDAO:
     def create_task(user_id, mentorship_relation_id, data):
         """Creates a new task.
 
-        Creates a new task in a mentorship relation if the specified user is already involved in it.
+        Creates a new task in a mentorship relation if the specified user
+        is already involved in it.
 
         Args:
             user_id: The id of the user.
@@ -23,15 +24,19 @@ class TaskDAO:
             data: A list containing the description of the task.
 
         Returns:
-            A two element list where the first element is a dictionary containing a key 'message' indicating
-            in its value if the task creation was succesful or not as a string. The last element is the HTTP
+            A two element list where the first element is a
+            dictionary containing a key 'message' indicating
+            in its value if the task creation was succesful
+            or not as a string. The last element is the HTTP
             response code.
         """
 
         description = data['description']
 
         user = UserModel.find_by_id(user_id)
-        relation = MentorshipRelationModel.find_by_id(_id=mentorship_relation_id)
+        relation = MentorshipRelationModel.find_by_id(
+            _id=mentorship_relation_id
+        )
         if relation is None:
             return messages.MENTORSHIP_RELATION_DOES_NOT_EXIST, 404
 
@@ -39,7 +44,9 @@ class TaskDAO:
             return messages.UNACCEPTED_STATE_RELATION, 400
 
         now_timestamp = datetime.now().timestamp()
-        relation.tasks_list.add_task(description=description, created_at=now_timestamp)
+        relation.tasks_list.add_task(
+            description=description, created_at=now_timestamp
+        )
         relation.tasks_list.save_to_db()
 
         return messages.TASK_WAS_CREATED_SUCCESSFULLY, 200
@@ -49,16 +56,20 @@ class TaskDAO:
     def list_tasks(user_id, mentorship_relation_id):
         """Retrieves all tasks of a user in a mentorship relation.
 
-        Lists all tasks from a mentorship relation for the specified user if the user is involved in a current mentorship relation.
+        Lists all tasks from a mentorship relation for the specified user if
+        the user is involved in a current mentorship relation.
 
         Args:
             user_id: The id of the user.
             mentorship_relation_id: The id of the mentorship relation.
 
         Returns:
-            A list containing all the tasks one user has in a mentorship relation. otherwise, it returns a two element list where the first element is
-            a dictionary containing a key 'message' indicating in its value if there were any problem finding user's tasks in the specified
-            mentorship relation as a string. The last element is the HTTP response code
+            A list containing all the tasks one user has in a mentorship
+            relation. otherwise, it returns a two element list where the
+            first element is a dictionary containing a key 'message'
+            indicating in its value if there were any problem finding
+            user's tasks in the specified mentorship relation as a string.
+            The last element is the HTTP response code
         """
 
         user = UserModel.find_by_id(user_id)
@@ -66,7 +77,9 @@ class TaskDAO:
         if relation is None:
             return messages.MENTORSHIP_RELATION_DOES_NOT_EXIST, 404
 
-        if not (user_id == relation.mentee_id or user_id == relation.mentor_id):
+        if not (
+            user_id == relation.mentee_id or user_id == relation.mentor_id
+        ):
             return messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION, 401
 
         all_tasks = relation.tasks_list.tasks
@@ -87,8 +100,10 @@ class TaskDAO:
             task_id: The id of the task.
 
         Returns:
-            A two element list where the first element is a dictionary containing a key 'message' indicating in its value if the
-            task was deleted succesfully or not as a string. The last element is the HTTP response code.
+            A two element list where the first element is a
+            dictionary containing a key 'message' indicating in
+            its value if the task was deleted succesfully or not as
+            a string. The last element is the HTTP response code.
         """
 
         user = UserModel.find_by_id(user_id)
@@ -100,7 +115,9 @@ class TaskDAO:
         if task is None:
             return messages.TASK_DOES_NOT_EXIST, 404
 
-        if not (user_id == relation.mentee_id or user_id == relation.mentor_id):
+        if not (
+            user_id == relation.mentee_id or user_id == relation.mentor_id
+        ):
             return messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION, 401
 
         relation.tasks_list.delete_task(task_id)
@@ -112,8 +129,8 @@ class TaskDAO:
     def complete_task(user_id, mentorship_relation_id, task_id):
         """Marks a task as completed.
 
-        Updates the task that belongs to a user who is involved in the specified
-        mentorship relation to finished task status.
+        Updates the task that belongs to a user who is involved in the
+        specified mentorship relation to finished task status.
 
         Args:
             user_id: The id of the user.
@@ -121,8 +138,10 @@ class TaskDAO:
             task_id: The id of the task.
 
         Returns:
-            A two element list where the first element is a dictionary containing a key 'message' indicating in its value
-            if the task was set to complete succesfully or not as a string. The last element is the HTTP response code.
+            A two element list where the first element is a dictionary
+            containing a key 'message' indicating in its valueif the
+            task was set to complete succesfully or not as a string.
+            The last element is the HTTP response code.
         """
 
         user = UserModel.find_by_id(user_id)
@@ -130,7 +149,9 @@ class TaskDAO:
         if relation is None:
             return messages.MENTORSHIP_RELATION_DOES_NOT_EXIST, 404
 
-        if not (user_id == relation.mentee_id or user_id == relation.mentor_id):
+        if not (
+            user_id == relation.mentee_id or user_id == relation.mentor_id
+        ):
             return messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION, 401
 
         task = relation.tasks_list.find_task_by_id(task_id)
@@ -141,6 +162,8 @@ class TaskDAO:
             return messages.TASK_WAS_ALREADY_ACHIEVED, 400
         else:
             relation.tasks_list.update_task(
-                task_id=task_id, is_done=True, completed_at=datetime.now().timestamp())
+                task_id=task_id, is_done=True,
+                completed_at=datetime.now().timestamp()
+            )
 
         return messages.TASK_WAS_ACHIEVED_SUCCESSFULLY, 200


### PR DESCRIPTION
### Description
app/api/dao/task.py made PEP8 compatible. Various warnings fixed:
- W291 trailing whitespace 
- E501 line too long

Fixes task.py for #177 

### Type of Change:
- Code
- Quality Assurance

### How Has This Been Tested?
1. Tested code with pep8 and made appropriate changes
```sh
pep8 app/api/dao/task.py
```
- before
![image](https://user-images.githubusercontent.com/50169911/70047941-1ca27f80-15ef-11ea-910c-688b041101b9.png)
- after
![image](https://user-images.githubusercontent.com/50169911/70047987-3cd23e80-15ef-11ea-8c09-66a8545b0557.png)

2. performed unit test
```sh
python -m unittest discover tests
```
![image](https://user-images.githubusercontent.com/50169911/70048082-7efb8000-15ef-11ea-9fd7-819942748c86.png)

### Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] My changes generate no new warnings 
- [ ] I have added tests that prove my fix is effective or that my feature works
