### PR TITLE
[Program: GCI] test: add test for user deleting a non-existent task

### DIFF
--- a/tests/tasks/test_api_delete_task.py
+++ b/tests/tasks/test_api_delete_task.py
@@ -16,6 +16,31 @@ class TestDeleteTaskApi(TasksBaseTestCase):
         self.assertEqual(401, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
+    def test_delete_task_non_existent_list_1(self):
+        expected_response = messages.TASK_DOES_NOT_EXIST 
+        auth_header = get_test_request_header(self.first_user.id)
+        next_task_id=self.tasks_list_1.next_task_id
+        # next_task_id is the value to be assigned, it's not yet assigned
+        # relation with second user
+        actual_response = self.client.delete('/mentorship_relation/%s/task/%s'
+                                             % (self.mentorship_relation_w_second_user.id, next_task_id),
+                                             follow_redirects=True, headers=auth_header)
+
+        self.assertEqual(404, actual_response.status_code)
+        self.assertDictEqual(expected_response, json.loads(actual_response.data))
+
+    def test_delete_task_non_existent_list_2(self):
+        expected_response = messages.TASK_DOES_NOT_EXIST 
+        auth_header = get_test_request_header(self.first_user.id)
+        next_task_id=self.tasks_list_2.next_task_id
+        # relation with admin user
+        actual_response = self.client.delete('/mentorship_relation/%s/task/%s'
+                                             % (self.mentorship_relation_w_admin_user.id, next_task_id),
+                                             follow_redirects=True, headers=auth_header)
+
+        self.assertEqual(404, actual_response.status_code)
+        self.assertDictEqual(expected_response, json.loads(actual_response.data))
+
     def test_full_task_deletion_api(self):
 
         existent_task = self.tasks_list_1.find_task_by_id(2)


### PR DESCRIPTION
### Description
Two unit tests added for when a user tries to delete a non existing task. In such a case **TASK_DOES_NOT_EXIST** message and **404** response case is returned. 
![image](https://user-images.githubusercontent.com/50169911/70067071-bf6cf500-1613-11ea-88d6-e60b333289f2.png)

To find a non-existent task id two parameters **self.tasks_list_1.next_task_id** and **self.tasks_list_2.next_task_id** were used. **next_task_id** will always return a non-existent task_id.     
Two unit tests created:
1. **test_delete_task_non_existent_list_1**: based on tasks_list_1 and mentorship_relation_w_second_user
2. **test_delete_task_non_existent_list_2**: based on tasks_list_2 and mentorship_relation_w_admin_user

#### test_api_delete_task.py
```py
def test_delete_task_non_existent_list_1(self):
        expected_response = messages.TASK_DOES_NOT_EXIST 
        auth_header = get_test_request_header(self.first_user.id)
        next_task_id=self.tasks_list_1.next_task_id
        # next_task_id is the value to be assigned, it's not yet assigned
        # relation with second user
        actual_response = self.client.delete('/mentorship_relation/%s/task/%s'
                                             % (self.mentorship_relation_w_second_user.id, next_task_id),
                                             follow_redirects=True, headers=auth_header)

        self.assertEqual(404, actual_response.status_code)
        self.assertDictEqual(expected_response, json.loads(actual_response.data))

    def test_delete_task_non_existent_list_2(self):
        expected_response = messages.TASK_DOES_NOT_EXIST 
        auth_header = get_test_request_header(self.first_user.id)
        next_task_id=self.tasks_list_2.next_task_id
        # relation with admin user
        actual_response = self.client.delete('/mentorship_relation/%s/task/%s'
                                             % (self.mentorship_relation_w_admin_user.id, next_task_id),
                                             follow_redirects=True, headers=auth_header)

        self.assertEqual(404, actual_response.status_code)
        self.assertDictEqual(expected_response, json.loads(actual_response.data))
```

Fixes #228

### Type of Change:
- Code
- Quality Assurance


**Code/Quality Assurance Only**
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
Describe the tests you ran to verify your changes. Provide instructions or GIFs so we can reproduce. List any relevant details for your test.
```sh
python -m unittest discover tests
```
![image](https://user-images.githubusercontent.com/50169911/70066522-e1b24300-1612-11ea-9277-d9eb46cdc71f.png)


### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes