### PR TITLE
[Program: GCI] style: typo fix on "account confirmed and thanks"

### DIFF
--- a/app/messages.py
+++ b/app/messages.py
@@ -208,7 +208,7 @@ PASSWORD_SUCCESSFULLY_UPDATED = {"message": "Password was updated "
 ACCOUNT_ALREADY_CONFIRMED = {"message": "Account already confirmed"}
 USER_ALREADY_CONFIRMED_ACCOUNT = {"message": "You already confirm your email"}
 ACCOUNT_ALREADY_CONFIRMED_AND_THANKS = {"message": "You have confirmed your"
-                                        " account.Thanks!"}
+                                        " account. Thanks!"}
 
 # Miscellaneous
 VALIDATION_ERROR = {"message": "Validation error."}


### PR DESCRIPTION
### Description
Edit message ACCOUNT_ALREADY_CONFIRMED_AND_THANKS to have a space between the 2 sentences

Fixes #226

### Type of Change:

- User Interface
- Documentation

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials