### PR TITLE
test: delete_task error on invalid task

### DIFF
--- a/tests/tasks/test_api_delete_task.py
+++ b/tests/tasks/test_api_delete_task.py
@@ -33,6 +33,16 @@ class TestDeleteTaskApi(TasksBaseTestCase):
         deleted_task = self.tasks_list_1.find_task_by_id(2)
         self.assertIsNone(deleted_task)
 
+    def test_delete_task_api_non_existing_task(self):
+        auth_header = get_test_request_header(self.first_user.id)
+        expected_response = messages.TASK_DOES_NOT_EXIST
+        actual_response = self.client.delete('/mentorship_relation/%s/task/%s'
+                                             % (self.mentorship_relation_w_second_user.id, 0),
+                                             follow_redirects=True, headers=auth_header)
+
+        self.assertEqual(404, actual_response.status_code)
+        self.assertDictEqual(expected_response, json.loads(actual_response.data))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description
A test to validate whether 'delete_task' will throw a TASK_DOES_NOT_EXIST error upon an invalid task. In this instance, the unused task #0 is used to test whether the api throws the correct error.

Fixes #228

### Type of Change:
- Code
- Quality Assurance

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
Unit test performed
`python test_api_delete_task.py`

![Screenshot 2019-12-03 at 18 46 20](https://user-images.githubusercontent.com/11770524/70079684-1e733f80-15fd-11ea-8b28-f56e79bac47f.png)


### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes

