### PR TITLE
feat: add password confirmation functionality in POST /register

### DIFF
--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -32,9 +32,11 @@ class UserDAO:
         name = data['name']
         username = data['username']
         password = data['password']
+        confirm_password = data['confirm_password']
         email = data['email']
         terms_and_conditions_checked = data['terms_and_conditions_checked']
-
+        if (password!=confirm_password):
+            return messages.PASSWORD_CONFIRMATION_MISMATCH, 400
         existing_user = UserModel.find_by_username(data['username'])
         if existing_user:
             return messages.USER_USES_A_USERNAME_THAT_ALREADY_EXISTS, 400

--- a/app/api/models/user.py
+++ b/app/api/models/user.py
@@ -139,6 +139,7 @@ register_user_api_model = Model('User registration model', {
     'name': fields.String(required=True, description='User name'),
     'username': fields.String(required=True, description='User username'),
     'password': fields.String(required=True, description='User password'),
+    'confirm_password': fields.String(required=True, description='Confirm password'),
     'email': fields.String(required=True, description='User email'),
     'terms_and_conditions_checked': fields.Boolean(required=True, description='User check Terms and Conditions value'),
     'need_mentoring': fields.Boolean(required=False, description='User need mentoring indication'),

--- a/app/messages.py
+++ b/app/messages.py
@@ -213,3 +213,6 @@ ACCOUNT_ALREADY_CONFIRMED_AND_THANKS = {"message": "You have confirmed your"
 # Miscellaneous
 VALIDATION_ERROR = {"message": "Validation error."}
 NOT_IMPLEMENTED = {"message": "Not implemented."}
+
+# Password confirmation
+PASSWORD_CONFIRMATION_MISMATCH={"message": "The 2 password fields do not match."}


### PR DESCRIPTION
### Description
Password confirmation functionality added.

**Working**
1. PASSWORD_CONFIRMATION_MISMATCH added in messages.py
2. confirm_password field added in app/api/models/user.py under register_user_api_model
3. password and confirm_password matched in app/api/dao/user.py . 400 response with message sent if they don't match

Fixes #252 

### Type of Change:
- Code


**Code/Quality Assurance Only**
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
Screenshots
1. Successful registration
![task18_3](https://user-images.githubusercontent.com/50169911/70719542-3727d780-1d18-11ea-87fc-d2fa17f2aa47.png)
![task18_4](https://user-images.githubusercontent.com/50169911/70719549-398a3180-1d18-11ea-8421-48eaea857df9.png)

2. Unsuccessful registration (duplicate password)
![task18_5](https://user-images.githubusercontent.com/50169911/70719584-473fb700-1d18-11ea-9044-2fb006ddaf17.png)
![task18_6](https://user-images.githubusercontent.com/50169911/70719586-49097a80-1d18-11ea-9b53-d31d60d1e03f.png)

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
One unit test failed because confirm_password field was not in test
```sh
python -m unittest discover tests
```
```sh
/home/shardul/Desktop/Dak/mentorship-backend/venv/lib/python3.7/site-packages/sqlalchemy/util/langhelpers.py:374: DeprecationWarning: `formatargspec` is deprecated since Python 3.5. Use `signature` and the `Signature` object directly
  args = inspect.formatargspec(*spec)
/home/shardul/Desktop/Dak/mentorship-backend/venv/lib/python3.7/site-packages/sqlalchemy/util/langhelpers.py:384: DeprecationWarning: `formatargspec` is deprecated since Python 3.5. Use `signature` and the `Signature` object directly
  spec[2], None, spec[4])
/home/shardul/Desktop/Dak/mentorship-backend/venv/lib/python3.7/site-packages/sqlalchemy/util/langhelpers.py:405: DeprecationWarning: `formatargspec` is deprecated since Python 3.5. Use `signature` and the `Signature` object directly
  formatvalue=lambda x: '=' + x)
.........................................................................................................................EEEF.........E....................................................
======================================================================
ERROR: test_user_registration_mentee (users.test_api_resources.TestUserRegistrationApi)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.7/unittest/mock.py", line 1255, in patched
    return func(*args, **keywargs)
  File "/home/shardul/Desktop/Dak/mentorship-backend/tests/users/test_api_resources.py", line 97, in test_user_registration_mentee
    self.assertTrue(user.need_mentoring)
AttributeError: 'NoneType' object has no attribute 'need_mentoring'

======================================================================
ERROR: test_user_registration_mentor (users.test_api_resources.TestUserRegistrationApi)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.7/unittest/mock.py", line 1255, in patched
    return func(*args, **keywargs)
  File "/home/shardul/Desktop/Dak/mentorship-backend/tests/users/test_api_resources.py", line 81, in test_user_registration_mentor
    self.assertFalse(user.need_mentoring)
AttributeError: 'NoneType' object has no attribute 'need_mentoring'

======================================================================
ERROR: test_user_registration_with_both_optional_fields (users.test_api_resources.TestUserRegistrationApi)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.7/unittest/mock.py", line 1255, in patched
    return func(*args, **keywargs)
  File "/home/shardul/Desktop/Dak/mentorship-backend/tests/users/test_api_resources.py", line 65, in test_user_registration_with_both_optional_fields
    self.assertTrue(user.need_mentoring)
AttributeError: 'NoneType' object has no attribute 'need_mentoring'

======================================================================
ERROR: test_dao_create_user (users.test_dao.TestUserDao)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/shardul/Desktop/Dak/mentorship-backend/tests/users/test_dao.py", line 28, in test_dao_create_user
    dao.create_user(data)
  File "/home/shardul/Desktop/Dak/mentorship-backend/app/api/dao/user.py", line 35, in create_user
    confirm_password = data['confirm_password']
KeyError: 'confirm_password'

======================================================================
FAIL: test_user_registration_without_optional_fields (users.test_api_resources.TestUserRegistrationApi)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.7/unittest/mock.py", line 1255, in patched
    return func(*args, **keywargs)
  File "/home/shardul/Desktop/Dak/mentorship-backend/tests/users/test_api_resources.py", line 40, in test_user_registration_without_optional_fields
    self.fail('POST /register failed to register Testing User! with error code = %d' % response.status_code)
AssertionError: POST /register failed to register Testing User! with error code = 400

----------------------------------------------------------------------
Ran 187 tests in 15.219s

FAILED (failures=1, errors=4)
```
