### PR TITLE
added requires_approval property to TaskModel

### DIFF
--- a/app/api/dao/task.py
+++ b/app/api/dao/task.py
@@ -142,8 +142,8 @@ class TaskDAO:
         if task is None:
             return messages.TASK_DOES_NOT_EXIST, 404
 
-        if user_id == relation.mentee_id and task.requires_approval:
-            return messages.TASK_REQUIRES_APPROVAL, 401
+        if user_id == relation.mentee_id and task.get('requires_approval'):
+            return messages.TASK_REQUIRES_APPROVAL, 403
 
         if task.get('is_done'):
             return messages.TASK_WAS_ALREADY_ACHIEVED, 400

--- a/app/api/models/mentorship_relation.py
+++ b/app/api/models/mentorship_relation.py
@@ -29,16 +29,20 @@ mentorship_request_response_body = Model('List mentorship relation request model
     'sent_by_me': fields.Boolean(required=True, description='Mentorship relation sent by current user indication'),
     'mentor': fields.Nested(relation_user_response_body),
     'mentee': fields.Nested(relation_user_response_body),
-    'creation_date': fields.Float(required=True, description='Mentorship relation creation date in UNIX timestamp format'),
-    'accept_date': fields.Float(required=True, description='Mentorship relation acceptance date in UNIX timestamp format'),
+    'creation_date': fields.Float(required=True,
+                                  description='Mentorship relation creation date in UNIX timestamp format'),
+    'accept_date': fields.Float(required=True,
+                                description='Mentorship relation acceptance date in UNIX timestamp format'),
     'start_date': fields.Float(required=True, description='Mentorship relation start date in UNIX timestamp format'),
     'end_date': fields.Float(required=True, description='Mentorship relation end date in UNIX timestamp format'),
-    'state': fields.Integer(required=True, enum=MentorshipRelationState.values, description='Mentorship relation state'),
+    'state': fields.Integer(required=True, enum=MentorshipRelationState.values,
+                            description='Mentorship relation state'),
     'notes': fields.String(required=True, description='Mentorship relation notes')
 })
 
 create_task_request_body = Model('Create task request model', {
-    'description': fields.String(required=True, description='Mentorship relation task description')
+    'description': fields.String(required=True, description='Mentorship relation task description'),
+    'requires_approval': fields.Boolean(required=False, description='If true, only mentor can mark task as completed.')
 })
 
 list_tasks_response_body = Model('List tasks response model', {
@@ -46,5 +50,6 @@ list_tasks_response_body = Model('List tasks response model', {
     'description': fields.String(required=True, description='Mentorship relation task description'),
     'is_done': fields.Boolean(required=True, description='Mentorship relation task is done indication'),
     'created_at': fields.Float(required=True, description='Task creation date in UNIX timestamp format'),
-    'completed_at': fields.Float(required=False, description='Task completion date in UNIX timestamp format')
+    'completed_at': fields.Float(required=False, description='Task completion date in UNIX timestamp format'),
+    'requires_approval': fields.Boolean(required=False, description='If true, only mentor can mark task as completed.')
 })

--- a/app/database/models/tasks_list.py
+++ b/app/database/models/tasks_list.py
@@ -40,7 +40,7 @@ class TasksListModel(db.Model):
             else:
                 raise ValueError(TypeError)
 
-    def add_task(self, description, created_at, is_done=False, completed_at=None):
+    def add_task(self, description, created_at, is_done=False, completed_at=None, requires_approval=False):
         """Adds a task to the list of tasks.
         
         Args:
@@ -48,6 +48,7 @@ class TasksListModel(db.Model):
             created_at: Date on which the task is created.
             is_done: Boolean specifying completion of the task.
             completed_at: Date on which task is completed.
+            requires_approval:  Boolean specifying whether mentee can mark task as completed on his own.
         """
 
         task = {
@@ -55,7 +56,8 @@ class TasksListModel(db.Model):
             TasksFields.DESCRIPTION.value: description,
             TasksFields.IS_DONE.value: is_done,
             TasksFields.CREATED_AT.value: created_at,
-            TasksFields.COMPLETED_AT.value: completed_at
+            TasksFields.COMPLETED_AT.value: completed_at,
+            TasksFields.REQUIRES_APPROVAL.value: requires_approval
         }
         self.next_task_id += 1
         self.tasks = self.tasks + [task]
@@ -151,7 +153,7 @@ class TasksListModel(db.Model):
             A string representation of the task object.
         """
         
-        return "Task | id = %s; tasks = %s; next task id = %s" % (self.id, self.tasks, self.next_task_id)
+        return f"Task | id = {self.id}; tasks = {self.tasks}; next task id = {self.next_task_id}"
 
     @classmethod
     def find_by_id(cls, _id):
@@ -184,6 +186,7 @@ class TasksFields(Enum):
         IS_DONE: Boolean specifying the completion of the task.
         COMPLETED_AT: The date on which the task is completed.
         CREATED_AT: The date on which the task was created.
+        REQUIRES_APPROVAL: Boolean specifying whether mentee can mark task as completed on his own.
     """
 
     ID = 'id'
@@ -191,6 +194,7 @@ class TasksFields(Enum):
     IS_DONE = 'is_done'
     COMPLETED_AT = 'completed_at'
     CREATED_AT = 'created_at'
+    REQUIRES_APPROVAL = 'requires_approval'
 
     def values(self):
         """Returns a list containing a task."""

--- a/app/messages.py
+++ b/app/messages.py
@@ -21,6 +21,7 @@ USER_NOT_FOUND = {"message": "User not found."}
 MENTOR_DOES_NOT_EXIST = {"message": "Mentor user does not exist."}
 MENTEE_DOES_NOT_EXIST = {"message": "Mentee user does not exist."}
 TASK_DOES_NOT_EXIST = {"message": "Task does not exist."}
+TASK_REQUIRES_APPROVAL = {"message": "Task requires mentor's approval."}
 USER_DOES_NOT_EXIST = {"message": "User does not exist"}
 
 # Missing fields

--- a/tests/tasks/tasks_base_setup.py
+++ b/tests/tasks/tasks_base_setup.py
@@ -108,6 +108,11 @@ class TasksBaseTestCase(BaseTestCase):
             is_done=True,
             completed_at=self.end_date_example.timestamp()
         )
+        self.tasks_list_1.add_task(
+            description=self.description_example,
+            created_at=self.now_datetime.timestamp(),
+            requires_approval=True
+        )
         self.tasks_list_2.add_task(
             description=self.description_example,
             created_at=self.now_datetime.timestamp()

--- a/tests/tasks/test_api_create_task.py
+++ b/tests/tasks/test_api_create_task.py
@@ -18,7 +18,7 @@ class TestCreateTaskApi(TasksBaseTestCase):
 
     def test_full_task_creation_api(self):
 
-        non_existent_task = self.tasks_list_1.find_task_by_id(3)
+        non_existent_task = self.tasks_list_1.find_task_by_id(4)
         self.assertIsNone(non_existent_task)
 
         auth_header = get_test_request_header(self.first_user.id)
@@ -30,7 +30,7 @@ class TestCreateTaskApi(TasksBaseTestCase):
         self.assertEqual(200, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
-        new_task = self.tasks_list_1.find_task_by_id(3)
+        new_task = self.tasks_list_1.find_task_by_id(4)
         self.assertIsNotNone(new_task)
         self.assertEqual(self.test_description, new_task.get('description'))
         self.assertEqual(self.test_is_done, new_task.get('is_done'))

--- a/tests/tasks/test_dao_complete_task.py
+++ b/tests/tasks/test_dao_complete_task.py
@@ -37,6 +37,19 @@ class TestCompleteTasksDao(TasksBaseTestCase):
 
         self.assertEqual(expected_response, actual_response)
 
+    def test_achieve_not_approved_task(self):
+        task = self.tasks_list_1.find_task_by_id(3)
+
+        self.assertFalse(self.tasks_list_1.find_task_by_id(3).get('is_done'))
+
+        expected_response = messages.TASK_REQUIRES_APPROVAL, 403
+        actual_response = TaskDAO.complete_task(self.second_user.id,
+                                                self.mentorship_relation_w_second_user.id,
+                                                3)
+
+        self.assertFalse(self.tasks_list_1.find_task_by_id(3).get('is_done'))
+        self.assertEqual(expected_response, actual_response)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/tasks/test_dao_create_task.py
+++ b/tests/tasks/test_dao_create_task.py
@@ -12,7 +12,7 @@ class TestListTasksDao(TasksBaseTestCase):
 
         expected_response = messages.TASK_WAS_CREATED_SUCCESSFULLY, 200
 
-        non_existent_task = self.tasks_list_1.find_task_by_id(3)
+        non_existent_task = self.tasks_list_1.find_task_by_id(4)
         self.assertIsNone(non_existent_task)
 
         actual_response = TaskDAO.create_task(user_id=self.first_user.id,
@@ -20,7 +20,7 @@ class TestListTasksDao(TasksBaseTestCase):
                                               data=dict(description=self.test_description, is_done=self.test_is_done))
         self.assertEqual(expected_response, actual_response)
 
-        new_task = self.tasks_list_1.find_task_by_id(3)
+        new_task = self.tasks_list_1.find_task_by_id(4)
         self.assertIsNotNone(new_task)
         self.assertEqual(self.test_description, new_task.get('description'))
         self.assertEqual(self.test_is_done, new_task.get('is_done'))

--- a/tests/tasks/test_tasks_list_database_model.py
+++ b/tests/tasks/test_tasks_list_database_model.py
@@ -10,7 +10,6 @@ class TestTasksListModel(BaseTestCase):
 
     def setUp(self):
         super(TestTasksListModel, self).setUp()
-
         self.empty_tasks_list = TasksListModel()
         self.tasks_list_1 = TasksListModel()
         db.session.add(self.empty_tasks_list)
@@ -45,7 +44,8 @@ class TestTasksListModel(BaseTestCase):
             created_at=self.now_timestamp,
             description=self.test_description_1,
             id=1,
-            is_done=False
+            is_done=False,
+            requires_approval=False
         )
 
         self.assertEqual([expected_task_1], tasks_list_one.tasks)
@@ -57,7 +57,8 @@ class TestTasksListModel(BaseTestCase):
             created_at=self.now_timestamp,
             description=self.test_description_1,
             id=2,
-            is_done=False
+            is_done=False,
+            requires_approval=False
         )
 
         self.assertEqual([expected_task_1, expected_task_2], tasks_list_one.tasks)
@@ -75,7 +76,8 @@ class TestTasksListModel(BaseTestCase):
             created_at=self.now_timestamp,
             description=self.test_description_1,
             id=1,
-            is_done=False
+            is_done=False,
+            requires_approval=False
         )
 
         self.assertEqual([expected_task_1], tasks_list_one.tasks)
@@ -93,7 +95,8 @@ class TestTasksListModel(BaseTestCase):
             created_at=self.now_timestamp,
             description=self.test_description_1,
             id=1,
-            is_done=False
+            is_done=False,
+            requires_approval=False
         )
 
         self.assertEqual([expected_task_1], tasks_list_two.tasks)
@@ -118,14 +121,16 @@ class TestTasksListModel(BaseTestCase):
             created_at=self.now_timestamp,
             description=self.test_description_1,
             id=1,
-            is_done=False
+            is_done=False,
+            requires_approval=False
         )
         expected_task_2 = dict(
             completed_at=None,
             created_at=self.now_timestamp,
             description=self.test_description_2,
             id=2,
-            is_done=False
+            is_done=False,
+            requires_approval=False
         )
 
         tasks_list_one.add_task(self.test_description_1, self.now_timestamp)

--- a/tests/users/test_api_home_statistics.py
+++ b/tests/users/test_api_home_statistics.py
@@ -243,7 +243,8 @@ class TestHomeStatisticsApi(BaseTestCase):
                 'created_at': task_created_time,
                 'description': 'Test task',
                 'id': 1,  # This is the only task in the list
-                'is_done': True
+                'is_done': True,
+                'requires_approval': False
             }]
         }
         auth_header = get_test_request_header(self.user1.id)

--- a/tests/users/test_dao.py
+++ b/tests/users/test_dao.py
@@ -302,13 +302,15 @@ class TestUserDao(BaseTestCase):
             'created_at': start_date.timestamp(),
             'description': 'Test Task',
             'id': 1,  # This is the first task in the list
-            'is_done': True
+            'is_done': True,
+            'requires_approval': False
         }, {
             'completed_at': end_date.timestamp(),
             'created_at': start_date.timestamp(),
             'description': 'Test Task 2',
             'id': 2,  # This is the second task in the list
-            'is_done': True
+            'is_done': True,
+            'requires_approval': False
         }]
         actual_response = dao.get_user_statistics(mentor.id)
         self.assertEqual(expected_response, actual_response)


### PR DESCRIPTION
### Description
Task has got new property `requires_approval: [bool]`. If it's set to `True` during creation, task becomes "restricted" - i.e only mentor can mark it as done/completed. When mentee tries to mark it as done, he get's `401 Unauthorized`.

Fixes #278

### Type of Change:

- Code

**Code/Quality Assurance Only**
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
Added new unit test to ensure that mentee can't mark task which `requires_approval: True` as completed.

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
