### PR TITLE
[Program: GCI] Display email ID of Registered Users at /users [Mentorship - Backend]

### DIFF
--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -32,6 +32,7 @@ class UserDAO:
         name = data['name']
         username = data['username']
         password = data['password']
+        confirm_password = data['confirm_password']
         email = data['email']
         terms_and_conditions_checked = data['terms_and_conditions_checked']
 
@@ -42,6 +43,8 @@ class UserDAO:
             existing_user = UserModel.find_by_email(data['email'])
             if existing_user:
                 return messages.USER_USES_AN_EMAIL_ID_THAT_ALREADY_EXISTS, 400
+            elif confirm_password != password:
+                return messages.PASSWORD_CONFIRMATION_MISMATCH, 400
 
         user = UserModel(name, username, password, email, terms_and_conditions_checked)
         if 'need_mentoring' in data:

--- a/app/api/models/user.py
+++ b/app/api/models/user.py
@@ -24,6 +24,10 @@ public_user_api_model = Model('User list model', {
         required=True,
         description='User username'
     ),
+    'email': fields.String(
+        required=True,
+        description='User email'
+    ),
     'name': fields.String(
         required=True,
         description='User name'
@@ -139,6 +143,7 @@ register_user_api_model = Model('User registration model', {
     'name': fields.String(required=True, description='User name'),
     'username': fields.String(required=True, description='User username'),
     'password': fields.String(required=True, description='User password'),
+    'confirm_password': fields.String(required=True, description='Confirm user password'),
     'email': fields.String(required=True, description='User email'),
     'terms_and_conditions_checked': fields.Boolean(required=True, description='User check Terms and Conditions value'),
     'need_mentoring': fields.Boolean(required=False, description='User need mentoring indication'),

--- a/app/messages.py
+++ b/app/messages.py
@@ -10,6 +10,7 @@ FIELD_NEED_MENTORING_IS_NOT_VALID = {"message": "Field need_mentoring is"
                                      " not valid."}
 FIELD_AVAILABLE_TO_MENTOR_IS_INVALID = {"message": "Field available_to_mentor"
                                         " is not valid."}
+PASSWORD_CONFIRMATION_MISMATCH = {"message": "The 2 password fields do not match."}
 
 # Not found
 MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST = {"message": "This mentorship"

--- a/tests/users/test_api_resources.py
+++ b/tests/users/test_api_resources.py
@@ -31,6 +31,7 @@ class TestUserRegistrationApi(BaseTestCase):
                 name=user1['name'],
                 username=user1['username'],
                 password=user1['password'],
+                confirm_password=user1['password'],
                 email=user1['email'],
                 terms_and_conditions_checked=user1['terms_and_conditions_checked']
             )), follow_redirects=True, content_type='application/json')
@@ -55,6 +56,7 @@ class TestUserRegistrationApi(BaseTestCase):
                 name=user1['name'],
                 username=user1['username'],
                 password=user1['password'],
+                confirm_password=user1['password'],
                 email=user1['email'],
                 terms_and_conditions_checked=user1['terms_and_conditions_checked'],
                 available_to_mentor=user1['available_to_mentor'],
@@ -72,6 +74,7 @@ class TestUserRegistrationApi(BaseTestCase):
                 name=user1['name'],
                 username=user1['username'],
                 password=user1['password'],
+                confirm_password=user1['password'],
                 email=user1['email'],
                 terms_and_conditions_checked=user1['terms_and_conditions_checked'],
                 available_to_mentor=user1['available_to_mentor'],
@@ -88,6 +91,7 @@ class TestUserRegistrationApi(BaseTestCase):
                 name=user1['name'],
                 username=user1['username'],
                 password=user1['password'],
+                confirm_password=user1['password'],
                 email=user1['email'],
                 terms_and_conditions_checked=user1['terms_and_conditions_checked'],
                 need_mentoring=user1['need_mentoring']

--- a/tests/users/test_dao.py
+++ b/tests/users/test_dao.py
@@ -23,6 +23,7 @@ class TestUserDao(BaseTestCase):
             username='user2',
             email='user2@email.com',
             password='test_password',
+            confirm_password='test_password',
             terms_and_conditions_checked=True
         )
         dao.create_user(data)


### PR DESCRIPTION
### Description
The API call to /users now shows email id of users.

Please refer to PR: https://github.com/systers/mentorship-backend/pull/271 for password confirmation screenshots.

NOTE: this commit includes code for both password confirmation and /users email show

### Type of Change:
- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
This was tested on the local URL. Here's a screenshot

click on the screenshot to see a clearer image
![Capture](https://user-images.githubusercontent.com/29257061/71313870-37854880-2465-11ea-9c58-1d888aab13a5.PNG)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged
- [x] Update Postman API at /docs folder
- [x] Update Swagger documentation and the exported file at /docs folder

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
