### PR TITLE
[Program: GCI] Write missing tests for Cancel Mentorship Relation API (Backend)

### DIFF
--- a/tests/mentorship_relation/test_api_cancel_relation.py
+++ b/tests/mentorship_relation/test_api_cancel_relation.py
@@ -9,6 +9,7 @@ from app.database.models.mentorship_relation import MentorshipRelationModel
 from app.utils.enum_utils import MentorshipRelationState
 from tests.mentorship_relation.relation_base_setup import MentorshipRelationBaseTestCase
 from tests.test_utils import get_test_request_header
+from datetime import timedelta
 
 
 class TestCancelMentorshipRelationApi(MentorshipRelationBaseTestCase):
@@ -62,6 +63,42 @@ class TestCancelMentorshipRelationApi(MentorshipRelationBaseTestCase):
             self.assertDictEqual(messages.MENTORSHIP_RELATION_WAS_CANCELLED_SUCCESSFULLY,
                              json.loads(response.data))
 
+    #Valid user tries to cancel valid task with authentication token missing (FAIL)
+    #Response= 401, AUTHORISATION_TOKEN_IS_MISSING
+    def test_cancel_mentorship_relation_noauth(self):
+        self.assertEqual(MentorshipRelationState.ACCEPTED, self.mentorship_relation.state)
+        with self.client:
+            expected_response = messages.AUTHORISATION_TOKEN_IS_MISSING
+            response = self.client.put('/mentorship_relation/%s/cancel' % self.mentorship_relation.id)
+
+            self.assertEqual(401, response.status_code)
+            self.assertDictEqual(expected_response,
+                                 json.loads(response.data))
+
+    #Valid user tries to cancel valid task with authentication token expired (FAIL)
+    #Response= 401, TOKEN_HAS_EXPIRED
+    def test_cancel_mentorship_relation_expiredauth(self):
+        self.assertEqual(MentorshipRelationState.ACCEPTED, self.mentorship_relation.state)
+        with self.client:
+            expected_response = messages.TOKEN_HAS_EXPIRED
+            response = self.client.put('/mentorship_relation/%s/cancel' % self.mentorship_relation.id,
+                                       headers=get_test_request_header(self.second_user.id, token_expiration_delta=timedelta(minutes=-7)))
+
+            self.assertEqual(401, response.status_code)
+            self.assertDictEqual(expected_response,
+                                 json.loads(response.data))
+    #User1 cancel a mentorship relation which the User1 is not involved with (FAIL)
+    #Response= 400, CANT_CANCEL_UNINVOLVED_REQUEST
+    def test_cancel_mentorship_relation_notinvolvedinrelation(self):
+        self.assertEqual(MentorshipRelationState.ACCEPTED, self.mentorship_relation.state)
+        with self.client:
+            expected_response = messages.CANT_CANCEL_UNINVOLVED_REQUEST
+            response = self.client.put('/mentorship_relation/%s/cancel' % self.mentorship_relation.id,
+                                       headers=get_test_request_header(self.admin_user.id))
+
+            self.assertEqual(400, response.status_code)
+            self.assertDictEqual(expected_response,
+                                 json.loads(response.data))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description
Added missing tests in tests/mentorship_relation/test_api_cancel_relation.py file for authorization token.

Fixes #307 

### Type of Change:
- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
I tested it using `python -m unittest discover tests` 

Here's a screenshot of the result
![Capture](https://user-images.githubusercontent.com/29257061/71374960-ae941b80-25e2-11ea-8d43-244a62a4920d.PNG)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged
- [x] Update Postman API at /docs folder
- [x] Update Swagger documentation and the exported file at /docs folder

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
