### PR TITLE
Change password returns error if the current and the new password are equal

### DIFF
--- a/app/api/validations/user.py
+++ b/app/api/validations/user.py
@@ -173,7 +173,11 @@ def validate_new_password(data):
     if 'new_password' not in data:
         return messages.NEW_PASSWORD_FIELD_IS_MISSING
 
+    current_password = data['current_password']
     new_password = data['new_password']
+
+    if current_password == new_password:
+        return messages.USER_ENTERED_CURRENT_PASSWORD
 
     if " " in new_password:
         return messages.USER_INPUTS_SPACE_IN_PASSWORD

--- a/app/messages.py
+++ b/app/messages.py
@@ -135,6 +135,8 @@ MENTORSHIP_RELATION_NOT_IN_ACCEPT_STATE = {"message": "Mentorship relation is"
 
 # Login errors
 USER_ENTERED_INCORRECT_PASSWORD = {"message": "Current password is incorrect."}
+USER_ENTERED_CURRENT_PASSWORD = {"message": "New password should not be same "
+                                            "as the current password."}
 EMAIL_EXPIRED_OR_TOKEN_IS_INVALID = {"message": "The confirmation link is"
                                      " invalid or the token has expired."}
 WRONG_USERNAME_OR_PASSWORD = {"message": "Username or password is wrong."}

--- a/tests/users/test_api_update_user.py
+++ b/tests/users/test_api_update_user.py
@@ -174,6 +174,33 @@ class TestUpdateUserApi(BaseTestCase):
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
         self.assertEqual(test_need_mentoring, self.first_user.need_mentoring)
 
+    def test_change_password_to_current_password(self):
+        self.first_user = UserModel(
+            name=user1['name'],
+            email=user1['email'],
+            username=user1['username'],
+            password=user1['password'],
+            terms_and_conditions_checked=user1['terms_and_conditions_checked']
+        )
+        self.first_user.is_email_verified = True
+        self.first_user.need_mentoring = True
+
+        db.session.add(self.first_user)
+        db.session.commit()
+
+        auth_header = get_test_request_header(self.first_user.id)
+        expected_response = messages.USER_ENTERED_CURRENT_PASSWORD
+        actual_response = self.client.put(
+            '/user/change_password', follow_redirects=True,
+            headers=auth_header,
+            data=json.dumps(dict(current_password=user1['password'],
+                                 new_password=user1['password'])),
+            content_type='application/json')
+
+        self.assertEqual(400, actual_response.status_code)
+        self.assertDictEqual(expected_response,
+                             json.loads(actual_response.data))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/users/test_validation_request_data.py
+++ b/tests/users/test_validation_request_data.py
@@ -196,7 +196,7 @@ class TestUserApiRequestDataValidation(unittest.TestCase):
     def test_user_password_change_request_password_inferior_to_limit(self):
         secure_random = SystemRandom()
         random_generated_password = "".join(secure_random.choice(ascii_lowercase) for x in range(PASSWORD_MIN_LENGTH-1))
-        data = dict(new_password=random_generated_password, current_password=random_generated_password)
+        data = dict(new_password=random_generated_password, current_password=user1['password'])
 
         expected_result = {"message": get_length_validation_error_message("new_password", PASSWORD_MIN_LENGTH, PASSWORD_MAX_LENGTH)}
         actual_result = validate_new_password(data)
@@ -206,7 +206,7 @@ class TestUserApiRequestDataValidation(unittest.TestCase):
     def test_user_password_change_request_password_superior_to_limit(self):
         secure_random = SystemRandom()
         random_generated_password = "".join(secure_random.choice(ascii_lowercase) for x in range(PASSWORD_MAX_LENGTH+1))
-        data = dict(new_password=random_generated_password, current_password=random_generated_password)
+        data = dict(new_password=random_generated_password, current_password=user1['password'])
 
         expected_result = {"message": get_length_validation_error_message("new_password", PASSWORD_MIN_LENGTH, PASSWORD_MAX_LENGTH)}
         actual_result = validate_new_password(data)


### PR DESCRIPTION
### Description
- Chane password returns error if the current and the new password are equal
- Added a new error message
- Added a test for change password function when the new password and the current one are the same
- Needed to change `test_user_password_change_request_password_superior_to_limit` and `test_user_password_change_request_password_inferior_to_limit,` because they were using same passwords

Fixes #319 

### Type of Change:
- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
The code was tested on my laptop.

### Screenshot:
![Screenshot (43)](https://user-images.githubusercontent.com/34242059/71409154-d31ee080-2640-11ea-805a-d37e1925584b.png)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
