### PR TITLE
[Program: GCI] Added query parameter to filter mentorship relations by current state

### DIFF
--- a/app/api/dao/mentorship_relation.py
+++ b/app/api/dao/mentorship_relation.py
@@ -113,7 +113,7 @@ class MentorshipRelationDAO:
 
     @staticmethod
     @email_verification_required
-    def list_mentorship_relations(user_id: int = None, rel_states: List[str] = None):
+    def list_mentorship_relations(user_id: int = None, rel_states = None):
         """Lists all relationships of a given user.
 
         Lists all relationships of a given user.
@@ -136,8 +136,8 @@ class MentorshipRelationDAO:
             setattr(relation, 'sent_by_me', relation.action_user_id == user_id)
 
             if rel_states:
-                for i, s in enumerate(rel_states):
-                    rel_states[i] = s.upper()
+                for iterable, start in enumerate(rel_states):
+                    rel_states[iterable] = start.upper()
 
                 if relation.state.name in rel_states:
                     response_relations.append(relation)

--- a/app/api/resources/mentorship_relation.py
+++ b/app/api/resources/mentorship_relation.py
@@ -63,6 +63,9 @@ class SendRequest(Resource):
 @mentorship_relation_ns.route('mentorship_relations')
 class GetAllMyMentorshipRelation(Resource):
 
+    auth_header_parser.add_argument('rel_state', type=str, action='append', help="Optional relation state(s) to filter "
+                    "by. Available values: pending, accepted, rejected, cancelled, completed")
+
     @classmethod
     @jwt_required
     @mentorship_relation_ns.doc('get_all_user_mentorship_relations')
@@ -70,13 +73,15 @@ class GetAllMyMentorshipRelation(Resource):
     @mentorship_relation_ns.response(200, 'Return all user\'s mentorship relations was successfully.',
                                      model=mentorship_request_response_body)
     @mentorship_relation_ns.marshal_list_with(mentorship_request_response_body)
-    def get(cls):
+    def get(cls, rel_states=None):
         """
         Lists all mentorship relations of current user.
         """
 
         user_id = get_jwt_identity()
-        response = DAO.list_mentorship_relations(user_id=user_id)
+        rel_states = request.args.getlist("rel_state")
+
+        response = DAO.list_mentorship_relations(user_id=user_id, rel_states=rel_states)
 
         return response
 

--- a/app/utils/list_of_string_converter.py
+++ b/app/utils/list_of_string_converter.py
@@ -1,0 +1,12 @@
+from werkzeug.routing import BaseConverter
+
+
+class ListOfStringConverter(BaseConverter):
+    def __init__(self, url_map, randomify=False):
+        self.regex = r'\d+(?:,\d+)*,?'
+
+    def to_python(self, value):
+        return [str(x) for x in value.split(',')]
+
+    def to_url(self, value):
+        return ','.join(str(x) for x in value)

--- a/run.py
+++ b/run.py
@@ -12,6 +12,9 @@ def create_app(config_filename):
     from app.database.sqlalchemy_extension import db
     db.init_app(app)
 
+    from app.utils.list_of_string_converter import ListOfStringConverter
+    app.url_map.converters['list_of_string'] = ListOfStringConverter
+
     from app.api.jwt_extension import jwt
     jwt.init_app(app)
 

--- a/tests/mentorship_relation/test_dao_listing.py
+++ b/tests/mentorship_relation/test_dao_listing.py
@@ -22,9 +22,11 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         self.now_datetime = datetime.now()
         self.end_date_example = self.now_datetime + timedelta(weeks=5)
 
+        self.dao = MentorshipRelationDAO()
+
         # create new mentorship relation
 
-        self.mentorship_relation = MentorshipRelationModel(
+        self.pending_mentorship_relation = MentorshipRelationModel(
             action_user_id=self.first_user.id,
             mentor_user=self.first_user,
             mentee_user=self.second_user,
@@ -79,7 +81,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
             tasks_list=TasksListModel()
         )
 
-        db.session.add(self.mentorship_relation)
+        db.session.add(self.pending_mentorship_relation)
         db.session.add(self.accepted_mentorship_relation)
         db.session.add(self.rejected_mentorship_relation)
         db.session.add(self.cancelled_mentorship_relation)
@@ -88,84 +90,42 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         db.session.commit()
 
     def test_dao_list_mentorship_relation_accepted(self):
-        DAO = MentorshipRelationDAO()
+        result = self.dao.list_mentorship_relations(user_id=self.first_user.id, rel_states=["accepted"])
 
-        self.mentorship_relation.state = MentorshipRelationState.ACCEPTED
-        db.session.add(self.mentorship_relation)
-        db.session.commit()
-
-        result = DAO.list_mentorship_relations(user_id=self.first_user.id, rel_states=["accepted"])
-
-        self.assertEqual(([self.mentorship_relation, self.accepted_mentorship_relation], 200), result)
+        self.assertEqual(([self.accepted_mentorship_relation], 200), result)
 
     def test_dao_list_mentorship_relation_cancelled(self):
-        DAO = MentorshipRelationDAO()
+        result = self.dao.list_mentorship_relations(user_id=self.first_user.id, rel_states=["cancelled"])
 
-        self.mentorship_relation.state = MentorshipRelationState.CANCELLED
-        db.session.add(self.mentorship_relation)
-        db.session.commit()
-
-        result = DAO.list_mentorship_relations(user_id=self.first_user.id, rel_states=["cancelled"])
-
-        self.assertEqual(([self.mentorship_relation, self.cancelled_mentorship_relation], 200), result)
+        self.assertEqual(([self.cancelled_mentorship_relation], 200), result)
 
     def test_dao_list_mentorship_relation_rejected(self):
-        DAO = MentorshipRelationDAO()
+        result = self.dao.list_mentorship_relations(user_id=self.first_user.id, rel_states=["rejected"])
 
-        self.mentorship_relation.state = MentorshipRelationState.REJECTED
-        db.session.add(self.mentorship_relation)
-        db.session.commit()
-
-        result = DAO.list_mentorship_relations(user_id=self.first_user.id, rel_states=["rejected"])
-
-        self.assertEqual(([self.mentorship_relation, self.rejected_mentorship_relation], 200), result)
+        self.assertEqual(([self.rejected_mentorship_relation], 200), result)
 
     def test_dao_list_mentorship_relation_completed(self):
-        DAO = MentorshipRelationDAO()
+        result = self.dao.list_mentorship_relations(user_id=self.first_user.id, rel_states=["completed"])
 
-        self.mentorship_relation.state = MentorshipRelationState.COMPLETED
-        db.session.add(self.mentorship_relation)
-        db.session.commit()
-
-        result = DAO.list_mentorship_relations(user_id=self.first_user.id, rel_states=["completed"])
-
-        self.assertEqual(([self.mentorship_relation, self.completed_mentorship_relation], 200), result)
+        self.assertEqual(([self.completed_mentorship_relation], 200), result)
 
     def test_dao_list_mentorship_relation_pending(self):
-        DAO = MentorshipRelationDAO()
+        result = self.dao.list_mentorship_relations(user_id=self.first_user.id, rel_states=["pending"])
 
-        self.mentorship_relation.state = MentorshipRelationState.PENDING
-        db.session.add(self.mentorship_relation)
-        db.session.commit()
-
-        result = DAO.list_mentorship_relations(user_id=self.first_user.id, rel_states=["pending"])
-
-        self.assertEqual(([self.mentorship_relation], 200), result)
+        self.assertEqual(([self.pending_mentorship_relation], 200), result)
 
     def test_dao_list_mentorship_relation_all(self):
-        DAO = MentorshipRelationDAO()
-
-        self.mentorship_relation.state = MentorshipRelationState.PENDING
-        db.session.add(self.mentorship_relation)
-        db.session.commit()
-
-        result = DAO.list_mentorship_relations(user_id=self.first_user.id)
-        expected_response = [self.mentorship_relation, self.accepted_mentorship_relation,
-                             self.rejected_mentorship_relation,self.cancelled_mentorship_relation,
+        result = self.dao.list_mentorship_relations(user_id=self.first_user.id)
+        expected_response = [self.pending_mentorship_relation, self.accepted_mentorship_relation,
+                             self.rejected_mentorship_relation, self.cancelled_mentorship_relation,
                              self.completed_mentorship_relation], 200
 
         self.assertIsNotNone(result)
         self.assertEqual(expected_response, result)
 
     def test_dao_list_mentorship_relation_all_pending_and_accepted(self):
-        DAO = MentorshipRelationDAO()
-
-        self.mentorship_relation.state = MentorshipRelationState.PENDING
-        db.session.add(self.mentorship_relation)
-        db.session.commit()
-
-        result = DAO.list_mentorship_relations(user_id=self.first_user.id, rel_states=["pending", "accepted"])
-        expected_response = [self.mentorship_relation, self.accepted_mentorship_relation], 200
+        result = self.dao.list_mentorship_relations(user_id=self.first_user.id, rel_states=["pending", "accepted"])
+        expected_response = [self.pending_mentorship_relation, self.accepted_mentorship_relation], 200
 
         self.assertIsNotNone(result)
         self.assertEqual(expected_response, result)

--- a/tests/mentorship_relation/test_dao_listing.py
+++ b/tests/mentorship_relation/test_dao_listing.py
@@ -38,6 +38,62 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
+        self.accepted_mentorship_relation = MentorshipRelationModel(
+            action_user_id=self.first_user.id,
+            mentor_user=self.first_user,
+            mentee_user=self.second_user,
+            creation_date=self.now_datetime.timestamp(),
+            end_date=self.end_date_example.timestamp(),
+            state=MentorshipRelationState.ACCEPTED,
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
+        )
+
+        db.session.add(self.accepted_mentorship_relation)
+        db.session.commit()
+
+        self.rejected_mentorship_relation = MentorshipRelationModel(
+            action_user_id=self.first_user.id,
+            mentor_user=self.first_user,
+            mentee_user=self.second_user,
+            creation_date=self.now_datetime.timestamp(),
+            end_date=self.end_date_example.timestamp(),
+            state=MentorshipRelationState.REJECTED,
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
+        )
+
+        db.session.add(self.rejected_mentorship_relation)
+        db.session.commit()
+
+        self.cancelled_mentorship_relation = MentorshipRelationModel(
+            action_user_id=self.first_user.id,
+            mentor_user=self.first_user,
+            mentee_user=self.second_user,
+            creation_date=self.now_datetime.timestamp(),
+            end_date=self.end_date_example.timestamp(),
+            state=MentorshipRelationState.CANCELLED,
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
+        )
+
+        self.completed_mentorship_relation = MentorshipRelationModel(
+            action_user_id=self.first_user.id,
+            mentor_user=self.first_user,
+            mentee_user=self.second_user,
+            creation_date=self.now_datetime.timestamp(),
+            end_date=self.end_date_example.timestamp(),
+            state=MentorshipRelationState.COMPLETED,
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
+        )
+
+        db.session.add(self.completed_mentorship_relation)
+        db.session.commit()
+
+        db.session.add(self.cancelled_mentorship_relation)
+        db.session.commit()
+
     def test_dao_list_mentorship_relation_accepted(self):
         DAO = MentorshipRelationDAO()
 
@@ -45,9 +101,9 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
-        result = DAO.list_mentorship_relations(user_id=self.first_user.id, accepted=True)
+        result = DAO.list_mentorship_relations(user_id=self.first_user.id, rel_states=["accepted"])
 
-        self.assertEqual((messages.NOT_IMPLEMENTED, 200), result)
+        self.assertEqual(([self.mentorship_relation, self.accepted_mentorship_relation], 200), result)
 
     def test_dao_list_mentorship_relation_cancelled(self):
         DAO = MentorshipRelationDAO()
@@ -56,9 +112,9 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
-        result = DAO.list_mentorship_relations(user_id=self.first_user.id, cancelled=True)
+        result = DAO.list_mentorship_relations(user_id=self.first_user.id, rel_states=["cancelled"])
 
-        self.assertEqual((messages.NOT_IMPLEMENTED, 200), result)
+        self.assertEqual(([self.mentorship_relation, self.cancelled_mentorship_relation], 200), result)
 
     def test_dao_list_mentorship_relation_rejected(self):
         DAO = MentorshipRelationDAO()
@@ -67,9 +123,9 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
-        result = DAO.list_mentorship_relations(user_id=self.first_user.id, rejected=True)
+        result = DAO.list_mentorship_relations(user_id=self.first_user.id, rel_states=["rejected"])
 
-        self.assertEqual((messages.NOT_IMPLEMENTED, 200), result)
+        self.assertEqual(([self.mentorship_relation, self.rejected_mentorship_relation], 200), result)
 
     def test_dao_list_mentorship_relation_completed(self):
         DAO = MentorshipRelationDAO()
@@ -78,9 +134,9 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
-        result = DAO.list_mentorship_relations(user_id=self.first_user.id, completed=True)
+        result = DAO.list_mentorship_relations(user_id=self.first_user.id, rel_states=["completed"])
 
-        self.assertEqual((messages.NOT_IMPLEMENTED, 200), result)
+        self.assertEqual(([self.mentorship_relation, self.completed_mentorship_relation], 200), result)
 
     def test_dao_list_mentorship_relation_pending(self):
         DAO = MentorshipRelationDAO()
@@ -89,9 +145,9 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
-        result = DAO.list_mentorship_relations(user_id=self.first_user.id, pending=True)
+        result = DAO.list_mentorship_relations(user_id=self.first_user.id, rel_states=["pending"])
 
-        self.assertEqual((messages.NOT_IMPLEMENTED, 200), result)
+        self.assertEqual(([self.mentorship_relation], 200), result)
 
     def test_dao_list_mentorship_relation_all(self):
         DAO = MentorshipRelationDAO()
@@ -101,7 +157,22 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         db.session.commit()
 
         result = DAO.list_mentorship_relations(user_id=self.first_user.id)
-        expected_response = [self.mentorship_relation], 200
+        expected_response = [self.mentorship_relation, self.accepted_mentorship_relation,
+                             self.rejected_mentorship_relation,self.cancelled_mentorship_relation,
+                             self.completed_mentorship_relation], 200
+
+        self.assertIsNotNone(result)
+        self.assertEqual(expected_response, result)
+
+    def test_dao_list_mentorship_relation_all_pending_and_accepted(self):
+        DAO = MentorshipRelationDAO()
+
+        self.mentorship_relation.state = MentorshipRelationState.PENDING
+        db.session.add(self.mentorship_relation)
+        db.session.commit()
+
+        result = DAO.list_mentorship_relations(user_id=self.first_user.id, rel_states=["pending", "accepted"])
+        expected_response = [self.mentorship_relation, self.accepted_mentorship_relation], 200
 
         self.assertIsNotNone(result)
         self.assertEqual(expected_response, result)

--- a/tests/mentorship_relation/test_dao_listing.py
+++ b/tests/mentorship_relation/test_dao_listing.py
@@ -35,9 +35,6 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
             tasks_list=TasksListModel()
         )
 
-        db.session.add(self.mentorship_relation)
-        db.session.commit()
-
         self.accepted_mentorship_relation = MentorshipRelationModel(
             action_user_id=self.first_user.id,
             mentor_user=self.first_user,
@@ -49,9 +46,6 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
             tasks_list=TasksListModel()
         )
 
-        db.session.add(self.accepted_mentorship_relation)
-        db.session.commit()
-
         self.rejected_mentorship_relation = MentorshipRelationModel(
             action_user_id=self.first_user.id,
             mentor_user=self.first_user,
@@ -62,9 +56,6 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
             notes=self.notes_example,
             tasks_list=TasksListModel()
         )
-
-        db.session.add(self.rejected_mentorship_relation)
-        db.session.commit()
 
         self.cancelled_mentorship_relation = MentorshipRelationModel(
             action_user_id=self.first_user.id,
@@ -88,10 +79,12 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
             tasks_list=TasksListModel()
         )
 
-        db.session.add(self.completed_mentorship_relation)
-        db.session.commit()
-
+        db.session.add(self.mentorship_relation)
+        db.session.add(self.accepted_mentorship_relation)
+        db.session.add(self.rejected_mentorship_relation)
         db.session.add(self.cancelled_mentorship_relation)
+        db.session.add(self.completed_mentorship_relation)
+
         db.session.commit()
 
     def test_dao_list_mentorship_relation_accepted(self):


### PR DESCRIPTION
### Description
Done what [the task](https://codein.withgoogle.com/dashboard/task-instances/5670080478707712/) asked for. Query param is `rel_state` and it accepts following values: `pending`, `accepted`, `rejected`, `cancelled` and `completed`. It's noteworthy that it's case-insensitive because eventually `upper()` is called.

One nice thing that costed me quite a lot of effort is possibility to easily add `rel_state` using Swagger.
![demo_swagger](https://user-images.githubusercontent.com/40357511/71495588-e4d5d300-284e-11ea-80ce-2771a5ca8362.gif)


fixes #329 (and partly #297)

### Type of Change:
- Code
- Quality Assurance
- Documentation

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
Tested manually *too many* times and ran whole test suite. Everything passes :)
I've also improved tests testing relationship-related stuff, so we can be really sure this functionality works.

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Update Postman API at /docs folder
- [x] Update Swagger documentation and the exported file at /docs folder

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
