### PR TITLE
Added saving Gravatar URL

### DIFF
--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -51,12 +51,6 @@ class UserDAO:
         if 'available_to_mentor' in data:
             user.available_to_mentor = data['available_to_mentor']
 
-        try:
-            gravatar = Gravatar(email)
-            user.photo_url = gravatar.get_image(size=512)
-        except:
-            return messages.ERROR_WHILE_CALLING_GRAVATAR, 500
-
         user.save_to_db()
 
         return messages.USER_WAS_CREATED_SUCCESSFULLY, 200
@@ -207,7 +201,7 @@ class UserDAO:
                 user.location = data['location']
             else:
                 user.location = None
-
+            
         if 'occupation' in data:
             if data['occupation']:
                 user.occupation = data['occupation']
@@ -261,6 +255,14 @@ class UserDAO:
 
         if 'available_to_mentor' in data:
             user.available_to_mentor = data['available_to_mentor']
+
+        try:
+            if user.photo_url:
+                pass
+            else:
+                user.photo_url = UserDAO.get_gravatar(user)
+        except:
+            return messages.ERROR_WHILE_CALLING_GRAVATAR, 500
 
         user.save_to_db()
 
@@ -318,8 +320,21 @@ class UserDAO:
         else:
             user.is_email_verified = True
             user.email_verification_date = datetime.now()
+
+            try:
+                user.photo_url = UserDAO.get_gravatar(user)
+            except:
+                return messages.ERROR_WHILE_CALLING_GRAVATAR, 500
+
             user.save_to_db()
             return messages.ACCOUNT_ALREADY_CONFIRMED_AND_THANKS, 200
+
+    @staticmethod
+    def get_gravatar(user):
+        """Finds user's Gravatar photo URL and returns it. If user doesn't have Gravatar account,
+        default Gravatar image will be returned. Default image: http://www.gravatar.com/avatar"""
+        gravatar = Gravatar(user.email)
+        return gravatar.get_image(size=512)
 
     @staticmethod
     def authenticate(username_or_email, password):

--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -7,6 +7,7 @@ from app.database.models.user import UserModel
 from app.utils.decorator_utils import email_verification_required
 from app.utils.enum_utils import MentorshipRelationState
 from app.utils.validation_utils import is_email_valid
+from libgravatar import Gravatar
 
 
 class UserDAO:
@@ -49,6 +50,12 @@ class UserDAO:
 
         if 'available_to_mentor' in data:
             user.available_to_mentor = data['available_to_mentor']
+
+        try:
+            gravatar = Gravatar(email)
+            user.photo_url = gravatar.get_image(size=512)
+        except:
+            return messages.ERROR_WHILE_CALLING_GRAVATAR, 500
 
         user.save_to_db()
 
@@ -200,7 +207,7 @@ class UserDAO:
                 user.location = data['location']
             else:
                 user.location = None
-            
+
         if 'occupation' in data:
             if data['occupation']:
                 user.occupation = data['occupation']

--- a/app/messages.py
+++ b/app/messages.py
@@ -213,3 +213,5 @@ ACCOUNT_ALREADY_CONFIRMED_AND_THANKS = {"message": "You have confirmed your"
 # Miscellaneous
 VALIDATION_ERROR = {"message": "Validation error."}
 NOT_IMPLEMENTED = {"message": "Not implemented."}
+ERROR_WHILE_CALLING_GRAVATAR = {"message": "An unknown error occurred while"
+                                           "calling Gravatar."}

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,3 +47,4 @@ urllib3==1.22
 wcwidth==0.1.7
 websocket-client==0.48.0
 Werkzeug==0.14.1
+libgravatar==0.2.3

--- a/tests/utils/test_gravatar.py
+++ b/tests/utils/test_gravatar.py
@@ -1,0 +1,18 @@
+import unittest
+
+from libgravatar import Gravatar
+
+
+class TestGravatar(unittest.TestCase):
+
+    def test_works(self):
+        valid_photo_url = "http://www.gravatar.com/avatar/b642b4217b34b1e8d3bd915fc65c4452?size=512"
+
+        gravatar = Gravatar("test@test.com")
+        photo_url = gravatar.get_image(size=512)
+
+        self.assertEqual(valid_photo_url, photo_url)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Description
When new account is created, gravatar_url is fetched and saved in database.

I'm using [libgravatar](https://pypi.org/project/libgravatar/) to retrieve gravatar url associated with particular email address.

Fixes #326

### Type of Change:
- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)


### How Has This Been Tested?
Tested manually, with two emails: one with profile picture and one without. First case works as expected, in second case [default gravatar](https://www.gravatar.com/avatar/00000000000000000000000000000000) URL is fetched and saved.


### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Update Postman API at /docs folder
- [x] Update Swagger documentation and the exported file at /docs folder
- [x] Update requirements.txt

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
