### PR TITLE
[Program: GCI] Improve PUT user/change_password endpoint to remove duplicates

### DIFF
--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -264,14 +264,17 @@ class UserDAO:
     def change_password(user_id, data):
         """ Changes the user's password.
         
-        Finds the user with the given ID, checks their current password, and then updates to the new one.
+        Finds the user with the given ID, checks their current password,
+        and then updates to the new one.
         
         Arguments:
             user_id: The ID of the user to be searched.
             data: The user's current and new password.
         
         Returns:
-            A message that indicates whether the password change was successful or not and a second element which is the HTTP response code.
+            A message that indicates whether the password change was successful or not
+            and a second element which is the HTTP response code.
+            Returns error if new password is a duplicate.
         
         """
 
@@ -280,6 +283,8 @@ class UserDAO:
 
         user = UserModel.find_by_id(user_id)
         if user.check_password(current_password):
+            if current_password == new_password:
+                return messages.DUPLICATE_PASSWORD, 400
             user.set_password(new_password)
             user.save_to_db()
             return messages.PASSWORD_SUCCESSFULLY_UPDATED, 201

--- a/app/messages.py
+++ b/app/messages.py
@@ -201,9 +201,9 @@ UPDATED_TASK_WITH_SUCCESS = {"message": "Updated task with success."}
 USER_SUCCESSFULLY_CREATED = {"message": "User successfully created."}
 USER_SUCCESSFULLY_DELETED = {"message": "User was deleted successfully"}
 USER_SUCCESSFULLY_UPDATED = {"message": "User was updated successfully."}
-PASSWORD_SUCCESSFULLY_UPDATED = {"message": "Password was updated "
-                                 "successfully"}
-
+PASSWORD_SUCCESSFULLY_UPDATED = {"message": "Password was updated successfully."}
+DUPLICATE_PASSWORD = {"message": "The password has not been changed. You can not "
+                        "use same password as current one."}
 # confimation
 ACCOUNT_ALREADY_CONFIRMED = {"message": "Account already confirmed"}
 USER_ALREADY_CONFIRMED_ACCOUNT = {"message": "You already confirm your email"}

--- a/tests/users/test_api_change_password.py
+++ b/tests/users/test_api_change_password.py
@@ -1,0 +1,41 @@
+import unittest
+
+from flask import json
+
+from app import messages
+from tests.base_test_case import BaseTestCase
+from tests.test_data import test_admin_user
+from tests.test_utils import get_test_request_header
+
+class TestChangePasswordApi(BaseTestCase):
+
+    def test_change_password_api(self):
+        auth_header = get_test_request_header(self.admin_user.id)
+        expected_response = messages.PASSWORD_SUCCESSFULLY_UPDATED
+        actual_response = self.client.put('/user/change_password', follow_redirects=True,
+                                          headers=auth_header,
+                                          data=json.dumps(dict(
+                                                current_password=test_admin_user["password"],
+                                                new_password="newpassword"
+                                              )),
+                                          content_type='application/json')
+
+        self.assertEqual(201, actual_response.status_code)
+        self.assertDictEqual(expected_response, json.loads(actual_response.data))
+
+    def test_change_password_duplicate_api(self):
+        auth_header = get_test_request_header(self.admin_user.id)
+        expected_response = messages.DUPLICATE_PASSWORD
+        actual_response = self.client.put('/user/change_password', follow_redirects=True,
+                                          headers=auth_header,
+                                          data=json.dumps(dict(
+                                                current_password=test_admin_user["password"],
+                                                new_password=test_admin_user["password"]
+                                              )),
+                                          content_type='application/json')
+
+        self.assertEqual(400, actual_response.status_code)
+        self.assertDictEqual(expected_response, json.loads(actual_response.data))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/users/test_dao_change_password.py
+++ b/tests/users/test_dao_change_password.py
@@ -1,0 +1,34 @@
+import unittest
+from app.api.dao.user import UserDAO
+from app import messages
+from tests.base_test_case import BaseTestCase
+from tests.test_data import test_admin_user
+
+class TestChangePasswordDao(BaseTestCase):
+
+    def test_change_password_dao(self):
+        expected_response = messages.PASSWORD_SUCCESSFULLY_UPDATED
+        actual_response = UserDAO.change_password(
+            user_id = self.admin_user.id,
+            data = {
+                "current_password": test_admin_user["password"],
+                "new_password": "newpassword"
+            }
+        )
+        self.assertEqual(201, actual_response[1])
+        self.assertDictEqual(expected_response, actual_response[0])
+
+    def test_change_password_duplicate_dao(self):
+        expected_response = messages.DUPLICATE_PASSWORD
+        actual_response = UserDAO.change_password(
+            user_id = self.admin_user.id,
+            data = {
+                "current_password": test_admin_user["password"],
+                "new_password": test_admin_user["password"]
+            }
+        )
+        self.assertEqual(400, actual_response[1])
+        self.assertDictEqual(expected_response, actual_response[0])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Description
PUT user/change_password endpoint improved to detect duplicate password. Message "The password has not been changed. You can not use same password as current one." and 400 response is displayed when the old password and new match each other.

Test cases created for DAO and API.

Fixes #319 

### Type of Change:

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
1. **Failure** (duplicate passwords)
![task39_1](https://user-images.githubusercontent.com/50169911/71517039-45f2ba80-28d2-11ea-9287-61f40a1d0b71.png)

2. **Success** (different passwords)
![task39_2](https://user-images.githubusercontent.com/50169911/71517048-4f7c2280-28d2-11ea-817f-946f28882a0d.png)

3. **Unit tests**
```sh
python -m unittest discover tests
```
![task39_3](https://user-images.githubusercontent.com/50169911/71517049-5014b900-28d2-11ea-958d-9d2af78ad17f.png)

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged
- [ ] Update Postman API at /docs folder
- [ ] Update Swagger documentation and the exported file at /docs folder
- [ ] Update requirements.txt

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
