### PR TITLE
[Program: GCI] Add query parameter to filter mentorship relations by current state (Backend)

### DIFF
--- a/app/api/dao/mentorship_relation.py
+++ b/app/api/dao/mentorship_relation.py
@@ -113,10 +113,10 @@ class MentorshipRelationDAO:
 
     @staticmethod
     @email_verification_required
-    def list_mentorship_relations(user_id=None, accepted=None, pending=None, completed=None, cancelled=None, rejected=None):
+    def list_mentorship_relations(user_id=None, stateList=None):
         """Lists all relationships of a given user.
 
-        Lists all relationships of a given user. Support for filtering not yet implemented.
+        Query and list all relationships of a given user with a given RELATION STATE. Support for filtering not yet implemented.
 
         Args:
             user_id: ID of the user whose relationships are to be listed.
@@ -124,16 +124,6 @@ class MentorshipRelationDAO:
         Returns:
             message: A message corresponding to the completed action; success if all relationships of a given user are listed, failure if otherwise.
         """
-        if pending is not None:
-            return messages.NOT_IMPLEMENTED, 200
-        if completed is not None:
-            return messages.NOT_IMPLEMENTED, 200
-        if cancelled is not None:
-            return messages.NOT_IMPLEMENTED, 200
-        if accepted is not None:
-            return messages.NOT_IMPLEMENTED, 200
-        if rejected is not None:
-            return messages.NOT_IMPLEMENTED, 200
 
         user = UserModel.find_by_id(user_id)
         all_relations = user.mentor_relations + user.mentee_relations
@@ -142,7 +132,22 @@ class MentorshipRelationDAO:
         for relation in all_relations:
             setattr(relation, 'sent_by_me', relation.action_user_id == user_id)
 
-        return all_relations, 200
+        response_relations = []
+        #filter and remove whitespaces and empty list items
+        if stateList:
+            for s in stateList:
+                s.replace(" ", "")
+                if s == "":
+                    stateList.remove(s)
+        #iterate through relations and filter out those which match query
+        if stateList and len(stateList) != 0:
+            for relation in all_relations:
+                if relation.state.name in stateList:
+                    response_relations.append(relation)
+        else:
+            return all_relations, 200
+
+        return response_relations, 200
 
     @staticmethod
     @email_verification_required

--- a/app/api/resources/mentorship_relation.py
+++ b/app/api/resources/mentorship_relation.py
@@ -62,21 +62,21 @@ class SendRequest(Resource):
 
 @mentorship_relation_ns.route('mentorship_relations')
 class GetAllMyMentorshipRelation(Resource):
-
+    auth_header_parser.add_argument('state', type=str, action='split', help='optional query filter mentor relation requests by state: PENDING, ACCEPTED, REJECTED, CANCELLED, COMPLETED')
     @classmethod
     @jwt_required
     @mentorship_relation_ns.doc('get_all_user_mentorship_relations')
     @mentorship_relation_ns.expect(auth_header_parser)
-    @mentorship_relation_ns.response(200, 'Return all user\'s mentorship relations was successfully.',
+    @mentorship_relation_ns.response(200, 'Return all user\'s mentorship relations with respective query filter was successful.',
                                      model=mentorship_request_response_body)
     @mentorship_relation_ns.marshal_list_with(mentorship_request_response_body)
     def get(cls):
         """
-        Lists all mentorship relations of current user.
+        Lists all mentorship relations of current user with query filter for state of relation.
         """
 
         user_id = get_jwt_identity()
-        response = DAO.list_mentorship_relations(user_id=user_id)
+        response = DAO.list_mentorship_relations(user_id=user_id, stateList=auth_header_parser.parse_args()['state'])
 
         return response
 

--- a/tests/mentorship_relation/test_dao_listing.py
+++ b/tests/mentorship_relation/test_dao_listing.py
@@ -24,7 +24,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
 
         # create new mentorship relation
 
-        self.mentorship_relation = MentorshipRelationModel(
+        self.mentorship_relation_pending = MentorshipRelationModel(
             action_user_id=self.first_user.id,
             mentor_user=self.first_user,
             mentee_user=self.second_user,
@@ -34,78 +34,133 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
             notes=self.notes_example,
             tasks_list=TasksListModel()
         )
+        self.mentorship_relation_accepted = MentorshipRelationModel(
+            action_user_id=self.first_user.id,
+            mentor_user=self.first_user,
+            mentee_user=self.second_user,
+            creation_date=self.now_datetime.timestamp(),
+            end_date=self.end_date_example.timestamp(),
+            state=MentorshipRelationState.ACCEPTED,
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
+        )
+        self.mentorship_relation_cancelled = MentorshipRelationModel(
+            action_user_id=self.first_user.id,
+            mentor_user=self.first_user,
+            mentee_user=self.second_user,
+            creation_date=self.now_datetime.timestamp(),
+            end_date=self.end_date_example.timestamp(),
+            state=MentorshipRelationState.CANCELLED,
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
+        )
+        self.mentorship_relation_rejected = MentorshipRelationModel(
+            action_user_id=self.first_user.id,
+            mentor_user=self.first_user,
+            mentee_user=self.second_user,
+            creation_date=self.now_datetime.timestamp(),
+            end_date=self.end_date_example.timestamp(),
+            state=MentorshipRelationState.REJECTED,
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
+        )
+        self.mentorship_relation_completed = MentorshipRelationModel(
+            action_user_id=self.first_user.id,
+            mentor_user=self.first_user,
+            mentee_user=self.second_user,
+            creation_date=self.now_datetime.timestamp(),
+            end_date=self.end_date_example.timestamp(),
+            state=MentorshipRelationState.COMPLETED,
+            notes=self.notes_example,
+            tasks_list=TasksListModel()
+        )
 
-        db.session.add(self.mentorship_relation)
+        db.session.add(self.mentorship_relation_pending)
+        db.session.add(self.mentorship_relation_accepted)
+        db.session.add(self.mentorship_relation_cancelled)
+        db.session.add(self.mentorship_relation_rejected)
+        db.session.add(self.mentorship_relation_completed)
         db.session.commit()
 
     def test_dao_list_mentorship_relation_accepted(self):
         DAO = MentorshipRelationDAO()
 
-        self.mentorship_relation.state = MentorshipRelationState.ACCEPTED
-        db.session.add(self.mentorship_relation)
+        db.session.add(self.mentorship_relation_accepted)
         db.session.commit()
 
-        result = DAO.list_mentorship_relations(user_id=self.first_user.id, accepted=True)
+        result = DAO.list_mentorship_relations(user_id=self.first_user.id, stateList=['ACCEPTED'])
 
-        self.assertEqual((messages.NOT_IMPLEMENTED, 200), result)
+        self.assertEqual(([self.mentorship_relation_accepted], 200), result)
 
     def test_dao_list_mentorship_relation_cancelled(self):
         DAO = MentorshipRelationDAO()
 
-        self.mentorship_relation.state = MentorshipRelationState.CANCELLED
-        db.session.add(self.mentorship_relation)
+        db.session.add(self.mentorship_relation_cancelled)
         db.session.commit()
 
-        result = DAO.list_mentorship_relations(user_id=self.first_user.id, cancelled=True)
+        result = DAO.list_mentorship_relations(user_id=self.first_user.id, stateList=['CANCELLED'])
 
-        self.assertEqual((messages.NOT_IMPLEMENTED, 200), result)
+        self.assertEqual(([self.mentorship_relation_cancelled], 200), result)
 
     def test_dao_list_mentorship_relation_rejected(self):
         DAO = MentorshipRelationDAO()
 
-        self.mentorship_relation.state = MentorshipRelationState.REJECTED
-        db.session.add(self.mentorship_relation)
+        db.session.add(self.mentorship_relation_rejected)
         db.session.commit()
 
-        result = DAO.list_mentorship_relations(user_id=self.first_user.id, rejected=True)
+        result = DAO.list_mentorship_relations(user_id=self.first_user.id, stateList=['REJECTED'])
 
-        self.assertEqual((messages.NOT_IMPLEMENTED, 200), result)
+        self.assertEqual(([self.mentorship_relation_rejected], 200), result)
 
     def test_dao_list_mentorship_relation_completed(self):
         DAO = MentorshipRelationDAO()
 
-        self.mentorship_relation.state = MentorshipRelationState.COMPLETED
-        db.session.add(self.mentorship_relation)
+        db.session.add(self.mentorship_relation_completed)
         db.session.commit()
 
-        result = DAO.list_mentorship_relations(user_id=self.first_user.id, completed=True)
+        result = DAO.list_mentorship_relations(user_id=self.first_user.id, stateList=['COMPLETED'])
 
-        self.assertEqual((messages.NOT_IMPLEMENTED, 200), result)
+        self.assertEqual(([self.mentorship_relation_completed], 200), result)
 
     def test_dao_list_mentorship_relation_pending(self):
         DAO = MentorshipRelationDAO()
 
-        self.mentorship_relation.state = MentorshipRelationState.PENDING
-        db.session.add(self.mentorship_relation)
+        db.session.add(self.mentorship_relation_pending)
         db.session.commit()
 
-        result = DAO.list_mentorship_relations(user_id=self.first_user.id, pending=True)
+        result = DAO.list_mentorship_relations(user_id=self.first_user.id, stateList=['PENDING'])
 
-        self.assertEqual((messages.NOT_IMPLEMENTED, 200), result)
+        self.assertEqual(([self.mentorship_relation_pending], 200), result)
 
     def test_dao_list_mentorship_relation_all(self):
         DAO = MentorshipRelationDAO()
 
-        self.mentorship_relation.state = MentorshipRelationState.PENDING
-        db.session.add(self.mentorship_relation)
+        db.session.add(self.mentorship_relation_pending)
+        db.session.add(self.mentorship_relation_accepted)
+        db.session.add(self.mentorship_relation_cancelled)
+        db.session.add(self.mentorship_relation_rejected)
+        db.session.add(self.mentorship_relation_completed)
         db.session.commit()
 
         result = DAO.list_mentorship_relations(user_id=self.first_user.id)
-        expected_response = [self.mentorship_relation], 200
+        expected_response = [self.mentorship_relation_pending, self.mentorship_relation_accepted,
+                             self.mentorship_relation_cancelled, self.mentorship_relation_rejected, self.mentorship_relation_completed], 200
 
         self.assertIsNotNone(result)
         self.assertEqual(expected_response, result)
 
+    def test_dao_list_mentorship_relation_pending_and_accepted(self):
+        DAO = MentorshipRelationDAO()
+
+        db.session.add(self.mentorship_relation_pending)
+        db.session.add(self.mentorship_relation_accepted)
+        db.session.commit()
+
+        result = DAO.list_mentorship_relations(user_id=self.first_user.id, stateList=['PENDING', 'ACCEPTED'])
+        expected_response = [self.mentorship_relation_pending, self.mentorship_relation_accepted], 200
+
+        self.assertIsNotNone(result)
+        self.assertEqual(expected_response, result)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Description
Added query support for GET/mentorship_relations. Query based on STATE of relation. 

Fixes #329 

### Type of Change:
- Code
- Quality Assurance

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
I tested this using `python -m unittest discover tests`
![dfsdfas](https://user-images.githubusercontent.com/29257061/71548156-293cac80-29d0-11ea-8ca2-eff527caba5a.PNG)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged
- [x] Update Postman API at /docs folder
- [x] Update Swagger documentation and the exported file at /docs folder

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
