### PR TITLE
[Program: GCI] Find if user is currently in mentorship relation using GET /users

### DIFF
--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -7,7 +7,8 @@ from app.database.models.user import UserModel
 from app.utils.decorator_utils import email_verification_required
 from app.utils.enum_utils import MentorshipRelationState
 from app.utils.validation_utils import is_email_valid
-
+from app.api.dao.mentorship_relation import MentorshipRelationDAO
+from app.database.models.mentorship_relation import MentorshipRelationModel
 
 class UserDAO:
     """Data Access Object for User functionalities"""
@@ -153,6 +154,13 @@ class UserDAO:
                     list_of_users += [user.json()]
         else:
             list_of_users = [user.json() for user in users_list]
+        # user is available for relation if: not in relation * (need_mentoring + available_to_mentor)
+        for user in list_of_users:
+            current_relation_response = MentorshipRelationDAO.list_current_mentorship_relation(user['id'])
+            # find if not in relation
+            if not isinstance(current_relation_response,MentorshipRelationModel):
+                if (user['need_mentoring'] or user['available_to_mentor']):
+                    user['is_available'] = True
 
         return list_of_users, 200
 

--- a/app/api/models/user.py
+++ b/app/api/models/user.py
@@ -63,6 +63,11 @@ public_user_api_model = Model('User list model', {
     'available_to_mentor': fields.Boolean(
         required=True,
         description='User availability to mentor indication'
+    ),
+    'is_available': fields.Boolean(
+        required = True,
+        description = 'User availability for mentorship relation',
+        default = False
     )
 })
 

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -870,7 +870,8 @@
                 "organization",
                 "skills",
                 "slack_username",
-                "username"
+                "username",
+                "is_available"
             ],
             "properties": {
                 "id": {
@@ -920,6 +921,10 @@
                 "available_to_mentor": {
                     "type": "boolean",
                     "description": "User availability to mentor indication"
+                },
+                "is_available": {
+                    "type": "boolean",
+                    "description": "User availability for mentorship relation"
                 }
             },
             "type": "object"

--- a/tests/users/test_api_list_users.py
+++ b/tests/users/test_api_list_users.py
@@ -4,12 +4,14 @@ from flask_restplus import marshal
 
 from app import messages
 from app.api.models.user import public_user_api_model
+from app.api.dao.user import UserDAO
 from app.database.models.user import UserModel
 from app.database.sqlalchemy_extension import db
 from tests.base_test_case import BaseTestCase
 from tests.test_utils import get_test_request_header
 from tests.test_data import user1, user2
-
+from app.api.dao.mentorship_relation import MentorshipRelationDAO
+from app.database.models.mentorship_relation import MentorshipRelationModel
 
 class TestListUsersApi(BaseTestCase):
     def setUp(self):
@@ -44,6 +46,18 @@ class TestListUsersApi(BaseTestCase):
 
     def test_list_users_api_resource_auth(self):
         auth_header = get_test_request_header(self.admin_user.id)
+        current_relation_response = MentorshipRelationDAO.list_current_mentorship_relation(
+            self.verified_user.id)
+        if not isinstance(current_relation_response,MentorshipRelationModel):
+            if (self.verified_user.need_mentoring or self.verified_user.available_to_mentor):
+                self.verified_user.is_available = True
+
+        current_relation_response = MentorshipRelationDAO.list_current_mentorship_relation(
+            self.other_user.id)
+        if not isinstance(current_relation_response,MentorshipRelationModel):
+            if (self.other_user.need_mentoring or self.other_user.available_to_mentor):
+                self.other_user.is_available = True
+
         expected_response = [marshal(self.verified_user, public_user_api_model), marshal(self.other_user, public_user_api_model)]
         actual_response = self.client.get('/users', follow_redirects=True, headers=auth_header)
 
@@ -52,12 +66,102 @@ class TestListUsersApi(BaseTestCase):
 
     def test_list_users_api_resource_verified_users(self):
         auth_header = get_test_request_header(self.admin_user.id)
+        current_relation_response = MentorshipRelationDAO.list_current_mentorship_relation(
+            self.verified_user.id)
+        if not isinstance(current_relation_response,MentorshipRelationModel):
+            if (self.verified_user.need_mentoring or self.verified_user.available_to_mentor):
+                self.verified_user.is_available = True
+
         expected_response = [marshal(self.verified_user, public_user_api_model)]
         actual_response = self.client.get('/users/verified', follow_redirects=True, headers=auth_header)
 
         self.assertEqual(200, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
+    """
+    admin_user and verified_user are available for mentorship
+    """
+    def test_list_users_api_is_available_true(self):
+        self.verified_user.need_mentoring = True
+        self.verified_user.available_to_mentor = True
+        db.session.add(self.verified_user)
+        self.admin_user.need_mentoring = True
+        self.admin_user.available_to_mentor = True
+        db.session.add(self.admin_user)
+        db.session.commit()
+        auth_header = get_test_request_header(self.admin_user.id)
+
+        current_relation_response = MentorshipRelationDAO.list_current_mentorship_relation(
+            self.verified_user.id)
+        if not isinstance(current_relation_response, MentorshipRelationModel):
+            if (self.verified_user.need_mentoring or self.verified_user.available_to_mentor):
+                self.verified_user.is_available = True
+
+        current_relation_response = MentorshipRelationDAO.list_current_mentorship_relation(
+            self.other_user.id)
+        if not isinstance(current_relation_response, MentorshipRelationModel):
+            if (self.other_user.need_mentoring or self.other_user.available_to_mentor):
+                self.other_user.is_available = True
+
+        expected_response = [marshal(self.verified_user, public_user_api_model), marshal(self.other_user, public_user_api_model)]
+        actual_response = self.client.get('/users', follow_redirects=True, headers=auth_header)
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+        #Check status with POST /mentorship_relation/send_request
+        send_request_response = self.client.post('/mentorship_relation/send_request',
+            follow_redirects = True, headers = auth_header, content_type = 'application/json',
+            data = json.dumps(dict(
+                mentor_id = self.admin_user.id,
+                mentee_id = self.verified_user.id,
+                end_date = 1585679400,
+                notes = "notes"
+            )))
+        self.assertEqual(messages.MENTORSHIP_RELATION_WAS_SENT_SUCCESSFULLY,
+            json.loads(send_request_response.data))
+
+    """
+    admin_user is available for mentorship, verified_user is not
+    """
+    def test_list_users_api_is_available_false(self):
+        self.verified_user.need_mentoring = False
+        self.verified_user.available_to_mentor = False
+        db.session.add(self.verified_user)
+        self.admin_user.need_mentoring = True
+        self.admin_user.available_to_mentor = True
+        db.session.add(self.admin_user)
+        db.session.commit()
+        auth_header = get_test_request_header(self.admin_user.id)
+
+        current_relation_response = MentorshipRelationDAO.list_current_mentorship_relation(
+            self.verified_user.id)
+        if not isinstance(current_relation_response, MentorshipRelationModel):
+            if (self.verified_user.need_mentoring or self.verified_user.available_to_mentor):
+                self.verified_user.is_available = True
+
+        current_relation_response = MentorshipRelationDAO.list_current_mentorship_relation(
+            self.other_user.id)
+        if not isinstance(current_relation_response, MentorshipRelationModel):
+            if (self.other_user.need_mentoring or self.other_user.available_to_mentor):
+                self.other_user.is_available = True
+
+        expected_response = [marshal(self.verified_user, public_user_api_model), marshal(self.other_user, public_user_api_model)]
+        actual_response = self.client.get('/users', follow_redirects=True, headers=auth_header)
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+        #Check status with POST /mentorship_relation/send_request
+        send_request_response = self.client.post('/mentorship_relation/send_request',
+            follow_redirects = True, headers = auth_header, content_type = 'application/json',
+            data=json.dumps(dict(
+                mentor_id = self.admin_user.id,
+                mentee_id = self.verified_user.id,
+                end_date = 1585679400,
+                notes = "notes"
+            )))
+        self.assertNotEqual(messages.MENTORSHIP_RELATION_WAS_SENT_SUCCESSFULLY,
+            json.loads(send_request_response.data))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description
Find if user is currently in mentorship relation using GET /users endpoint.

#### Working
- Logic in /dao/user.py
```
user is available for relation if:
	not_in_relation AND (need_mentoring OR available_to_mentor)
```
- Model in models/user.py
- Documentation in swagger.json

#### Test cases
- test_list_users_api_resource_auth(), test_list_users_api_resource_verified_users()
  updated to work with 'is_available' parameter
- New test cases 'test_list_users_api_is_available_true()', 'test_list_users_api_is_available_false()'
  created

Fixes #232

### Type of Change:

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
1. Swagger
![task43_1](https://user-images.githubusercontent.com/50169911/71549920-bccfa680-29eb-11ea-886f-478c1585223f.png)

2. Call GET /users endpoint
![image](https://user-images.githubusercontent.com/50169911/71549902-65313b00-29eb-11ea-9680-f6d297bebf8a.png)

```sh
home@HP:~$ curl -X GET "http://127.0.0.1:5000/users" -H "accept: application/json" -H "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE1NzcxNzE5ODgsIm5iZiI6MTU3NzE3MTk4OCwianRpIjoiMGYzMzc1M2QtZDM2YS00YWE4LTljZDEtYzNlMjkzY2I5MzU4IiwiZXhwIjoxNTc3Nzc2Nzg4LCJpZGVudGl0eSI6NiwiZnJlc2giOmZhbHNlLCJ0eXBlIjoiYWNjZXNzIn0.XZso4DRncAMxKsQVkc6shYBkkvP9fwyCaEoMn5KFT8E"
[
    {
        "id": 1,
        "username": "gciuser",
        "name": "gciuser",
        "slack_username": null,
        "bio": null,
        "location": null,
        "occupation": null,
        "organization": null,
        "interests": null,
        "skills": null,
        "need_mentoring": true,
        "available_to_mentor": true,
        "is_available": true
    },
    {
        "id": 2,
        "username": "gciusertwo",
        "name": "gciusertwo",
        "slack_username": null,
        "bio": null,
        "location": null,
        "occupation": null,
        "organization": null,
        "interests": null,
        "skills": null,
        "need_mentoring": true,
        "available_to_mentor": true,
        "is_available": true
    },
    {
        "id": 3,
        "username": "gciuserthree",
        "name": "gciuserthree",
        "slack_username": null,
        "bio": null,
        "location": null,
        "occupation": null,
        "organization": null,
        "interests": null,
        "skills": null,
        "need_mentoring": true,
        "available_to_mentor": true,
        "is_available": true
    },
    {
        "id": 4,
        "username": "username",
        "name": "username",
        "slack_username": null,
        "bio": null,
        "location": null,
        "occupation": null,
        "organization": null,
        "interests": null,
        "skills": null,
        "need_mentoring": true,
        "available_to_mentor": true,
        "is_available": true
    },
    {
        "id": 5,
        "username": "typofixuser",
        "name": "typofixuser",
        "slack_username": null,
        "bio": null,
        "location": null,
        "occupation": null,
        "organization": null,
        "interests": null,
        "skills": null,
        "need_mentoring": true,
        "available_to_mentor": true,
        "is_available": true
    },
    {
        "id": 7,
        "username": "gciuserfive",
        "name": "gciuserfive",
        "slack_username": "string",
        "bio": "string",
        "location": "string",
        "occupation": "string",
        "organization": "string",
        "interests": "string",
        "skills": "string",
        "need_mentoring": false,
        "available_to_mentor": false,
        "is_available": false
    },
    {
        "id": 8,
        "username": "gciuserfivet",
        "name": "gciuserfivet",
        "slack_username": null,
        "bio": null,
        "location": null,
        "occupation": null,
        "organization": null,
        "interests": null,
        "skills": null,
        "need_mentoring": true,
        "available_to_mentor": true,
        "is_available": false
    },
    {
        "id": 9,
        "username": "gciusereighteen",
        "name": "gciusereighteen",
        "slack_username": null,
        "bio": null,
        "location": null,
        "occupation": null,
        "organization": null,
        "interests": null,
        "skills": null,
        "need_mentoring": true,
        "available_to_mentor": true,
        "is_available": true
    },
    {
        "id": 10,
        "username": "trialuser",
        "name": "trialuser",
        "slack_username": null,
        "bio": null,
        "location": null,
        "occupation": null,
        "organization": null,
        "interests": null,
        "skills": null,
        "need_mentoring": true,
        "available_to_mentor": true,
        "is_available": true
    },
    {
        "id": 11,
        "username": "tempname",
        "name": "tempname",
        "slack_username": null,
        "bio": null,
        "location": null,
        "occupation": null,
        "organization": null,
        "interests": null,
        "skills": null,
        "need_mentoring": true,
        "available_to_mentor": true,
        "is_available": true
    },
    {
        "id": 12,
        "username": "strijwoi",
        "name": "tgkrlvkp",
        "slack_username": null,
        "bio": null,
        "location": null,
        "occupation": null,
        "organization": null,
        "interests": null,
        "skills": null,
        "need_mentoring": true,
        "available_to_mentor": true,
        "is_available": true
    },
    {
        "id": 13,
        "username": "gciusertwenty",
        "name": "gciusertwenty",
        "slack_username": null,
        "bio": null,
        "location": null,
        "occupation": null,
        "organization": null,
        "interests": null,
        "skills": null,
        "need_mentoring": true,
        "available_to_mentor": true,
        "is_available": true
    }
]
```

3. Tests
```sh
python -m unittest discover tests
```
![image](https://user-images.githubusercontent.com/50169911/71549924-e5f03700-29eb-11ea-893b-66f8d36a873a.png)

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged
- [ ] Update Postman API at /docs folder
- [x] Update Swagger documentation and the exported file at /docs folder
- [ ] Update requirements.txt

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
