### PR TITLE
[Program: GCI] Write new logic to indicate if a user is currently on a relation for GET /users API (Backend)

### DIFF
--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -7,7 +7,8 @@ from app.database.models.user import UserModel
 from app.utils.decorator_utils import email_verification_required
 from app.utils.enum_utils import MentorshipRelationState
 from app.utils.validation_utils import is_email_valid
-
+from app.database.models.mentorship_relation import MentorshipRelationModel
+from app.api.dao.mentorship_relation import MentorshipRelationDAO
 
 class UserDAO:
     """Data Access Object for User functionalities"""
@@ -153,6 +154,15 @@ class UserDAO:
                     list_of_users += [user.json()]
         else:
             list_of_users = [user.json() for user in users_list]
+
+        for user in list_of_users:
+
+            user_current_relation = MentorshipRelationDAO.list_current_mentorship_relation(user['id'])
+
+            if isinstance(user_current_relation, MentorshipRelationModel):
+                user['is_available_for_relation'] = False
+            else:
+                user['is_available_for_relation'] = user['need_mentoring'] or user['available_to_mentor']
 
         return list_of_users, 200
 

--- a/app/api/models/user.py
+++ b/app/api/models/user.py
@@ -63,6 +63,10 @@ public_user_api_model = Model('User list model', {
     'available_to_mentor': fields.Boolean(
         required=True,
         description='User availability to mentor indication'
+    ),
+    'is_available_for_relation': fields.Boolean(
+        required=True,
+        description='User availability to be involved in a mentorship relationship'
     )
 })
 

--- a/tests/users/test_api_list_users.py
+++ b/tests/users/test_api_list_users.py
@@ -30,6 +30,18 @@ class TestListUsersApi(BaseTestCase):
             terms_and_conditions_checked=user2['terms_and_conditions_checked']
         )
 
+        self.other_user.available_to_mentor = False
+        self.other_user.need_mentoring = False
+
+        self.verified_user.available_to_mentor = True
+
+        self.admin_user.need_mentoring = False
+        self.admin_user.available_to_mentor = False
+
+        self.verified_user.is_available_for_relation = True
+        self.other_user.is_available_for_relation = False
+        self.admin_user.is_available_for_relation = False
+
         self.verified_user.is_email_verified = True
         db.session.add(self.verified_user)
         db.session.add(self.other_user)
@@ -44,7 +56,8 @@ class TestListUsersApi(BaseTestCase):
 
     def test_list_users_api_resource_auth(self):
         auth_header = get_test_request_header(self.admin_user.id)
-        expected_response = [marshal(self.verified_user, public_user_api_model), marshal(self.other_user, public_user_api_model)]
+        expected_response = [marshal(self.verified_user, public_user_api_model),
+                             marshal(self.other_user, public_user_api_model)]
         actual_response = self.client.get('/users', follow_redirects=True, headers=auth_header)
 
         self.assertEqual(200, actual_response.status_code)
@@ -54,6 +67,15 @@ class TestListUsersApi(BaseTestCase):
         auth_header = get_test_request_header(self.admin_user.id)
         expected_response = [marshal(self.verified_user, public_user_api_model)]
         actual_response = self.client.get('/users/verified', follow_redirects=True, headers=auth_header)
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_list_users_availability_api_resource_users(self):
+        auth_header = get_test_request_header(self.verified_user.id)
+        expected_response = [marshal(self.admin_user, public_user_api_model),
+                             marshal(self.other_user, public_user_api_model)]
+        actual_response = self.client.get('/users', follow_redirects=True, headers=auth_header)
 
         self.assertEqual(200, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))


### PR DESCRIPTION
### Description
added is_available_for_relation to GET/users and a test

Fixes #232 

### Type of Change:
- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
I tested this using `python -m unittest discover tests`

Here's a screenshot
![Capture](https://user-images.githubusercontent.com/29257061/71699914-e459b100-2de7-11ea-95a3-6594f01f48be.PNG)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged
- [x] Update Postman API at /docs folder
- [x] Update Swagger documentation and the exported file at /docs folder

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
