### PR TITLE
[Program: GCI] Add potential error responses to Swagger UI

### DIFF
--- a/app/api/dao/mentorship_relation.py
+++ b/app/api/dao/mentorship_relation.py
@@ -174,7 +174,7 @@ class MentorshipRelationDAO:
 
         # verify if I'm involved in this relation
         if not (request.mentee_id == user_id or request.mentor_id == user_id):
-            return CANT_ACCEPT_UNINVOLVED_MENTOR_RELATION, 400
+            return messages.CANT_ACCEPT_UNINVOLVED_MENTOR_RELATION, 400
 
         requests = user.mentee_relations + user.mentor_relations
 

--- a/app/api/resources/admin.py
+++ b/app/api/resources/admin.py
@@ -18,6 +18,16 @@ class AssignNewUserAdmin(Resource):
     @classmethod
     @jwt_required
     @admin_ns.expect(auth_header_parser, assign_and_revoke_user_admin_request_body, validate=True)
+    @admin_ns.doc(responses={
+        200: messages.USER_IS_NOW_AN_ADMIN['message'],
+        400: messages.USER_IS_ALREADY_AN_ADMIN['message'],
+        401: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
+             f"{messages.TOKEN_IS_INVALID['message']}<br>"
+             f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}",
+        403: f"{messages.USER_CANNOT_BE_ASSIGNED_ADMIN_BY_USER['message']}<br>"
+             f"{messages.USER_ASSIGN_NOT_ADMIN['message']}",
+        404: f"{messages.USER_NOT_FOUND['message']}<br>"
+             f"{messages.USER_DOES_NOT_EXIST['message']}"})
     def post(cls):
         """
         Assigns a User as a new Admin.
@@ -38,6 +48,16 @@ class RevokeUserAdmin(Resource):
     @classmethod
     @jwt_required
     @admin_ns.expect(auth_header_parser, assign_and_revoke_user_admin_request_body, validate=True)
+    @admin_ns.doc(responses={
+        200: messages.USER_ADMIN_STATUS_WAS_REVOKED['message'],
+        400: messages.USER_IS_NOT_AN_ADMIN['message'],
+        401: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
+             f"{messages.TOKEN_IS_INVALID['message']}<br>"
+             f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}",
+        403: f"{messages.USER_CANNOT_REVOKE_ADMIN_STATUS['message']}<br>"
+             f"{messages.USER_REVOKE_NOT_ADMIN['message']}",
+        404: f"{messages.USER_NOT_FOUND['message']}<br>"
+             f"{messages.USER_DOES_NOT_EXIST['message']}"})
     def post(cls):
         """
         Revoke admin status from another User Admin.

--- a/app/api/resources/mentorship_relation.py
+++ b/app/api/resources/mentorship_relation.py
@@ -25,6 +25,26 @@ class SendRequest(Resource):
     @jwt_required
     @mentorship_relation_ns.doc('send_request')
     @mentorship_relation_ns.expect(auth_header_parser, send_mentorship_request_body)
+    @mentorship_relation_ns.doc(responses={
+        200: messages.MENTORSHIP_RELATION_WAS_SENT_SUCCESSFULLY['message'],
+        400: f"{messages.MATCH_EITHER_MENTOR_OR_MENTEE['message']}<br>"
+             f"{messages.MENTOR_ID_SAME_AS_MENTEE_ID['message']}<br>"
+             f"{messages.END_TIME_BEFORE_PRESENT['message']}<br>"
+             f"{messages.MENTOR_TIME_GREATER_THAN_MAX_TIME['message']}<br>"
+             f"{messages.MENTOR_TIME_LESS_THAN_MIN_TIME['message']}<br>"
+             f"{messages.MENTOR_NOT_AVAILABLE_TO_MENTOR['message']}<br>"
+             f"{messages.MENTEE_NOT_AVAIL_TO_BE_MENTORED['message']}<br>"
+             f"{messages.MENTOR_IN_RELATION['message']}<br>"
+             f"{messages.MENTEE_ALREADY_IN_A_RELATION['message']}<br>"
+             f"{messages.MENTOR_ID_FIELD_IS_MISSING['message']}<br>"
+             f"{messages.MENTEE_ID_FIELD_IS_MISSING['message']}<br>"
+             f"{messages.END_DATE_FIELD_IS_MISSING['message']}<br>"
+             f"{messages.NOTES_FIELD_IS_MISSING['message']}",
+        401: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
+             f"{messages.TOKEN_IS_INVALID['message']}<br>"
+             f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}",
+        404: f"{messages.MENTOR_DOES_NOT_EXIST['message']}<br>"
+             f"{messages.MENTEE_DOES_NOT_EXIST['message']}"})
     @mentorship_relation_ns.response(200, 'Mentorship Relation request was sent successfully.')
     @mentorship_relation_ns.response(400, 'Validation error.')
     def post(cls):
@@ -67,8 +87,15 @@ class GetAllMyMentorshipRelation(Resource):
     @jwt_required
     @mentorship_relation_ns.doc('get_all_user_mentorship_relations')
     @mentorship_relation_ns.expect(auth_header_parser)
-    @mentorship_relation_ns.response(200, 'Return all user\'s mentorship relations was successfully.',
-                                     model=mentorship_request_response_body)
+    @mentorship_relation_ns.response(
+        200,
+        messages.RETURNED_ALL_MENTORSHIP_RELATIONS_WITH_SUCCESS['message'],
+        model=mentorship_request_response_body)
+    @mentorship_relation_ns.doc(responses={
+        401: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
+             f"{messages.TOKEN_IS_INVALID['message']}<br>"
+             f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}"
+    })
     @mentorship_relation_ns.marshal_list_with(mentorship_request_response_body)
     def get(cls):
         """
@@ -88,7 +115,16 @@ class AcceptMentorshipRelation(Resource):
     @jwt_required
     @mentorship_relation_ns.doc('accept_mentorship_relation')
     @mentorship_relation_ns.expect(auth_header_parser)
-    @mentorship_relation_ns.response(200, 'Accept mentorship relations with success.')
+    @mentorship_relation_ns.doc(responses={
+        200: messages.ACCEPT_MENTORSHIP_RELATIONS_WITH_SUCCESS['message'],
+        400: f"{messages.NOT_PENDING_STATE_RELATION['message']}<br>"
+             f"{messages.CANT_ACCEPT_MENTOR_REQ_SENT_BY_USER['message']}<br>"
+             f"{messages.CANT_ACCEPT_UNINVOLVED_MENTOR_RELATION['message']}<br>"
+             f"{messages.USER_IS_INVOLVED_IN_A_MENTORSHIP_RELATION['message']}",
+        401: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
+             f"{messages.TOKEN_IS_INVALID['message']}<br>"
+             f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}",
+        404: messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST['message']})
     def put(cls, request_id):
         """
         Accept a mentorship relation.
@@ -110,7 +146,15 @@ class RejectMentorshipRelation(Resource):
     @jwt_required
     @mentorship_relation_ns.doc('reject_mentorship_relation')
     @mentorship_relation_ns.expect(auth_header_parser)
-    @mentorship_relation_ns.response(200, 'Rejected mentorship relations with success.')
+    @mentorship_relation_ns.doc(responses={
+        200: messages.MENTORSHIP_RELATION_WAS_REJECTED_SUCCESSFULLY['message'],
+        400: f"{messages.NOT_PENDING_STATE_RELATION['message']}<br>"
+             f"{messages.USER_CANT_REJECT_REQUEST_SENT_BY_USER['message']}<br>"
+             f"{messages.CANT_REJECT_UNINVOLVED_RELATION_REQUEST['message']}<br>",
+        401: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
+             f"{messages.TOKEN_IS_INVALID['message']}<br>"
+             f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}",
+        404: messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST['message']})
     def put(cls, request_id):
         """
         Reject a mentorship relation.
@@ -131,7 +175,14 @@ class CancelMentorshipRelation(Resource):
     @jwt_required
     @mentorship_relation_ns.doc('cancel_mentorship_relation')
     @mentorship_relation_ns.expect(auth_header_parser)
-    @mentorship_relation_ns.response(200, 'Cancelled mentorship relations with success.')
+    @mentorship_relation_ns.doc(responses={
+        200: messages.MENTORSHIP_RELATION_WAS_CANCELLED_SUCCESSFULLY['message'],
+        400: f"{messages.UNACCEPTED_STATE_RELATION['message']}<br>"
+             f"{messages.CANT_CANCEL_UNINVOLVED_REQUEST['message']}<br>",
+        401: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
+             f"{messages.TOKEN_IS_INVALID['message']}<br>"
+             f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}",
+        404: messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST['message']})
     def put(cls, request_id):
         """
         Cancel a mentorship relation.
@@ -152,7 +203,14 @@ class DeleteMentorshipRelation(Resource):
     @jwt_required
     @mentorship_relation_ns.doc('delete_mentorship_relation')
     @mentorship_relation_ns.expect(auth_header_parser)
-    @mentorship_relation_ns.response(200, 'Deleted mentorship relation with success.')
+    @mentorship_relation_ns.doc(responses={
+        200: messages.MENTORSHIP_RELATION_WAS_DELETED_SUCCESSFULLY['message'],
+        400: f"{messages.NOT_PENDING_STATE_RELATION['message']}<br>"
+             f"{messages.CANT_DELETE_UNINVOLVED_REQUEST['message']}<br>",
+        401: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
+             f"{messages.TOKEN_IS_INVALID['message']}<br>"
+             f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}",
+        404: messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST['message']})
     def delete(cls, request_id):
         """
         Delete a mentorship request.
@@ -173,8 +231,14 @@ class ListPastMentorshipRelations(Resource):
     @jwt_required
     @mentorship_relation_ns.doc('get_past_mentorship_relations')
     @mentorship_relation_ns.expect(auth_header_parser)
-    @mentorship_relation_ns.response(200, 'Returned past mentorship relations with success.',
-                                     model=mentorship_request_response_body)
+    @mentorship_relation_ns.response(
+        200,
+        messages.RETURNED_PAST_MENTORSHIP_RELATIONS_WITH_SUCCESS['message'],
+        model=mentorship_request_response_body)
+    @mentorship_relation_ns.doc(responses={
+        401: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
+             f"{messages.TOKEN_IS_INVALID['message']}<br>"
+             f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}"})
     @mentorship_relation_ns.marshal_list_with(mentorship_request_response_body)
     def get(cls):
         """
@@ -194,8 +258,14 @@ class ListCurrentMentorshipRelation(Resource):
     @jwt_required
     @mentorship_relation_ns.doc('get_current_mentorship_relation')
     @mentorship_relation_ns.expect(auth_header_parser)
-    @mentorship_relation_ns.response(200, 'Returned current mentorship relation with success.',
-                                     model=mentorship_request_response_body)
+    @mentorship_relation_ns.response(
+        200,
+        messages.RETURNED_CURRENT_MENTORSHIP_RELATIONS_WITH_SUCCESS['message'],
+        model=mentorship_request_response_body)
+    @mentorship_relation_ns.doc(responses={
+        401: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
+             f"{messages.TOKEN_IS_INVALID['message']}<br>"
+             f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}"})
     def get(cls):
         """
         Lists current mentorship relation of the current user.
@@ -217,8 +287,14 @@ class ListPendingMentorshipRequests(Resource):
     @jwt_required
     @mentorship_relation_ns.doc('get_pending_mentorship_relations')
     @mentorship_relation_ns.expect(auth_header_parser)
-    @mentorship_relation_ns.response(200, 'Returned pending mentorship relation with success.',
-                                     model=mentorship_request_response_body)
+    @mentorship_relation_ns.response(
+        200,
+        messages.RETURNED_PENDING_MENTORSHIP_RELATIONS_WITH_SUCCESS['message'],
+        model=mentorship_request_response_body)
+    @mentorship_relation_ns.doc(responses={
+        401: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
+             f"{messages.TOKEN_IS_INVALID['message']}<br>"
+             f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}"})
     @mentorship_relation_ns.marshal_list_with(mentorship_request_response_body)
     def get(cls):
         """
@@ -238,7 +314,14 @@ class CreateTask(Resource):
     @jwt_required
     @mentorship_relation_ns.doc('create_task_in_mentorship_relation')
     @mentorship_relation_ns.expect(auth_header_parser, create_task_request_body)
-    @mentorship_relation_ns.response(200, 'Created task with success.')
+    @mentorship_relation_ns.doc(responses={
+        200: messages.TASK_WAS_CREATED_SUCCESSFULLY['message'],
+        400: f"{messages.UNACCEPTED_STATE_RELATION['message']}<br>"
+             f"{messages.DESCRIPTION_FIELD_IS_MISSING['message']}",
+        401: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
+             f"{messages.TOKEN_IS_INVALID['message']}<br>"
+             f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}",
+        404: messages.MENTORSHIP_RELATION_DOES_NOT_EXIST['message']})
     def post(cls, request_id):
         """
         Create a task.
@@ -274,7 +357,14 @@ class DeleteTask(Resource):
     @jwt_required
     @mentorship_relation_ns.doc('delete_task_in_mentorship_relation')
     @mentorship_relation_ns.expect(auth_header_parser)
-    @mentorship_relation_ns.response(200, 'Delete task with success.')
+    @mentorship_relation_ns.doc(responses={
+        200: messages.TASK_WAS_DELETED_SUCCESSFULLY['message'],
+        401: f"{messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION['message']}<br>"
+             f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
+             f"{messages.TOKEN_IS_INVALID['message']}<br>"
+             f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}",
+        404: f"{messages.MENTORSHIP_RELATION_DOES_NOT_EXIST['message']}"
+             f"{messages.TASK_DOES_NOT_EXIST['message']}"})
     def delete(cls, request_id, task_id):
         """
         Delete a task.
@@ -296,8 +386,16 @@ class ListTasks(Resource):
     @jwt_required
     @mentorship_relation_ns.doc('list_tasks_in_mentorship_relation')
     @mentorship_relation_ns.expect(auth_header_parser)
-    @mentorship_relation_ns.response(200, 'List tasks from a mentorship relation with success.',
-                                     model=list_tasks_response_body)
+    @mentorship_relation_ns.response(
+        200,
+        messages.LISTS_ALL_TASKS_WITH_SUCCESS['message'],
+        model=list_tasks_response_body)
+    @mentorship_relation_ns.doc(responses={
+        401: f"{messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION['message']}<br>"
+             f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
+             f"{messages.TOKEN_IS_INVALID['message']}<br>"
+             f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}",
+        404: messages.MENTORSHIP_RELATION_DOES_NOT_EXIST['message']})
     def get(cls, request_id):
         """
         List all tasks from a mentorship relation.
@@ -322,7 +420,15 @@ class UpdateTask(Resource):
     @jwt_required
     @mentorship_relation_ns.doc('update_task_in_mentorship_relation')
     @mentorship_relation_ns.expect(auth_header_parser)
-    @mentorship_relation_ns.response(200, 'Updated task with success.')
+    @mentorship_relation_ns.doc(responses={
+        200: messages.TASK_WAS_ACHIEVED_SUCCESSFULLY['message'],
+        400: messages.TASK_WAS_ALREADY_ACHIEVED['message'],
+        401: f"{messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION['message']}<br>"
+             f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
+             f"{messages.TOKEN_IS_INVALID['message']}<br>"
+             f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}",
+        404: f"{messages.MENTORSHIP_RELATION_DOES_NOT_EXIST['message']}"
+             f"{messages.TASK_DOES_NOT_EXIST['message']}"})
     def put(cls, request_id, task_id):
         """
         Update a task.

--- a/app/api/resources/user.py
+++ b/app/api/resources/user.py
@@ -10,6 +10,7 @@ from app.api.email_utils import send_email_verification_message
 from app.api.models.user import *
 from app.api.dao.user import UserDAO
 from app.api.resources.common import auth_header_parser
+from app.utils.validation_utils import get_length_validation_error_message
 
 users_ns = Namespace('Users', description='Operations related to users')
 add_models_to_namespace(users_ns)
@@ -25,6 +26,10 @@ class UserList(Resource):
     @users_ns.doc('list_users')
     @users_ns.marshal_list_with(public_user_api_model)
     @users_ns.expect(auth_header_parser)
+    @users_ns.doc(responses={
+        401: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
+             f"{messages.TOKEN_IS_INVALID['message']}<br>"
+             f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}"})
     def get(cls):
         """
         Returns list of all the users.
@@ -41,9 +46,13 @@ class OtherUser(Resource):
     @jwt_required
     @users_ns.doc('get_user')
     @users_ns.expect(auth_header_parser)
-    @users_ns.response(201, 'Success.', public_user_api_model)
-    @users_ns.response(400, 'User id is not valid.')
-    @users_ns.response(404, 'User does not exist.')
+    @users_ns.response(201, messages.SUCCESS['message'], public_user_api_model)
+    @users_ns.doc(responses={
+        400: messages.USER_ID_IS_NOT_VALID['message'],
+        401: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
+             f"{messages.TOKEN_IS_INVALID['message']}<br>"
+             f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}",
+        404: messages.USER_DOES_NOT_EXIST['message']})
     def get(cls, user_id):
         """
         Returns a user.
@@ -64,7 +73,6 @@ class OtherUser(Resource):
 
 
 @users_ns.route('user')
-@users_ns.response(404, 'User not found.')
 class MyUserProfile(Resource):
 
     @classmethod
@@ -72,6 +80,11 @@ class MyUserProfile(Resource):
     @users_ns.doc('get_user')
     @users_ns.expect(auth_header_parser, validate=True)
     @users_ns.marshal_with(full_user_api_model)  # , skip_none=True
+    @users_ns.doc(responses={
+        401: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
+             f"{messages.TOKEN_IS_INVALID['message']}<br>"
+             f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}",
+        404: messages.USER_DOES_NOT_EXIST['message']})
     def get(cls):
         """
         Returns a user.
@@ -83,8 +96,28 @@ class MyUserProfile(Resource):
     @jwt_required
     @users_ns.doc('update_user_profile')
     @users_ns.expect(auth_header_parser, update_user_request_body_model)
-    @users_ns.response(200, 'User successfully updated.')
-    @users_ns.response(404, 'User not found.')
+    @users_ns.doc(responses={
+        200: messages.USER_SUCCESSFULLY_UPDATED['message'],
+        400: f"{messages.USER_USES_A_USERNAME_THAT_ALREADY_EXISTS['message']}<br>"
+             f"{messages.NO_DATA_FOR_UPDATING_PROFILE_WAS_SENT['message']}<br>"
+             f"{messages.NEW_USERNAME_INPUT_BY_USER_IS_INVALID['message']}<br>"
+             f"{messages.NAME_INPUT_BY_USER_IS_INVALID['message']}<br>"
+             f"{messages.FIELD_NEED_MENTORING_IS_NOT_VALID['message']}<br>"
+             f"{messages.FIELD_AVAILABLE_TO_MENTOR_IS_INVALID['message']}<br>"
+             f"{get_length_validation_error_message('username', USERNAME_MIN_LENGTH, USERNAME_MAX_LENGTH)}<br>"
+             f"{get_length_validation_error_message('name', NAME_MIN_LENGTH, NAME_MAX_LENGTH)}<br>"
+             f"{get_length_validation_error_message('bio', None, BIO_MAX_LENGTH)}<br>"
+             f"{get_length_validation_error_message('location', None, LOCATION_MAX_LENGTH)}<br>"
+             f"{get_length_validation_error_message('occupation', None, OCCUPATION_MAX_LENGTH)}<br>"
+             f"{get_length_validation_error_message('organization', None, ORGANIZATION_MAX_LENGTH)}<br>"
+             f"{get_length_validation_error_message('slack_username', None, SLACK_USERNAME_MAX_LENGTH)}<br>"
+             f"{get_length_validation_error_message('social_media_links', None, SOCIALS_MAX_LENGTH)}<br>"
+             f"{get_length_validation_error_message('skills', None, SKILLS_MAX_LENGTH)}<br>"
+             f"{get_length_validation_error_message('interests', None, INTERESTS_MAX_LENGTH)}<br>",
+        401: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
+             f"{messages.TOKEN_IS_INVALID['message']}<br>"
+             f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}",
+        404: messages.USER_DOES_NOT_EXIST['message']})
     def put(cls):
         """
         Updates user profile
@@ -104,8 +137,13 @@ class MyUserProfile(Resource):
     @jwt_required
     @users_ns.doc('delete_user')
     @users_ns.expect(auth_header_parser, validate=True)
-    @users_ns.response(200, 'User successfully deleted.')
-    @users_ns.response(404, 'User not found.')
+    @users_ns.doc(responses={
+        200: messages.USER_SUCCESSFULLY_DELETED['message'],
+        400: messages.USER_CANT_DELETE['message'],
+        401: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
+             f"{messages.TOKEN_IS_INVALID['message']}<br>"
+             f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}",
+        404: messages.USER_DOES_NOT_EXIST['message']})
     def delete(cls):
         """
         Deletes user.
@@ -121,6 +159,17 @@ class ChangeUserPassword(Resource):
     @jwt_required
     @users_ns.doc('update_user_password')
     @users_ns.expect(auth_header_parser, change_password_request_data_model, validate=True)
+    @users_ns.doc(responses={
+        201: messages.PASSWORD_SUCCESSFULLY_UPDATED['message'],
+        400: f"{messages.USER_ENTERED_INCORRECT_PASSWORD['message']}<br>"
+             f"{messages.CURRENT_PASSWORD_FIELD_IS_MISSING['message']}<br>"
+             f"{messages.NEW_PASSWORD_FIELD_IS_MISSING['message']}<br>"
+             f"{messages.USER_INPUTS_SPACE_IN_PASSWORD['message']}<br>"
+             f"{get_length_validation_error_message('new_password', PASSWORD_MIN_LENGTH, PASSWORD_MAX_LENGTH)}",
+        401: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
+             f"{messages.TOKEN_IS_INVALID['message']}<br>"
+             f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}",
+        404: messages.USER_DOES_NOT_EXIST['message']})
     def put(cls):
         """
         Updates the user's password
@@ -141,6 +190,10 @@ class VerifiedUser(Resource):
     @users_ns.doc('get_verified_users')
     @users_ns.marshal_list_with(public_user_api_model)  # , skip_none=True
     @users_ns.expect(auth_header_parser)
+    @users_ns.doc(responses={
+        401: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
+             f"{messages.TOKEN_IS_INVALID['message']}<br>"
+             f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}"})
     def get(cls):
         """
         Returns all verified users.
@@ -154,8 +207,24 @@ class UserRegister(Resource):
 
     @classmethod
     @users_ns.doc('create_user')
-    @users_ns.response(201, 'User successfully created.')
     @users_ns.expect(register_user_api_model, validate=True)
+    @users_ns.doc(responses={
+        201: messages.USER_WAS_CREATED_SUCCESSFULLY['message'],
+        400: f"{messages.USER_USES_A_USERNAME_THAT_ALREADY_EXISTS['message']}<br>"
+             f"{messages.USER_USES_AN_EMAIL_ID_THAT_ALREADY_EXISTS['message']}<br>"
+             f"{messages.NAME_FIELD_IS_MISSING['message']}<br>"
+             f"{messages.USERNAME_FIELD_IS_MISSING['message']}<br>"
+             f"{messages.PASSWORD_FIELD_IS_MISSING['message']}<br>"
+             f"{messages.EMAIL_FIELD_IS_MISSING['message']}<br>"
+             f"{messages.TERMS_AND_CONDITIONS_FIELD_IS_MISSING['message']}<br>"
+             f"{messages.NAME_USERNAME_AND_PASSWORD_NOT_IN_STRING_FORMAT['message']}<br>"
+             f"{get_length_validation_error_message('name', NAME_MIN_LENGTH, NAME_MAX_LENGTH)}<br>"
+             f"{get_length_validation_error_message('username', USERNAME_MIN_LENGTH, USERNAME_MAX_LENGTH)}<br>"
+             f"{get_length_validation_error_message('password', PASSWORD_MIN_LENGTH, PASSWORD_MAX_LENGTH)}<br>"
+             f"{messages.TERMS_AND_CONDITIONS_ARE_NOT_CHECKED['message']}<br>"
+             f"{messages.NAME_INPUT_BY_USER_IS_INVALID['message']}<br>"
+             f"{messages.EMAIL_INPUT_BY_USER_IS_INVALID['message']}<br>"
+             f"{messages.USERNAME_INPUT_BY_USER_IS_INVALID['message']}"})
     def post(cls):
         """
         Creates a new user.
@@ -181,6 +250,10 @@ class UserRegister(Resource):
 class UserEmailConfirmation(Resource):
 
     @classmethod
+    @users_ns.doc(responses={
+        200: f"{messages.ACCOUNT_ALREADY_CONFIRMED['message']}<br>"
+             f"{messages.ACCOUNT_ALREADY_CONFIRMED_AND_THANKS['message']}",
+        400: messages.EMAIL_EXPIRED_OR_TOKEN_IS_INVALID['message']})
     def get(cls, token):
         """Confirms the user's account."""
 
@@ -192,6 +265,12 @@ class UserResendEmailConfirmation(Resource):
 
     @classmethod
     @users_ns.expect(resend_email_request_body_model)
+    @users_ns.doc(responses={
+        200: messages.EMAIL_VERIFICATION_MESSAGE['message'],
+        400: f"{messages.EMAIL_FIELD_IS_MISSING['message']}<br>"
+             f"{messages.EMAIL_INPUT_BY_USER_IS_INVALID['message']}",
+        403: messages.USER_ALREADY_CONFIRMED_ACCOUNT['message'],
+        404: messages.USER_IS_NOT_REGISTERED_IN_THE_SYSTEM['message']})
     def post(cls):
         """Sends the user a new verification email."""
 
@@ -220,7 +299,10 @@ class RefreshUser(Resource):
     @classmethod
     @jwt_refresh_token_required
     @users_ns.doc('refresh')
-    @users_ns.response(200, 'Successful refresh', refresh_response_body_model)
+    @users_ns.response(
+        200,
+        messages.SUCCESSFUL_REFRESH['message'],
+        refresh_response_body_model)
     @users_ns.expect(auth_header_parser)
     def post(cls):
         """Refresh user's access
@@ -245,8 +327,16 @@ class LoginUser(Resource):
 
     @classmethod
     @users_ns.doc('login')
-    @users_ns.response(200, 'Successful login', login_response_body_model)
+    @users_ns.response(
+        200,
+        messages.SUCCESSFUL_LOGIN['message'],
+        login_response_body_model)
     @users_ns.expect(login_request_body_model)
+    @users_ns.doc(responses={
+        400: f"{messages.USERNAME_FIELD_IS_MISSING['message']}<br>"
+             f"{messages.PASSWORD_FIELD_IS_MISSING['message']}<br>",
+        403: messages.USER_HAS_NOT_VERIFIED_EMAIL_BEFORE_LOGIN['message'],
+        404: messages.WRONG_USERNAME_OR_PASSWORD['message']})
     def post(cls):
         """
         Login user
@@ -292,12 +382,20 @@ class LoginUser(Resource):
 
 @users_ns.route('home')
 @users_ns.expect(auth_header_parser, validate=True)
-@users_ns.response(200, 'Successful response', home_response_body_model)
-@users_ns.response(404, 'User not found')
 class UserHomeStatistics(Resource):
+
     @classmethod
     @jwt_required
     @users_ns.expect(auth_header_parser)
+    @users_ns.response(
+        200,
+        messages.SUCCESSFUL_RESPONSE['message'],
+        home_response_body_model)
+    @users_ns.doc(responses={
+        401: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
+             f"{messages.TOKEN_IS_INVALID['message']}<br>"
+             f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}",
+        404: messages.USER_NOT_FOUND['message']})
     def get(cls):
         """Get Statistics regarding the current user
 

--- a/app/messages.py
+++ b/app/messages.py
@@ -196,6 +196,10 @@ RETURNED_PENDING_MENTORSHIP_RELATIONS_WITH_SUCCESS = {"message": "Returned"
                                                       " pending mentorship"
                                                       " relations"
                                                       " with success."}
+RETURNED_ALL_MENTORSHIP_RELATIONS_WITH_SUCCESS = {
+    "message": "Returned all user\'s mentorship relations with success."}
+LISTS_ALL_TASKS_WITH_SUCCESS = {
+    "message": "List tasks from a mentorship relation with success."}
 DELETE_TASK_WITH_SUCCESS = {"message": "Delete task with success."}
 UPDATED_TASK_WITH_SUCCESS = {"message": "Updated task with success."}
 USER_SUCCESSFULLY_CREATED = {"message": "User successfully created."}
@@ -203,6 +207,10 @@ USER_SUCCESSFULLY_DELETED = {"message": "User was deleted successfully"}
 USER_SUCCESSFULLY_UPDATED = {"message": "User was updated successfully."}
 PASSWORD_SUCCESSFULLY_UPDATED = {"message": "Password was updated "
                                  "successfully"}
+SUCCESS = {"message": "Success."}
+SUCCESSFUL_REFRESH = {"message": "Successful refresh."}
+SUCCESSFUL_LOGIN = {"message": "Successful login."}
+SUCCESSFUL_RESPONSE = {"message": "Successful response."}
 
 # confimation
 ACCOUNT_ALREADY_CONFIRMED = {"message": "Account already confirmed"}


### PR DESCRIPTION
### Description
- Added potential error responses to every endpoint that were included in API methods,
DAO methods and validate() functions (for instance: see the screenshot of update user endpoint)
- `@api.doc(responses={})` as it is more readable and as there might a lot of issues, so that responses in doc will look more organized
- I used `f"{messages.example['message']"` as it is easier to read in comparison to `"%s" % (...)` or `string.format(...)` 
(% (...) is even not recommended by Python, for more information read [this](https://realpython.com/python-f-strings/))
- I used `<br>` in order to split multiple messages referencing the same issue as `\n` isn't working in Swagger UI as the message is inside of a `<span>` block
- Added some new messages
- Fixed some tiny issues

Fixes #345 

### Type of Change:
- Code
- Quality Assurance
- Documentation

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
The code was tested on my laptop using Swagger UI and unit tests.

### Screenshots:

**Update user**

![Screenshot (60)](https://user-images.githubusercontent.com/34242059/71770378-268c0b00-2f2c-11ea-83ef-c0137f060948.png)

**Create admin**

![Screenshot (61)](https://user-images.githubusercontent.com/34242059/71770379-268c0b00-2f2c-11ea-97d9-7db15e04d975.png)

**Send request**

![Screenshot (62)](https://user-images.githubusercontent.com/34242059/71770380-268c0b00-2f2c-11ea-9d44-4362dbc35392.png)

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have made corresponding changes to the documentation

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes