### PR TITLE
bug fix: Scheduler starts only if it isn't running already.

### DIFF
--- a/app/schedulers/background_scheduler.py
+++ b/app/schedulers/background_scheduler.py
@@ -11,7 +11,8 @@ def init_schedulers():
     """Runs all schedulers"""
     init_complete_relation_scheduler()
     init_delete_unverified_users_scheduler()
-    scheduler.start()
+    if not scheduler.running:
+        scheduler.start()
 
 
 def init_complete_relation_scheduler():


### PR DESCRIPTION
### Description
While registering a user I received following error :
`ERROR in app: Exception on /register [POST]`
Which had one line mentioning that :
`apscheduler.schedulers.SchedulerAlreadyRunningError: Scheduler is already running`
So,
 We were trying to run scheduler even when the scheduler was already running.
Hence added a condition if the scheduler isn't running, then only we try to start the scheduler.

References:
https://apscheduler.readthedocs.io/en/latest/modules/schedulers/base.html#apscheduler.schedulers.base.BaseScheduler.running

https://apscheduler.readthedocs.io/en/latest/modules/schedulers.html#apscheduler.schedulers.SchedulerAlreadyRunningError


### Type of Change:

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
- [x] Unittests

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [ ] I have made corresponding changes to the documentation

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
