### PR TITLE
fix: dashboard crash when user is not in mentorship relation

### DIFF
--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -493,8 +493,10 @@ class UserDAO:
         response['as_mentee'] = as_mentee
 
         current_relation = MentorshipRelationDAO.list_current_mentorship_relation(user_id=user_id)
-        response['tasks_todo'] = marshal([task for task in current_relation.tasks_list.tasks if not task['is_done']], list_tasks_response_body)
-        response['tasks_done'] = marshal([task for task in current_relation.tasks_list.tasks if task['is_done']], list_tasks_response_body)
+        
+        if current_relation != (messages.NOT_IN_MENTORED_RELATION_CURRENTLY, 200):
+            response['tasks_todo'] = marshal([task for task in current_relation.tasks_list.tasks if not task['is_done']], list_tasks_response_body)
+            response['tasks_done'] = marshal([task for task in current_relation.tasks_list.tasks if task['is_done']], list_tasks_response_body)
 
         return response
 


### PR DESCRIPTION
### Description
Checking if mentorship relation exist before accessing sub-objects.

Fixes [#438](https://github.com/anitab-org/mentorship-backend/issues/438)

### Type of Change:
- Code

### How Has This Been Tested?
Has been tested on local server
<img width="1421" alt="Screenshot 2020-02-16 at 19 36 06" src="https://user-images.githubusercontent.com/31966073/74611422-9b3d9200-50f3-11ea-9021-459928c2de78.png">


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged
- [ ] Update Postman API at /docs folder
- [ ] Update Swagger documentation and the exported file at /docs folder
- [ ] Update requirements.txt

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
