### PR TITLE
Hardcoded testcases removed

### DIFF
--- a/tests/users/test_api_list_users.py
+++ b/tests/users/test_api_list_users.py
@@ -91,7 +91,7 @@ class TestListUsersApi(BaseTestCase):
     def test_list_users_api_with_a_search_query_resource_auth(self):
         auth_header = get_test_request_header(self.admin_user.id)
         expected_response = [marshal(self.other_user, public_user_api_model)]
-        actual_response = self.client.get('/users?search=b', follow_redirects=True,
+        actual_response = self.client.get(f'/users?search={self.other_user.name[-3:]}', follow_redirects=True,
                                           headers=auth_header)
 
         self.assertEqual(200, actual_response.status_code)
@@ -102,7 +102,7 @@ class TestListUsersApi(BaseTestCase):
         auth_header = get_test_request_header(self.admin_user.id)
         expected_response = [
             marshal(self.other_user, public_user_api_model)]
-        actual_response = self.client.get('/users?search=USERB',
+        actual_response = self.client.get(f'/users?search={self.other_user.name.upper()}',
                                           follow_redirects=True,
                                           headers=auth_header)
 
@@ -130,7 +130,7 @@ class TestListUsersApi(BaseTestCase):
         expected_response = [
             marshal(self.second_user, public_user_api_model)]
         actual_response = self.client.get(
-            f"/users?search=s_t-r%24a%2Fn'ge",
+            f"/users?search={self.second_user.name}",
             follow_redirects=True,
             headers=auth_header)
 


### PR DESCRIPTION
### Description
Test cases were hardcoded with strings, but if any changes are done in test data, there should be no error in the corresponding tests, but in this case, tests would fail. 

Fixes # [ISSUE]

### Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
python -m unittest discover


### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
