### PR TITLE
fix: email verification date type changed from datetime to float (#447)

### DIFF
--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from operator import itemgetter
+import time
 from flask_restplus import marshal
 
 from app import messages
@@ -326,7 +327,7 @@ class UserDAO:
             return messages.ACCOUNT_ALREADY_CONFIRMED, 200
         else:
             user.is_email_verified = True
-            user.email_verification_date = datetime.now()
+            user.email_verification_date = time.time()
             user.save_to_db()
             return messages.ACCOUNT_ALREADY_CONFIRMED_AND_THANKS, 200
 

--- a/app/api/models/user.py
+++ b/app/api/models/user.py
@@ -109,7 +109,7 @@ full_user_api_model = Model('User Complete model used in listing', {
         required=True,
         description='User email verification status'
     ),
-    'email_verification_date': fields.DateTime(
+    'email_verification_date': fields.Float(
         required=False,
         description='User email verification date'
     ),

--- a/app/database/models/user.py
+++ b/app/database/models/user.py
@@ -36,7 +36,7 @@ class UserModel(db.Model):
 
     # email verification
     is_email_verified = db.Column(db.Boolean)
-    email_verification_date = db.Column(db.DateTime)
+    email_verification_date = db.Column(db.Float)
 
     # other info
     current_mentorship_role = db.Column(db.Integer)

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1035,7 +1035,7 @@
                 },
                 "email_verification_date": {
                     "type": "string",
-                    "format": "date-time",
+                    "format": "float",
                     "description": "User email verification date"
                 },
                 "bio": {


### PR DESCRIPTION
### Description
email verification date type changed from datetime to float to save and send response in unix float format

Fixes #447 

### Type of Change:
**Delete irrelevant options.**

- Quality Assurance


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
![Screenshot from 2020-02-27 02-42-38](https://user-images.githubusercontent.com/32351832/75388375-d79a9a80-590a-11ea-964d-13ede7459dc5.png)



### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have made corresponding changes to the documentation

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] Any dependent changes have been published in downstream modules
