### PR TITLE
Add a query parameter support to GET /users, to order users by name a…

### DIFF
--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -140,43 +140,33 @@ class UserDAO:
         return UserModel.find_by_username(username)
 
     @staticmethod
-    def list_users(user_id, search_query='', is_verified=None, filter_by='', order_by=''):
+    def list_users(user_id, search_query='', is_verified=None, name_asc='', name_desc=''):
         """ Retrieves a list of verified users with the specified ID.
         
         Arguments:
             user_id: The ID of the user to be listed.
             search_query: The search query for name of the users to be found.
             is_verified: Status of the user's verification; None when provided as an argument.
-            filter: 0 for alphabetically order and 1 for creation date.
-            order: 0 for ascending order and 1 for descending order.
+            name_asc: 1 for sort ascending order by name.
+            name_desc: 1 for sort descending order by name.
         
         Returns:
             A list of users matching conditions and the HTTP response code.
         
         """
-        
-        if filter_by=="":
-            if order_by=="":
-                users_list = UserModel.query.filter(UserModel.id != user_id).all()
-            else:
-                raise BadRequest(f"{messages.FILTER_BY_IS_MISSING['message']}")
-        elif filter_by=="0":
-            if order_by=="0" or order_by=="":
+
+        if name_asc!="" or name_desc!="":
+            if name_asc=="1" and name_desc=="1":
+                raise BadRequest(f"{messages.FIELD_FOR_ORDER_BY_IS_NOT_VALID['message']}")
+            elif name_asc=="1":
                 users_list = UserModel.query.filter(UserModel.id != user_id).order_by(UserModel.name.asc()).all()
-            elif order_by=="1":
+            elif name_desc=="1":
                 users_list = UserModel.query.filter(UserModel.id != user_id).order_by(UserModel.name.desc()).all()
             else:
                 raise BadRequest(f"{messages.FIELD_FOR_ORDER_BY_IS_INVALID['message']}")
-
-        elif filter_by=="1":
-            if order_by=="0" or order_by=="":
-                users_list = UserModel.query.filter(UserModel.id != user_id).order_by(UserModel.email_verification_date.asc()).all()
-            elif order_by=="1":
-                users_list = UserModel.query.filter(UserModel.id != user_id).order_by(UserModel.email_verification_date.desc()).all()
-            else:
-                raise BadRequest(f"{messages.FIELD_FOR_ORDER_BY_IS_INVALID['message']}")
         else:
-            raise BadRequest(f"{messages.FIELD_FOR_FILTER_BY_IS_INVALID['message']}")
+            users_list = UserModel.query.filter(UserModel.id != user_id).all()
+
 
         list_of_users = [user.json() for user in filter(
             lambda user: (not is_verified or user.is_email_verified)

--- a/app/api/resources/user.py
+++ b/app/api/resources/user.py
@@ -29,11 +29,18 @@ class UserList(Resource):
 
     @classmethod
     @jwt_required
-    @users_ns.doc('list_users', params={'search': 'Search query'})
+    @users_ns.doc('list_users', params={'search': 'Search query',
+                                        'filter_by': '0 for alphabetically order and 1 for creation date',
+                                        'order_by': '0 for ascending order and 1 for descending order'
+                                        })
     @users_ns.doc(responses={
         401: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
              f"{messages.TOKEN_IS_INVALID['message']}<br>"
              f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}"})
+    @users_ns.doc(responses={
+        400: f"{messages.FIELD_FOR_FILTER_BY_IS_INVALID['message']}<br>"
+             f"{messages.FIELD_FOR_ORDER_BY_IS_INVALID['message']}<br>"
+             f"{messages.FILTER_BY_IS_MISSING['message']}"})
     @users_ns.marshal_list_with(public_user_api_model)
     @users_ns.expect(auth_header_parser)
     def get(cls):
@@ -47,7 +54,7 @@ class UserList(Resource):
         available_to_mentor. The current user's details are not returned.
         """
         user_id = get_jwt_identity()
-        return DAO.list_users(user_id, request.args.get('search', ''))
+        return DAO.list_users(user_id, request.args.get('search', ''),filter_by=request.args.get('filter_by', ''), order_by=request.args.get('order_by', ''))
 
 
 @users_ns.route('users/<int:user_id>')

--- a/app/api/resources/user.py
+++ b/app/api/resources/user.py
@@ -30,17 +30,17 @@ class UserList(Resource):
     @classmethod
     @jwt_required
     @users_ns.doc('list_users', params={'search': 'Search query',
-                                        'filter_by': '0 for alphabetically order and 1 for creation date',
-                                        'order_by': '0 for ascending order and 1 for descending order'
+                                        'name_asc': '1 for sort ascending order by name',
+                                        'name_desc': '1 for sort descending order by name'
                                         })
     @users_ns.doc(responses={
         401: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
              f"{messages.TOKEN_IS_INVALID['message']}<br>"
              f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}"})
     @users_ns.doc(responses={
-        400: f"{messages.FIELD_FOR_FILTER_BY_IS_INVALID['message']}<br>"
-             f"{messages.FIELD_FOR_ORDER_BY_IS_INVALID['message']}<br>"
-             f"{messages.FILTER_BY_IS_MISSING['message']}"})
+        400: f"{messages.FIELD_FOR_ORDER_BY_IS_INVALID['message']}<br>"
+             f"{messages.FIELD_FOR_ORDER_BY_IS_NOT_VALID['message']}"
+            })
     @users_ns.marshal_list_with(public_user_api_model)
     @users_ns.expect(auth_header_parser)
     def get(cls):
@@ -54,7 +54,7 @@ class UserList(Resource):
         available_to_mentor. The current user's details are not returned.
         """
         user_id = get_jwt_identity()
-        return DAO.list_users(user_id, request.args.get('search', ''),filter_by=request.args.get('filter_by', ''), order_by=request.args.get('order_by', ''))
+        return DAO.list_users(user_id, request.args.get('search', ''), name_asc=request.args.get('name_asc', ''), name_desc=request.args.get('name_desc', ''))
 
 
 @users_ns.route('users/<int:user_id>')

--- a/app/messages.py
+++ b/app/messages.py
@@ -10,6 +10,8 @@ FIELD_NEED_MENTORING_IS_NOT_VALID = {"message": "Field need_mentoring is"
                                      " not valid."}
 FIELD_AVAILABLE_TO_MENTOR_IS_INVALID = {"message": "Field available_to_mentor"
                                         " is not valid."}
+FIELD_FOR_FILTER_BY_IS_INVALID = {"message": "Filter by should be either 0 or 1"}
+FIELD_FOR_ORDER_BY_IS_INVALID = {"message": "Order by should be either 0 or 1"}
 
 # Not found
 MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST = {"message": "This mentorship"
@@ -44,6 +46,7 @@ AUTHORISATION_TOKEN_IS_MISSING = {"message": "The authorization token is"
                                   " missing!."}
 DESCRIPTION_FIELD_IS_MISSING = {"message": "Description field is missing"}
 COMMENT_FIELD_IS_MISSING = {"message": "Comment field is missing"}
+FILTER_BY_IS_MISSING = {"message": "Filter by is missing"}
 
 # Admin
 USER_IS_ALREADY_AN_ADMIN = {"message": "User is already an Admin."}

--- a/app/messages.py
+++ b/app/messages.py
@@ -10,8 +10,8 @@ FIELD_NEED_MENTORING_IS_NOT_VALID = {"message": "Field need_mentoring is"
                                      " not valid."}
 FIELD_AVAILABLE_TO_MENTOR_IS_INVALID = {"message": "Field available_to_mentor"
                                         " is not valid."}
-FIELD_FOR_FILTER_BY_IS_INVALID = {"message": "Filter by should be either 0 or 1"}
-FIELD_FOR_ORDER_BY_IS_INVALID = {"message": "Order by should be either 0 or 1"}
+FIELD_FOR_ORDER_BY_IS_INVALID = {"message": "name_asc and name_desc should be 1"}
+FIELD_FOR_ORDER_BY_IS_NOT_VALID = {"message": "Both name_asc and name_desc should not be 1 at same time"}
 
 # Not found
 MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST = {"message": "This mentorship"
@@ -46,7 +46,6 @@ AUTHORISATION_TOKEN_IS_MISSING = {"message": "The authorization token is"
                                   " missing!."}
 DESCRIPTION_FIELD_IS_MISSING = {"message": "Description field is missing"}
 COMMENT_FIELD_IS_MISSING = {"message": "Comment field is missing"}
-FILTER_BY_IS_MISSING = {"message": "Filter by is missing"}
 
 # Admin
 USER_IS_ALREADY_AN_ADMIN = {"message": "User is already an Admin."}

--- a/tests/users/test_api_list_users.py
+++ b/tests/users/test_api_list_users.py
@@ -98,10 +98,20 @@ class TestListUsersApi(BaseTestCase):
         self.assertEqual(expected_response,
                          json.loads(actual_response.data))
 
-    def test_list_users_api_with_a_search_query_with_filter_by_and_order_by_resource_auth(self):
+    def test_list_users_api_with_a_search_query_with_name_asc_by_resource_auth(self):
         auth_header = get_test_request_header(self.admin_user.id)
         expected_response = [marshal(self.other_user, public_user_api_model)]
-        actual_response = self.client.get('/users?search=b&filter_by=1&order_by=1', follow_redirects=True,
+        actual_response = self.client.get('/users?search=b&name_asc=1', follow_redirects=True,
+                                          headers=auth_header)
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response,
+                         json.loads(actual_response.data))
+    
+    def test_list_users_api_with_a_search_query_with_name_desc_by_resource_auth(self):
+        auth_header = get_test_request_header(self.admin_user.id)
+        expected_response = [marshal(self.other_user, public_user_api_model)]
+        actual_response = self.client.get('/users?search=b&name_desc=1', follow_redirects=True,
                                           headers=auth_header)
 
         self.assertEqual(200, actual_response.status_code)

--- a/tests/users/test_api_list_users.py
+++ b/tests/users/test_api_list_users.py
@@ -98,6 +98,16 @@ class TestListUsersApi(BaseTestCase):
         self.assertEqual(expected_response,
                          json.loads(actual_response.data))
 
+    def test_list_users_api_with_a_search_query_with_filter_by_and_order_by_resource_auth(self):
+        auth_header = get_test_request_header(self.admin_user.id)
+        expected_response = [marshal(self.other_user, public_user_api_model)]
+        actual_response = self.client.get('/users?search=b&filter_by=1&order_by=1', follow_redirects=True,
+                                          headers=auth_header)
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response,
+                         json.loads(actual_response.data))
+
     def test_list_users_api_with_a_search_query_all_caps_resource_auth(self):
         auth_header = get_test_request_header(self.admin_user.id)
         expected_response = [


### PR DESCRIPTION
### Description
1. Add a query parameter support to GET /users, to order users by name and creation date (both ascending and descending order).
2. Update Swagger UI documentation for this API.
3. Write one test case to check where filter_by(name, creation date) and order_by(ascending or descending order) is working properly or not.

Fixes #420

### Type of Change:
- Code
- Quality Assurance
- User Interface

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
When filter_by=0 (filter by name) and order_by=0 (ascending order)
![filter0order0](https://user-images.githubusercontent.com/35588980/75910393-ce15b300-5e73-11ea-8438-b953bd59a862.gif)

When filter_by=0(filter by name) and order_by=1(descending order)
![filter0order1](https://user-images.githubusercontent.com/35588980/75910634-32387700-5e74-11ea-96c5-44c3bef780f6.gif)

When filter_by=1(filter by creation date; use email_verification_date) and order_by=0(ascending order)
![filter1order0](https://user-images.githubusercontent.com/35588980/75910673-42e8ed00-5e74-11ea-9782-a93944a49c23.gif)

When filter_by=1(ffilter by creation date; use email_verification_date) and order_by=1(descending order)
![filter1order1](https://user-images.githubusercontent.com/35588980/75910727-5dbb6180-5e74-11ea-912d-62f81c1e32d2.gif)


### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] Update Swagger UI documentation

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works

