### PR TITLE
Update Environment Variables link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is the Backend REST API for the Mentorship System.
 To setup the project locally read these wiki pages and follow the instructions:
 
  - [Fork, Clone and Remote](https://github.com/anitab-org/mentorship-backend/wiki/Fork%2C-Clone-%26-Remote)
- - [Export Environment Variables](https://github.com/anitab-org/mentorship-backend/wiki/Environment-Variables)
+ - [Export Environment Variables](https://github.com/anitab-org/mentorship-backend/blob/develop/docs/environment-variables.md)
 
 ### Run app
 
@@ -30,7 +30,7 @@ The project runs on Python 3.
 
 4. Make sure you create `.env` using `.env.template` and update the values of corresponding environment variables
 or
-make sure you exported the following [environment variables](https://github.com/anitab-org/mentorship-backend/wiki/Environment-Variables):
+make sure you exported the following [environment variables](https://github.com/anitab-org/mentorship-backend/blob/develop/docs/environment-variables.md):
 
 ```
 export FLASK_ENVIRONMENT_CONFIG=<local-or-dev-or-test-or-prod-or-stag>
@@ -60,7 +60,7 @@ export DB_NAME=<database_name>
 `deactivate`
 
 ### Run with docker
-1. Make sure you exported the following [environment variables](https://github.com/anitab-org/mentorship-backend/wiki/Environment-Variables) to '.env' file
+1. Make sure you exported the following [environment variables](https://github.com/anitab-org/mentorship-backend/blob/develop/docs/environment-variables.md) to '.env' file
 
 2. Build docker image
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is the Backend REST API for the Mentorship System.
 To setup the project locally read these wiki pages and follow the instructions:
 
  - [Fork, Clone and Remote](https://github.com/anitab-org/mentorship-backend/wiki/Fork%2C-Clone-%26-Remote)
- - [Export Environment Variables](https://github.com/anitab-org/mentorship-backend/blob/develop/docs/environment-variables.md)
+ - [Export Environment Variables](docs/environment-variables.md)
 
 ### Run app
 
@@ -30,7 +30,7 @@ The project runs on Python 3.
 
 4. Make sure you create `.env` using `.env.template` and update the values of corresponding environment variables
 or
-make sure you exported the following [environment variables](https://github.com/anitab-org/mentorship-backend/blob/develop/docs/environment-variables.md):
+make sure you exported the following [environment variables](docs/environment-variables.md):
 
 ```
 export FLASK_ENVIRONMENT_CONFIG=<local-or-dev-or-test-or-prod-or-stag>
@@ -60,7 +60,7 @@ export DB_NAME=<database_name>
 `deactivate`
 
 ### Run with docker
-1. Make sure you exported the following [environment variables](https://github.com/anitab-org/mentorship-backend/blob/develop/docs/environment-variables.md) to '.env' file
+1. Make sure you exported the following [environment variables](docs/environment-variables.md) to '.env' file
 
 2. Build docker image
 ```


### PR DESCRIPTION
Changed the link assosciated with environment variables from wiki to the repo link as mentioned in the issue.

### Description
Earlier the link explaining the exporting of environment variables was to a wiki page which asked to refer to mentorship-backend/docs/environment-variables.md. I simply connected the link directly to the file thus skipping the wiki link.

Fixes #494 

### Type of Change:
- Documentation



### How Has This Been Tested?
The new link takes to the appropriate directory.

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have made corresponding changes to the documentation

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
