### PR TITLE
Update Email max length

### DIFF
--- a/app/database/models/user.py
+++ b/app/database/models/user.py
@@ -25,7 +25,7 @@ class UserModel(db.Model):
     # personal data
     name = db.Column(db.String(30))
     username = db.Column(db.String(30), unique=True)
-    email = db.Column(db.String(30), unique=True)
+    email = db.Column(db.String(254), unique=True)
 
     # security
     password_hash = db.Column(db.String(100))


### PR DESCRIPTION
### Description
Changed the email length restriction from 30 chars to 254 chars
there is a restriction in RFC 2821 on the length of an email address of 254 characters. The upper limit on address lengths should normally be considered to be 254 (neglecting the angular brackets used to form a path).

Fixes #504 

### Type of Change:

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
