### PR TITLE
RE - Issue #403 -  is_verified filter implemented to filter users by verification state to GET /users API for 

### DIFF
--- a/app/api/resources/user.py
+++ b/app/api/resources/user.py
@@ -37,7 +37,7 @@ DAO = UserDAO()  # User data access object
 class UserList(Resource):
     @classmethod
     @jwt_required
-    @users_ns.doc("list_users", params={"search": "Search query"})
+    @users_ns.doc("list_users", params={"search": "Search query", "is_verified":"Status of the user's verification. Type of this parameter is boolean. Default value is false."})
     @users_ns.doc(
         responses={
             401: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
@@ -58,7 +58,10 @@ class UserList(Resource):
         available_to_mentor. The current user's details are not returned.
         """
         user_id = get_jwt_identity()
-        return DAO.list_users(user_id, request.args.get("search", ""))
+
+        is_verified  = True if request.args.get("is_verified","false").lower() == "true" else False
+        
+        return DAO.list_users(user_id, request.args.get("search", ""), is_verified = is_verified)
 
 
 @users_ns.route("users/<int:user_id>")

--- a/tests/users/test_api_list_users.py
+++ b/tests/users/test_api_list_users.py
@@ -92,6 +92,16 @@ class TestListUsersApi(BaseTestCase):
         self.assertEqual(200, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
+    def test_list_users_api_with_is_verified_query_resource_auth(self):
+        auth_header = get_test_request_header(self.admin_user.id)
+        expected_response = [marshal(self.verified_user, public_user_api_model)]
+        actual_response = self.client.get(
+            "/users?is_verified=true", follow_redirects=True, headers=auth_header
+        )
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
     def test_list_users_api_with_a_search_query_resource_auth(self):
         auth_header = get_test_request_header(self.admin_user.id)
         expected_response = [marshal(self.other_user, public_user_api_model)]


### PR DESCRIPTION
Hi ,

There were some issues related to user email in the previous PR. I got messy so I closed that and created a fresh new one.

#### Description 
I have added a query parameter to filter verified users in` GET /users` API. So now we don't need a separate API `GET /users/verified`. But I have not removed it as It can break the application.
Please review and merge my code.

Fixes #403

#### Type of Change:
Code

#### Code/Quality Assurance Only
I have added the new query parameter in swagger using `@users_ns.doc`

####How Has This Been Tested?
I have tested it on local.
First created some users and tested if they are coming in GET /users with is_verified=true and without it. Then I verified some of the users and again checked the same.
API was returning JSON output as expected .

#### Checklist:
 - [X] My PR follows the style guidelines of this project
 - [X] I have performed a self-review of my own code or materials
 - [X] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
 - [X]  I have made corresponding changes to the documentation

####Code/Quality Assurance Only

- [X] My changes generate no new warnings
 - [X] I have added tests that prove my fix is effective or that my feature works

####Acceptance Criteria
Update [Required]

- [X]  Add a query parameter support to `GET /users`, to filter by its current state.
- [X]  Update Swagger UI documentation for this API.
- [X]  Write at least one test to prove your new feature is working.

Note - Please review & approve this quickly. I have code ready for other PR's as well. 