### PR TITLE
Add mock email service

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -5,4 +5,4 @@ MAIL_DEFAULT_SENDER = <mail-default-sender>
 MAIL_SERVER = <mail-server>
 APP_MAIL_USERNAME = <app-mail-username>
 APP_MAIL_PASSWORD = <app-mail-password>
-MOCK_EMAIL = <True-False>
+MOCK_EMAIL = <True-or-False>

--- a/.env.template
+++ b/.env.template
@@ -5,3 +5,4 @@ MAIL_DEFAULT_SENDER = <mail-default-sender>
 MAIL_SERVER = <mail-server>
 APP_MAIL_USERNAME = <app-mail-username>
 APP_MAIL_PASSWORD = <app-mail-password>
+MOCK_EMAIL = <True-False>

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ export MAIL_DEFAULT_SENDER=<mail-default-sender>
 export MAIL_SERVER=<mail-server>
 export APP_MAIL_USERNAME=<app-mail-username>
 export APP_MAIL_PASSWORD=<app-mail-password>
-export MOCK_EMAIL = <True-False>
+export MOCK_EMAIL = <True-or-False>
 ```
 
 If you're testing any environment other than "local", then you have to also set these other variables:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ export MAIL_DEFAULT_SENDER=<mail-default-sender>
 export MAIL_SERVER=<mail-server>
 export APP_MAIL_USERNAME=<app-mail-username>
 export APP_MAIL_PASSWORD=<app-mail-password>
+export MOCK_EMAIL = <True-False>
 ```
 
 If you're testing any environment other than "local", then you have to also set these other variables:

--- a/app/api/email_utils.py
+++ b/app/api/email_utils.py
@@ -43,17 +43,29 @@ def confirm_token(token, expiration=config.BaseConfig.UNVERIFIED_USER_THRESHOLD)
     return email
 
 
+def mock_send_email(recipient,subject,template):
+    """Mocks the email sending behaviour by printing it as terminal output."""
+
+    print("Mock Email Service")
+    print("Subject: {}".format(subject))
+    print("Recipient: {}".format(recipient))
+    print(template)
+
+
 def send_email(recipient, subject, template):
     """Sends a html email message with a subject to the specified recipient."""
     from run import application
 
-    msg = Message(
-        subject,
-        recipients=[recipient],
-        html=template,
-        sender=application.config["MAIL_DEFAULT_SENDER"],
-    )
-    mail.send(msg)
+    if application.config["MOCK_EMAIL"]:
+        mock_send_email(recipient,subject,template)
+    else:
+        msg = Message(
+            subject,
+            recipients=[recipient],
+            html=template,
+            sender=application.config["MAIL_DEFAULT_SENDER"],
+        )
+        mail.send(msg)
 
 
 def send_email_verification_message(user_name, email):

--- a/app/api/email_utils.py
+++ b/app/api/email_utils.py
@@ -47,8 +47,8 @@ def mock_send_email(recipient,subject,template):
     """Mocks the email sending behaviour by printing it as terminal output."""
 
     print("Mock Email Service")
-    print("Subject: {}".format(subject))
-    print("Recipient: {}".format(recipient))
+    print(f"Subject: {subject}")
+    print(f"Recipient: {recipient}")
     print(template)
 
 

--- a/config.py
+++ b/config.py
@@ -2,6 +2,23 @@ import os
 from datetime import timedelta
 
 
+def get_mock_email_config() -> bool:
+    MOCK_EMAIL = os.getenv("MOCK_EMAIL")
+
+    if  MOCK_EMAIL:
+        if MOCK_EMAIL=="True":
+            return True
+        elif MOCK_EMAIL=="False":
+            return False
+        else:
+            raise ValueError(
+                "MOCK_EMAIL environment variable has to valued either: 'True' or 'False' or <not defined>"
+            )
+    else:
+        # Default behaviour is to send the email if MOCK_EMAIL is not set
+        return False
+
+
 class BaseConfig(object):
     """Base configuration."""
 
@@ -41,6 +58,7 @@ class BaseConfig(object):
     DEBUG_TB_INTERCEPT_REDIRECTS = False
 
     # mail settings
+    MOCK_EMAIL = get_mock_email_config()
     MAIL_SERVER = os.getenv("MAIL_SERVER")
     MAIL_PORT = 465
     MAIL_USE_TLS = False
@@ -76,6 +94,7 @@ class ProductionConfig(BaseConfig):
     """Production configuration."""
 
     SQLALCHEMY_DATABASE_URI = BaseConfig.build_db_uri()
+    MOCK_EMAIL = False
 
 
 class DevelopmentConfig(BaseConfig):
@@ -90,7 +109,7 @@ class StagingConfig(BaseConfig):
 
     DEBUG = True
     SQLALCHEMY_DATABASE_URI = BaseConfig.build_db_uri()
-
+    MOCK_EMAIL = False
 
 class LocalConfig(BaseConfig):
     """Local configuration."""
@@ -105,6 +124,7 @@ class TestingConfig(BaseConfig):
     """Testing configuration."""
 
     TESTING = True
+    MOCK_EMAIL = True
 
     # Use in-memory SQLite database for testing
     SQLALCHEMY_DATABASE_URI = "sqlite://"

--- a/config.py
+++ b/config.py
@@ -5,14 +5,19 @@ from datetime import timedelta
 def get_mock_email_config() -> bool:
     MOCK_EMAIL = os.getenv("MOCK_EMAIL")
 
-    if  MOCK_EMAIL:
-        if MOCK_EMAIL=="True":
+    #if MOCK_EMAIL env variable is set
+    if  MOCK_EMAIL: 
+        # MOCK_EMAIL is case insensitive
+        MOCK_EMAIL = MOCK_EMAIL.lower()
+        
+        if MOCK_EMAIL=="true":
             return True
-        elif MOCK_EMAIL=="False":
+        elif MOCK_EMAIL=="false":
             return False
-        else:
+        else: 
+            # if MOCK_EMAIL env variable is set a wrong value
             raise ValueError(
-                "MOCK_EMAIL environment variable has to valued either: 'True' or 'False' or <not defined>"
+                "MOCK_EMAIL environment variable is optional if set, it has to be valued as either 'True' or 'False'"
             )
     else:
         # Default behaviour is to send the email if MOCK_EMAIL is not set

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -11,6 +11,7 @@ export MAIL_DEFAULT_SENDER=<mail-default-sender>
 export MAIL_SERVER=<mail-server>
 export APP_MAIL_USERNAME=<app-mail-username>
 export APP_MAIL_PASSWORD=<app-mail-password>
+export MOCK_EMAIL = <True-False>
 ```
 
 ## Environment Variables Description
@@ -48,7 +49,12 @@ _Note:_
 - In the examples we use Gmail account example, but you are not restricted to use a Gmail account to send the verification email. If you use other email providers make sure to research about the correct SMTP server name.
 - The `'` character may be optional for environment variables without space on them.
 
-## Exporting Environment Variables
+
+### Mock Email Service
+
+The email sending behaviour can be mocked by setting **MOCK_EMAIL** to 'True'. When set to 'True' it pipes the email as terminal output. Setting it to 'False' (or not setting it) will result in sending emails.
+
+## Exporting environment variables
 
 Assume that KEY is the name of the variable and VALUE is the actual value of the environment variable. 
 To export an environment variable you have to run:

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -11,7 +11,7 @@ export MAIL_DEFAULT_SENDER=<mail-default-sender>
 export MAIL_SERVER=<mail-server>
 export APP_MAIL_USERNAME=<app-mail-username>
 export APP_MAIL_PASSWORD=<app-mail-password>
-export MOCK_EMAIL = <True-False>
+export MOCK_EMAIL = <True-or-False>
 ```
 
 ## Environment Variables Description


### PR DESCRIPTION
### Description
1. MOCK_EMAIL env variable is added
1. Updated send_email function
1. Default behaviour is set to send emails
1. Corresponding changes have been set to different environments like prod, dev, local etc.,

Fixes #524

### Type of Change:
- Code
- Documentation

**Code/Quality Assurance Only**
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
* Tested the 4 options of MOCK_EMAIL for expect outcome by triggering /user/resend_email API call.
  1. True
  1. False
  1. not set
  1. random-string 
* Ran the complete test suite for bugs.

### Checklist:

- [X] My PR follows the style guidelines of this project
- [X] I have performed a self-review of my own code or materials
- [X] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation

**Code/Quality Assurance Only**
- [X] My changes generate no new warnings 
- [X] New and existing unit tests pass locally with my changes
