### PR TITLE
Fix: prevent user data insert on failed sending email verification

### DIFF
--- a/app/messages.py
+++ b/app/messages.py
@@ -282,3 +282,9 @@ INVALID_END_DATE = {
     "message": "Validation error. End date represented by the timestamp is invalid."
 }
 NOT_IMPLEMENTED = {"message": "Not implemented."}
+
+# Failed to send verification email due to security settings on default MAIL_SERVER
+EMAIL_SETTINGS_ERROR = {"message": "The application is not authorized to use the default email server. Please adjust your Email security settings."}
+
+# Failed to send verification email caused by SMTP error
+SMTP_ERROR = {"message": "Registration cannot be completed due to error in sending verification email. Please try again or contact our IT support-desk."}


### PR DESCRIPTION
### Description
Include a summary of the change and relevant motivation/context. List any dependencies that are required for this change.

Fixes #461 and replaces PR #463 

### Type of Change:

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)



### How Has This Been Tested?
This is tested by:

-  attempting to create user with 'Less secure app access' turned 'OFF' on gmail settings. 

- checking local database to ensure new data is not inserted

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes
