### PR TITLE
docs: Fix typos in docs files.

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -13,13 +13,13 @@ export APP_MAIL_USERNAME=<app-mail-username>
 export APP_MAIL_PASSWORD=<app-mail-password>
 ```
 
-## Environment variables description
+## Environment Variables Description
 
-### Run configuration
+### Run Configuration
 
 | Environment Variable     | Description                                                                                                                                                                                                                    | Example |
 |--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
-| FLASK_ENVIRONMENT_CONFIG | Short running environment name so that Flask know which configuration to load. Currently, there are 3 options for this: `dev`, `test` and `prod`.  To use the development environment configuration you should use "dev" as a value. | dev     |
+| FLASK_ENVIRONMENT_CONFIG | Short running environment name so that Flask knows which configuration to load. Currently, there are 3 options for this: `dev`, `test` and `prod`.  To use the development environment configuration you should use "dev" as a value. | dev     |
 
 These are the currently available run configurations:
 - **dev:** Development environment used when developing locally
@@ -48,7 +48,7 @@ _Note:_
 - In the examples we use Gmail account example, but you are not restricted to use a Gmail account to send the verification email. If you use other email providers make sure to research about the correct SMTP server name.
 - The `'` character may be optional for environment variables without space on them.
 
-## Exporting environment variables
+## Exporting Environment Variables
 
 Assume that KEY is the name of the variable and VALUE is the actual value of the environment variable. 
 To export an environment variable you have to run:

--- a/docs/quality-assurance-test-cases.md
+++ b/docs/quality-assurance-test-cases.md
@@ -7,7 +7,7 @@ This document contains some examples of test cases for each feature implemented 
 
 **Notes:**
 - Outcome _Fail_ means the test case as no effect in the database, so no changes are done in the data. An error message should be returned;
-- Outcome _Success_ means e that the test case was successful and had an effect in the database, so this changes/effect should be visible on the database. E.g.: If a user is registered successfully, you should be able to login, and be seen using the GET /users API;
+- Outcome _Success_ means that the test case was successful and had an effect in the database, so this change/effect should be visible on the database. E.g.: If a user is registered successfully, you should be able to login, and be seen using the GET /users API;
 - When testing something make sure only one aspect of the test is failing the requirements;
 - “Logged in” means that a valid access token is being sent in the Authorization header;
 - Nonrestricted API will have a marker -> (not restricted);


### PR DESCRIPTION
### Description
Fix typos in documentation files such as `docs/environment-variables.md` and `docs/quality-assurance-test-cases.md`.

Fixes #522 

### Type of Change:
- Documentation

**Code/Quality Assurance Only**
Not Applicable

### How Has This Been Tested?
There is no code change. No test needed.


### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials


**Code/Quality Assurance Only**
Not Applicable
