### PR TITLE
fix: add values to error message in get_env_config fuc

### DIFF
--- a/config.py
+++ b/config.py
@@ -114,7 +114,7 @@ def get_env_config() -> str:
     flask_config_name = os.getenv("FLASK_ENVIRONMENT_CONFIG", "dev")
     if flask_config_name not in ["prod", "test", "dev", "local", "stag"]:
         raise ValueError(
-            "The environment config value has to be within these values: prod, dev, test."
+            "The environment config value has to be within these values: prod, dev, test, local, stag."
         )
     return CONFIGURATION_MAPPER[flask_config_name]
 


### PR DESCRIPTION
### Description
i added values local, stag to error message of get_env_config fuc  in config.py

Fixes #533

### Type of Change:
- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
I checked that an error message containing local and stag was printed.


### Checklist:
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works

