### PR TITLE
Add to List Users API the ability to filter users who need or want to provide mentoring (issue # 424)

### DIFF
--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -143,12 +143,14 @@ class UserDAO:
         return UserModel.find_by_username(username)
 
     @staticmethod
-    def list_users(user_id: int, search_query: str = "", is_verified = None):
+    def list_users(user_id: int, search_query: str = "", need_mentoring = None, available_to_mentor = None, is_verified = None):
         """ Retrieves a list of verified users with the specified ID.
         
         Arguments:
-            user_id: The ID of the user to be listed.
+            user_id: The ID of the user requesting the list.
             search_query: The search query for name of the users to be found.
+	        need_mentoring: Flag to only pull users who need mentoring.
+	        available_to_mentor: Flag to only pull users who are available to mentor.
             is_verified: Status of the user's verification; None when provided as an argument.
         
         Returns:
@@ -161,7 +163,9 @@ class UserDAO:
             user.json()
             for user in filter(
                 lambda user: (not is_verified or user.is_email_verified)
-                and search_query.lower() in user.name.lower(),
+                and (search_query.lower() in user.name.lower())
+                and (need_mentoring == None or (need_mentoring.lower() == "true" and user.need_mentoring) or (need_mentoring.lower() == "false" and not user.need_mentoring))
+                and (available_to_mentor == None or (available_to_mentor.lower() == "true" and user.available_to_mentor) or (available_to_mentor.lower() == "false" and not user.available_to_mentor)),
                 users_list,
             )
         ]

--- a/app/api/resources/user.py
+++ b/app/api/resources/user.py
@@ -37,7 +37,7 @@ DAO = UserDAO()  # User data access object
 class UserList(Resource):
     @classmethod
     @jwt_required
-    @users_ns.doc("list_users", params={"search": "Search query"})
+    @users_ns.doc("list_users", params={"search": "Search query", "need_mentoring": "Flag for needing mentoring", "available_to_mentor": "Flag for availability to mentor"})
     @users_ns.doc(
         responses={
             401: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
@@ -58,7 +58,7 @@ class UserList(Resource):
         available_to_mentor. The current user's details are not returned.
         """
         user_id = get_jwt_identity()
-        return DAO.list_users(user_id, request.args.get("search", ""))
+        return DAO.list_users(user_id, request.args.get("search", ""), request.args.get("need_mentoring", None), request.args.get("available_to_mentor", None))
 
 
 @users_ns.route("users/<int:user_id>")
@@ -221,7 +221,7 @@ class ChangeUserPassword(Resource):
 class VerifiedUser(Resource):
     @classmethod
     @jwt_required
-    @users_ns.doc("get_verified_users", params={"search": "Search query"})
+    @users_ns.doc("get_verified_users", params={"search": "Search query", "need_mentoring": "Flag for needing mentoring", "available_to_mentor": "Flag for availability to mentor"})
     @users_ns.doc(
         responses={
             401: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
@@ -242,7 +242,7 @@ class VerifiedUser(Resource):
         available_to_mentor. The current user's details are not returned.
         """
         user_id = get_jwt_identity()
-        return DAO.list_users(user_id, request.args.get("search", ""), is_verified=True)
+        return DAO.list_users(user_id, request.args.get("search", ""), request.args.get("need_mentoring", None), request.args.get("available_to_mentor", None), is_verified=True)
 
 
 @users_ns.route("register")

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -738,6 +738,20 @@
                         "description": "Authentication access token. E.g.: Bearer <access_token>"
                     },
                     {
+                        "name": "need_mentoring",
+                        "in": "query",
+                        "type": "string",
+                        "required": false,
+                        "description": "Flag for needing mentoring"
+                    },
+                    {
+                        "name": "available_to_mentor",
+                        "in": "query",
+                        "type": "string",
+                        "required": false,
+                        "description": "Flag for availability to mentor"
+                    },
+                    {
                         "name": "X-Fields",
                         "in": "header",
                         "type": "string",
@@ -772,6 +786,20 @@
                         "type": "string",
                         "required": true,
                         "description": "Authentication access token. E.g.: Bearer <access_token>"
+                    },
+                    {
+                        "name": "need_mentoring",
+                        "in": "query",
+                        "type": "string",
+                        "required": false,
+                        "description": "Flag for needing mentoring"
+                    },
+                    {
+                        "name": "available_to_mentor",
+                        "in": "query",
+                        "type": "string",
+                        "required": false,
+                        "description": "Flag for availability to mentor"
                     },
                     {
                         "name": "X-Fields",

--- a/tests/users/test_api_list_users.py
+++ b/tests/users/test_api_list_users.py
@@ -44,6 +44,7 @@ class TestListUsersApi(BaseTestCase):
 
         self.verified_user.is_email_verified = True
         self.verified_user.need_mentoring = True
+        self.verified_user.available_to_mentor = True
 
         # all three users are not in a current relationship
         # verified_user needs mentoring -> is_available = True
@@ -136,6 +137,52 @@ class TestListUsersApi(BaseTestCase):
         self.assertEqual(200, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
+    def test_list_users_api_with_need_mentoring_query_true_auth(self):
+        auth_header = get_test_request_header(self.admin_user.id)
+        expected_response = [marshal(self.verified_user, public_user_api_model)]
+        actual_response = self.client.get(
+            "/users?need_mentoring=True", follow_redirects=True, headers=auth_header
+        )
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_list_users_api_with_need_mentoring_query_false_auth(self):
+        auth_header = get_test_request_header(self.admin_user.id)
+        expected_response = [
+            marshal(self.other_user, public_user_api_model),
+            marshal(self.second_user, public_user_api_model),
+        ]
+        actual_response = self.client.get(
+            "/users?need_mentoring=False", follow_redirects=True, headers=auth_header
+        )
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_list_users_api_with_available_to_mentor_query_true_auth(self):
+        auth_header = get_test_request_header(self.admin_user.id)
+        expected_response = [marshal(self.verified_user, public_user_api_model)]
+        actual_response = self.client.get(
+            "/users?available_to_mentor=True", follow_redirects=True, headers=auth_header
+        )
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_list_users_api_with_available_to_mentor_query_false_auth(self):
+        auth_header = get_test_request_header(self.admin_user.id)
+        expected_response = [
+            marshal(self.other_user, public_user_api_model),
+            marshal(self.second_user, public_user_api_model),
+        ]
+        actual_response = self.client.get(
+            "/users?available_to_mentor=False", follow_redirects=True, headers=auth_header
+        )
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
     def test_list_users_api_resource_verified_users(self):
         auth_header = get_test_request_header(self.admin_user.id)
         expected_response = [marshal(self.verified_user, public_user_api_model)]
@@ -145,6 +192,47 @@ class TestListUsersApi(BaseTestCase):
 
         self.assertEqual(200, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_list_users_api_verified_users_with_need_mentoring_query_true_auth(self):
+        auth_header = get_test_request_header(self.admin_user.id)
+        expected_response = [marshal(self.verified_user, public_user_api_model)]
+        actual_response = self.client.get(
+            "/users/verified?need_mentoring=True", follow_redirects=True, headers=auth_header
+        )
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_list_users_api_verified_users_with_need_mentoring_query_false_auth(self):
+        auth_header = get_test_request_header(self.admin_user.id)
+        expected_response = []
+        actual_response = self.client.get(
+            "/users/verified?need_mentoring=False", follow_redirects=True, headers=auth_header
+        )
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_list_users_api_verified_users_with_available_to_mentor_query_true_auth(self):
+        auth_header = get_test_request_header(self.admin_user.id)
+        expected_response = [marshal(self.verified_user, public_user_api_model)]
+        actual_response = self.client.get(
+            "/users/verified?available_to_mentor=True", follow_redirects=True, headers=auth_header
+        )
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_list_users_api_verified_users_with_available_to_mentor_query_false_auth(self):
+        auth_header = get_test_request_header(self.admin_user.id)
+        expected_response = []
+        actual_response = self.client.get(
+            "/users/verified?available_to_mentor=False", follow_redirects=True, headers=auth_header
+        )
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
 
     def test_list_users_api_relation(self):
         # Creates relationship between two users, which means that they are


### PR DESCRIPTION
### Description
As a member of the app,
I need be able to filter other members for their availability,
so that I can choose the member I want to create a mentorship relation with.

APIs used to fetch Users, don't have an option to filter users by need_mentoring and available_to_mentor attributes.

Fixes #424

### Type of Change:

- Code
- Quality Assurance
- Documentation

**Code/Quality Assurance Only**
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
We created more unit tests in the tests/users/test_api_list_users.py. You can run these tests by following this guideline: https://github.com/anitab-org/mentorship-backend#run-tests.


### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Update Swagger documentation and the exported file at /docs folder

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings \
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
