### PR TITLE
chore: update markupsafe dependency in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ itsdangerous==0.24
 Jinja2==2.10
 jmespath==0.9.3
 jsonschema==2.6.0
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 mccabe==0.6.1
 paramiko==2.7.1
 pathspec==0.5.5


### PR DESCRIPTION
### Description

I updated the MarkupSafe package version to the latest, from 1.0 to 1.1.1.
MarkupSafe python package: https://pypi.org/project/MarkupSafe/

Fixes #539 

### Type of Change:

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?

I ran after this change: `pip install -r requirements.txt`
I did not get the error mentioned in the issue:

![image](https://user-images.githubusercontent.com/11148726/79287489-deca3780-7ebb-11ea-86c3-48844e92df89.png)



### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged
- [ ] Update Postman API at /docs folder
- [ ] Update Swagger documentation and the exported file at /docs folder
- [ ] Update requirements.txt

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
