### PR TITLE
Add pagination to /users and /users/verified endpoints (issue #279)

### DIFF
--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from operator import itemgetter
 from typing import Dict
 from flask_restplus import marshal
+from sqlalchemy import func
 
 from app import messages
 from app.api.dao.mentorship_relation import MentorshipRelationDAO
@@ -160,14 +161,10 @@ class UserDAO:
         
         """
 
-        users_list = UserModel.query.filter(UserModel.id != user_id).paginate(page=page, per_page=per_page, error_out=False, max_per_page=UserDAO.DEFAULT_USERS_PER_PAGE).items
+        users_list = UserModel.query.filter(UserModel.id != user_id, not is_verified or UserModel.is_email_verified == True, func.lower(UserModel.name).contains(search_query.lower())).paginate(page=page, per_page=per_page, error_out=False, max_per_page=UserDAO.DEFAULT_USERS_PER_PAGE).items
         list_of_users = [
             user.json()
-            for user in filter(
-                lambda user: (not is_verified or user.is_email_verified)
-                and search_query.lower() in user.name.lower(),
-                users_list,
-            )
+            for user in users_list
         ]
 
         for user in list_of_users:

--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -145,7 +145,7 @@ class UserDAO:
         return UserModel.find_by_username(username)
 
     @staticmethod
-    def list_users(user_id: int, search_query: str = "", page: int = 1, per_page: int = 10, is_verified = None):
+    def list_users(user_id: int, search_query: str = "", page: int = DEFAULT_PAGE, per_page: int = DEFAULT_USERS_PER_PAGE, is_verified = None):
         """ Retrieves a list of verified users with the specified ID.
         
         Arguments:
@@ -160,7 +160,7 @@ class UserDAO:
         
         """
 
-        users_list = UserModel.query.filter(UserModel.id != user_id).all()
+        users_list = UserModel.query.filter(UserModel.id != user_id).paginate(page, per_page, False).items
         list_of_users = [
             user.json()
             for user in filter(
@@ -169,9 +169,6 @@ class UserDAO:
                 users_list,
             )
         ]
-
-        page = page - 1
-        list_of_users = list_of_users[page * per_page: (page * per_page) + per_page]
 
         for user in list_of_users:
             relation = MentorshipRelationDAO.list_current_mentorship_relation(

--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -160,7 +160,7 @@ class UserDAO:
         
         """
 
-        users_list = UserModel.query.filter(UserModel.id != user_id).paginate(page, per_page, False).items
+        users_list = UserModel.query.filter(UserModel.id != user_id).paginate(page=page, per_page=per_page, error_out=False, max_per_page=UserDAO.DEFAULT_USERS_PER_PAGE).items
         list_of_users = [
             user.json()
             for user in filter(

--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -25,6 +25,8 @@ class UserDAO:
     FAIL_USER_ALREADY_EXISTS = "FAIL_USER_ALREADY_EXISTS"
     SUCCESS_USER_CREATED = "SUCCESS_USER_CREATED"
     MIN_NUMBER_OF_ADMINS = 1
+    DEFAULT_PAGE = 1
+    DEFAULT_USERS_PER_PAGE = 10
 
     @staticmethod
     def create_user(data: Dict[str, str]):

--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -161,7 +161,12 @@ class UserDAO:
         
         """
 
-        users_list = UserModel.query.filter(UserModel.id != user_id, not is_verified or UserModel.is_email_verified, func.lower(UserModel.name).contains(search_query.lower())).paginate(page=page, per_page=per_page, error_out=False, max_per_page=UserDAO.DEFAULT_USERS_PER_PAGE).items
+        users_list = UserModel.query.filter(
+            UserModel.id != user_id,
+            not is_verified or UserModel.is_email_verified,
+            func.lower(UserModel.name).contains(search_query.lower())
+        ).paginate(page=page, per_page=per_page, error_out=False, max_per_page=UserDAO.DEFAULT_USERS_PER_PAGE).items
+
         list_of_users = [
             user.json()
             for user in users_list

--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -143,7 +143,7 @@ class UserDAO:
         return UserModel.find_by_username(username)
 
     @staticmethod
-    def list_users(user_id: int, search_query: str = "", page: int = 0, per_page: int = 10, is_verified = None):
+    def list_users(user_id: int, search_query: str = "", page: int = 1, per_page: int = 10, is_verified = None):
         """ Retrieves a list of verified users with the specified ID.
         
         Arguments:
@@ -168,6 +168,7 @@ class UserDAO:
             )
         ]
 
+        page = page - 1
         list_of_users = list_of_users[page * per_page: (page * per_page) + per_page]
 
         for user in list_of_users:

--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -28,6 +28,7 @@ class UserDAO:
     MIN_NUMBER_OF_ADMINS = 1
     DEFAULT_PAGE = 1
     DEFAULT_USERS_PER_PAGE = 10
+    MAX_USERS_PER_PAGE = 50
 
     @staticmethod
     def create_user(data: Dict[str, str]):
@@ -165,7 +166,7 @@ class UserDAO:
             UserModel.id != user_id,
             not is_verified or UserModel.is_email_verified,
             func.lower(UserModel.name).contains(search_query.lower())
-        ).paginate(page=page, per_page=per_page, error_out=False, max_per_page=UserDAO.DEFAULT_USERS_PER_PAGE).items
+        ).paginate(page=page, per_page=per_page, error_out=False, max_per_page=UserDAO.MAX_USERS_PER_PAGE).items
 
         list_of_users = [
             user.json()

--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -161,7 +161,7 @@ class UserDAO:
         
         """
 
-        users_list = UserModel.query.filter(UserModel.id != user_id, not is_verified or UserModel.is_email_verified == True, func.lower(UserModel.name).contains(search_query.lower())).paginate(page=page, per_page=per_page, error_out=False, max_per_page=UserDAO.DEFAULT_USERS_PER_PAGE).items
+        users_list = UserModel.query.filter(UserModel.id != user_id, not is_verified or UserModel.is_email_verified, func.lower(UserModel.name).contains(search_query.lower())).paginate(page=page, per_page=per_page, error_out=False, max_per_page=UserDAO.DEFAULT_USERS_PER_PAGE).items
         list_of_users = [
             user.json()
             for user in users_list

--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -166,7 +166,10 @@ class UserDAO:
             UserModel.id != user_id,
             not is_verified or UserModel.is_email_verified,
             func.lower(UserModel.name).contains(search_query.lower())
-        ).paginate(page=page, per_page=per_page, error_out=False, max_per_page=UserDAO.MAX_USERS_PER_PAGE).items
+        ).order_by(UserModel.id).paginate(page=page,
+                                          per_page=per_page,
+                                          error_out=False,
+                                          max_per_page=UserDAO.MAX_USERS_PER_PAGE).items
 
         list_of_users = [
             user.json()

--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -143,13 +143,15 @@ class UserDAO:
         return UserModel.find_by_username(username)
 
     @staticmethod
-    def list_users(user_id: int, search_query: str = "", is_verified = None):
+    def list_users(user_id: int, search_query: str = "", page: int = 0, per_page: int = 10, is_verified = None):
         """ Retrieves a list of verified users with the specified ID.
         
         Arguments:
             user_id: The ID of the user to be listed.
             search_query: The search query for name of the users to be found.
             is_verified: Status of the user's verification; None when provided as an argument.
+            page: The page of users to be returned
+            per_page: The number of users to return per page
         
         Returns:
             A list of users matching conditions and the HTTP response code.
@@ -165,6 +167,8 @@ class UserDAO:
                 users_list,
             )
         ]
+
+        list_of_users = list_of_users[page * per_page: (page * per_page) + per_page]
 
         for user in list_of_users:
             relation = MentorshipRelationDAO.list_current_mentorship_relation(

--- a/app/api/resources/user.py
+++ b/app/api/resources/user.py
@@ -246,8 +246,8 @@ class VerifiedUser(Resource):
         available_to_mentor. The current user's details are not returned.
         """
 
-        page = request.args.get("page", default=1, type=int)
-        per_page = request.args.get("per_page", default=10, type=int)
+        page = request.args.get("page", default=UserDAO.DEFAULT_PAGE, type=int)
+        per_page = request.args.get("per_page", default=UserDAO.DEFAULT_USERS_PER_PAGE, type=int)
 
         user_id = get_jwt_identity()
         return DAO.list_users(user_id, request.args.get("search", ""), page, per_page, is_verified=True)

--- a/app/api/resources/user.py
+++ b/app/api/resources/user.py
@@ -37,7 +37,7 @@ DAO = UserDAO()  # User data access object
 class UserList(Resource):
     @classmethod
     @jwt_required
-    @users_ns.doc("list_users", params={"search": "Search query"})
+    @users_ns.doc("list_users", params={"search": "Search query", "page": "specify page of users", "per_page": "specify number of users per page"})
     @users_ns.doc(
         responses={
             401: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
@@ -57,8 +57,12 @@ class UserList(Resource):
         location, occupation, organization, interests, skills, need_mentoring,
         available_to_mentor. The current user's details are not returned.
         """
+
+        page = request.args.get("page", default=0, type=int)
+        per_page = request.args.get("per_page", default=10, type=int)
+
         user_id = get_jwt_identity()
-        return DAO.list_users(user_id, request.args.get("search", ""))
+        return DAO.list_users(user_id, request.args.get("search", ""), page, per_page)
 
 
 @users_ns.route("users/<int:user_id>")
@@ -221,7 +225,7 @@ class ChangeUserPassword(Resource):
 class VerifiedUser(Resource):
     @classmethod
     @jwt_required
-    @users_ns.doc("get_verified_users", params={"search": "Search query"})
+    @users_ns.doc("get_verified_users", params={"search": "Search query", "page": "specify page of users", "per_page": "specify number of users per page"})
     @users_ns.doc(
         responses={
             401: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
@@ -241,8 +245,12 @@ class VerifiedUser(Resource):
         location, occupation, organization, interests, skills, need_mentoring,
         available_to_mentor. The current user's details are not returned.
         """
+
+        page = request.args.get("page", default=0, type=int)
+        per_page = request.args.get("per_page", default=10, type=int)
+
         user_id = get_jwt_identity()
-        return DAO.list_users(user_id, request.args.get("search", ""), is_verified=True)
+        return DAO.list_users(user_id, request.args.get("search", ""), page, per_page, is_verified=True)
 
 
 @users_ns.route("register")

--- a/app/api/resources/user.py
+++ b/app/api/resources/user.py
@@ -58,7 +58,7 @@ class UserList(Resource):
         available_to_mentor. The current user's details are not returned.
         """
 
-        page = request.args.get("page", default=0, type=int)
+        page = request.args.get("page", default=1, type=int)
         per_page = request.args.get("per_page", default=10, type=int)
 
         user_id = get_jwt_identity()
@@ -246,7 +246,7 @@ class VerifiedUser(Resource):
         available_to_mentor. The current user's details are not returned.
         """
 
-        page = request.args.get("page", default=0, type=int)
+        page = request.args.get("page", default=1, type=int)
         per_page = request.args.get("per_page", default=10, type=int)
 
         user_id = get_jwt_identity()

--- a/app/api/resources/user.py
+++ b/app/api/resources/user.py
@@ -58,8 +58,8 @@ class UserList(Resource):
         available_to_mentor. The current user's details are not returned.
         """
 
-        page = request.args.get("page", default=1, type=int)
-        per_page = request.args.get("per_page", default=10, type=int)
+        page = request.args.get("page", default=UserDAO.DEFAULT_PAGE, type=int)
+        per_page = request.args.get("per_page", default=UserDAO.DEFAULT_USERS_PER_PAGE, type=int)
 
         user_id = get_jwt_identity()
         return DAO.list_users(user_id, request.args.get("search", ""), page, per_page)

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -738,6 +738,20 @@
                         "description": "Authentication access token. E.g.: Bearer <access_token>"
                     },
                     {
+                        "name": "page",
+                        "in": "query",
+                        "type": "int",
+                        "required": false,
+                        "description": "specify page of users",
+                    },
+                    {
+                        "name": "per_page",
+                        "in": "query",
+                        "type": "int",
+                        "required": false,
+                        "description": "specify number of users per page",
+                    },
+                    {
                         "name": "X-Fields",
                         "in": "header",
                         "type": "string",
@@ -772,6 +786,20 @@
                         "type": "string",
                         "required": true,
                         "description": "Authentication access token. E.g.: Bearer <access_token>"
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "type": "int",
+                        "required": false,
+                        "description": "specify page of users",
+                    },
+                    {
+                        "name": "per_page",
+                        "in": "query",
+                        "type": "int",
+                        "required": false,
+                        "description": "specify number of users per page",
                     },
                     {
                         "name": "X-Fields",

--- a/tests/users/test_api_list_users.py
+++ b/tests/users/test_api_list_users.py
@@ -143,7 +143,7 @@ class TestListUsersApi(BaseTestCase):
             marshal(self.other_user, public_user_api_model),
             marshal(self.second_user, public_user_api_model)]
         actual_response = self.client.get(
-            "/users?page=0", follow_redirects=True, headers=auth_header
+            "/users?page=1", follow_redirects=True, headers=auth_header
         )
 
         self.assertEqual(200, actual_response.status_code)
@@ -153,7 +153,7 @@ class TestListUsersApi(BaseTestCase):
         auth_header = get_test_request_header(self.admin_user.id)
         expected_response = []
         actual_response = self.client.get(
-            "/users?page=1", follow_redirects=True, headers=auth_header
+            "/users?page=2", follow_redirects=True, headers=auth_header
         )
 
         self.assertEqual(200, actual_response.status_code)
@@ -163,7 +163,7 @@ class TestListUsersApi(BaseTestCase):
         auth_header = get_test_request_header(self.admin_user.id)
         expected_response = [marshal(self.verified_user, public_user_api_model)]
         actual_response = self.client.get(
-            "/users?page=0&per_page=1", follow_redirects=True, headers=auth_header
+            "/users?page=1&per_page=1", follow_redirects=True, headers=auth_header
         )
 
         self.assertEqual(200, actual_response.status_code)
@@ -173,7 +173,7 @@ class TestListUsersApi(BaseTestCase):
         auth_header = get_test_request_header(self.admin_user.id)
         expected_response = [marshal(self.second_user, public_user_api_model)]
         actual_response = self.client.get(
-            "/users?page=1&per_page=2", follow_redirects=True, headers=auth_header
+            "/users?page=2&per_page=2", follow_redirects=True, headers=auth_header
         )
 
         self.assertEqual(200, actual_response.status_code)
@@ -193,7 +193,7 @@ class TestListUsersApi(BaseTestCase):
         auth_header = get_test_request_header(self.admin_user.id)
         expected_response = [marshal(self.verified_user, public_user_api_model)]
         actual_response = self.client.get(
-            "/users/verified?page=0", follow_redirects=True, headers=auth_header
+            "/users/verified?page=1", follow_redirects=True, headers=auth_header
         )
 
         self.assertEqual(200, actual_response.status_code)
@@ -203,7 +203,7 @@ class TestListUsersApi(BaseTestCase):
         auth_header = get_test_request_header(self.admin_user.id)
         expected_response = []
         actual_response = self.client.get(
-            "/users/verified?page=1", follow_redirects=True, headers=auth_header
+            "/users/verified?page=2", follow_redirects=True, headers=auth_header
         )
 
         self.assertEqual(200, actual_response.status_code)
@@ -213,7 +213,7 @@ class TestListUsersApi(BaseTestCase):
         auth_header = get_test_request_header(self.admin_user.id)
         expected_response = [marshal(self.verified_user, public_user_api_model)]
         actual_response = self.client.get(
-            "/users/verified?page=0&per_page=1", follow_redirects=True, headers=auth_header
+            "/users/verified?page=1&per_page=1", follow_redirects=True, headers=auth_header
         )
 
         self.assertEqual(200, actual_response.status_code)
@@ -223,7 +223,7 @@ class TestListUsersApi(BaseTestCase):
         auth_header = get_test_request_header(self.admin_user.id)
         expected_response = []
         actual_response = self.client.get(
-            "/users/verified?page=0&per_page=0", follow_redirects=True, headers=auth_header
+            "/users/verified?page=1&per_page=0", follow_redirects=True, headers=auth_header
         )
 
         self.assertEqual(200, actual_response.status_code)

--- a/tests/users/test_api_list_users.py
+++ b/tests/users/test_api_list_users.py
@@ -136,11 +136,94 @@ class TestListUsersApi(BaseTestCase):
         self.assertEqual(200, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
+    def test_list_users_api_with_a_page_query_resource_auth(self):
+        auth_header = get_test_request_header(self.admin_user.id)
+        expected_response = [
+            marshal(self.verified_user, public_user_api_model),
+            marshal(self.other_user, public_user_api_model),
+            marshal(self.second_user, public_user_api_model)]
+        actual_response = self.client.get(
+            "/users?page=0", follow_redirects=True, headers=auth_header
+        )
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_list_users_api_with_a_page_query_out_of_range_resource_auth(self):
+        auth_header = get_test_request_header(self.admin_user.id)
+        expected_response = []
+        actual_response = self.client.get(
+            "/users?page=1", follow_redirects=True, headers=auth_header
+        )
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_list_users_api_with_a_page_and_per_page_query_resource_auth(self):
+        auth_header = get_test_request_header(self.admin_user.id)
+        expected_response = [marshal(self.verified_user, public_user_api_model)]
+        actual_response = self.client.get(
+            "/users?page=0&per_page=1", follow_redirects=True, headers=auth_header
+        )
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_list_users_api_with_a_partial_page_and_per_page_query_resource_auth(self):
+        auth_header = get_test_request_header(self.admin_user.id)
+        expected_response = [marshal(self.second_user, public_user_api_model)]
+        actual_response = self.client.get(
+            "/users?page=1&per_page=2", follow_redirects=True, headers=auth_header
+        )
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
     def test_list_users_api_resource_verified_users(self):
         auth_header = get_test_request_header(self.admin_user.id)
         expected_response = [marshal(self.verified_user, public_user_api_model)]
         actual_response = self.client.get(
             "/users/verified", follow_redirects=True, headers=auth_header
+        )
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_list_users_api_with_a_page_query_resource_verified_users(self):
+        auth_header = get_test_request_header(self.admin_user.id)
+        expected_response = [marshal(self.verified_user, public_user_api_model)]
+        actual_response = self.client.get(
+            "/users/verified?page=0", follow_redirects=True, headers=auth_header
+        )
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_list_users_api_with_a_page_query_out_of_range_resource_verified_users(self):
+        auth_header = get_test_request_header(self.admin_user.id)
+        expected_response = []
+        actual_response = self.client.get(
+            "/users/verified?page=1", follow_redirects=True, headers=auth_header
+        )
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_list_users_api_with_a_page_and_per_page_query_resource_verified_users(self):
+        auth_header = get_test_request_header(self.admin_user.id)
+        expected_response = [marshal(self.verified_user, public_user_api_model)]
+        actual_response = self.client.get(
+            "/users/verified?page=0&per_page=1", follow_redirects=True, headers=auth_header
+        )
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_list_users_api_with_a_page_and_empty_per_page_query_resource_verified_users(self):
+        auth_header = get_test_request_header(self.admin_user.id)
+        expected_response = []
+        actual_response = self.client.get(
+            "/users/verified?page=0&per_page=0", follow_redirects=True, headers=auth_header
         )
 
         self.assertEqual(200, actual_response.status_code)


### PR DESCRIPTION
### Description

Adds pagination support for GET requests to the /users and /users/verified endpoints. Instead of returning all users at once, it returns 10 at a time for each request received. 10 is a constant value that can be changed in config.py under the USERS_PER_PAGE variable.

Fixes #279

### Type of Change:

- Code
- Quality Assurance
- Documentation

**Code/Quality Assurance Only**

- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?

We created more unit tests in the tests/users/test_api_list_users.py. You can run these tests by following this guideline: https://github.com/anitab-org/mentorship-backend#run-tests.

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Update Swagger documentation and the exported file at /docs folder

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes