### PR TITLE
fix: Return error message when relationship is not accepted in Comple…

### DIFF
--- a/app/api/dao/task.py
+++ b/app/api/dao/task.py
@@ -133,7 +133,8 @@ class TaskDAO:
 
         if not (user_id == relation.mentee_id or user_id == relation.mentor_id):
             return messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION, 401
-
+        if relation.state != MentorshipRelationState.ACCEPTED:
+            return messages.UNACCEPTED_STATE_RELATION, 400
         task = relation.tasks_list.find_task_by_id(task_id)
         if task is None:
             return messages.TASK_DOES_NOT_EXIST, 404

--- a/app/api/dao/task.py
+++ b/app/api/dao/task.py
@@ -131,7 +131,7 @@ class TaskDAO:
 
         user = UserModel.find_by_id(user_id)
         relation = MentorshipRelationModel.find_by_id(mentorship_relation_id)
-        
+
         if relation is None:
             return messages.MENTORSHIP_RELATION_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND
 
@@ -140,8 +140,8 @@ class TaskDAO:
 
         if relation.state != MentorshipRelationState.ACCEPTED:
             return messages.UNACCEPTED_STATE_RELATION, HTTPStatus.BAD_REQUEST
+            
         task = relation.tasks_list.find_task_by_id(task_id)
-
         if task is None:
             return messages.TASK_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND
 

--- a/app/api/dao/task.py
+++ b/app/api/dao/task.py
@@ -131,14 +131,17 @@ class TaskDAO:
 
         user = UserModel.find_by_id(user_id)
         relation = MentorshipRelationModel.find_by_id(mentorship_relation_id)
+        
         if relation is None:
             return messages.MENTORSHIP_RELATION_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND
 
         if not (user_id == relation.mentee_id or user_id == relation.mentor_id):
             return messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION, HTTPStatus.UNAUTHORIZED
+
         if relation.state != MentorshipRelationState.ACCEPTED:
             return messages.UNACCEPTED_STATE_RELATION, HTTPStatus.BAD_REQUEST
         task = relation.tasks_list.find_task_by_id(task_id)
+
         if task is None:
             return messages.TASK_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND
 

--- a/app/api/resources/mentorship_relation.py
+++ b/app/api/resources/mentorship_relation.py
@@ -658,12 +658,8 @@ class UpdateTask(Resource):
         HTTPStatus.OK, "%s" % messages.TASK_WAS_ACHIEVED_SUCCESSFULLY
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.BAD_REQUEST,
-        "%s\n%s"
-        % (
-            messages.TASK_WAS_ALREADY_ACHIEVED,
-            messages.UNACCEPTED_STATE_RELATION,
-        ),
+            HTTPStatus.BAD_REQUEST,f"{messages.TASK_WAS_ALREADY_ACHIEVED}<br>"
+            f"{messages.UNACCEPTED_STATE_RELATION}<br>"
     )
     @mentorship_relation_ns.response(
         HTTPStatus.UNAUTHORIZED,

--- a/app/api/resources/mentorship_relation.py
+++ b/app/api/resources/mentorship_relation.py
@@ -656,7 +656,14 @@ class UpdateTask(Resource):
     @mentorship_relation_ns.response(
         200, "%s" % messages.TASK_WAS_ACHIEVED_SUCCESSFULLY
     )
-    @mentorship_relation_ns.response(400, "%s" % messages.TASK_WAS_ALREADY_ACHIEVED)
+    @mentorship_relation_ns.response(
+        400,
+        "%s\n%s"
+        % (
+            messages.TASK_WAS_ALREADY_ACHIEVED,
+            messages.UNACCEPTED_STATE_RELATION,
+        ),
+    )
     @mentorship_relation_ns.response(
         401,
         "%s\n%s\n%s\n%s"

--- a/tests/tasks/tasks_base_setup.py
+++ b/tests/tasks/tasks_base_setup.py
@@ -6,7 +6,7 @@ from app.database.models.user import UserModel
 from app.database.sqlalchemy_extension import db
 from app.utils.enum_utils import MentorshipRelationState
 from tests.base_test_case import BaseTestCase
-from tests.test_data import user1, user2, user4
+from tests.test_data import user1, user2, user4, user5
 
 
 class TasksBaseTestCase(BaseTestCase):
@@ -24,6 +24,7 @@ class TasksBaseTestCase(BaseTestCase):
             password=user1["password"],
             terms_and_conditions_checked=user1["terms_and_conditions_checked"],
         )
+
         self.second_user = UserModel(
             name=user2["name"],
             email=user2["email"],
@@ -39,6 +40,15 @@ class TasksBaseTestCase(BaseTestCase):
             password=user4["password"],
             terms_and_conditions_checked=user4["terms_and_conditions_checked"],
         )
+
+        self.fifth_user = UserModel(
+            name=user5["name"],
+            email=user5["email"],
+            username=user5["username"],
+            password=user5["password"],
+            terms_and_conditions_checked=user5["terms_and_conditions_checked"],
+        )
+
         # making sure both are available to be mentor or mentee
         self.first_user.need_mentoring = True
         self.first_user.available_to_mentor = True
@@ -48,6 +58,9 @@ class TasksBaseTestCase(BaseTestCase):
         self.second_user.is_email_verified = True
         self.fourth_user.available_to_mentor = True
         self.fourth_user.is_email_verified = True
+        self.fifth_user.is_email_verified = True
+        self.fifth_user.available_to_mentor = True
+        self.fifth_user.need_mentoring = True
 
         self.notes_example = "description of a good mentorship relation"
 
@@ -64,6 +77,7 @@ class TasksBaseTestCase(BaseTestCase):
         db.session.add(self.first_user)
         db.session.add(self.second_user)
         db.session.add(self.fourth_user)
+        db.session.add(self.fifth_user)
         db.session.commit()
 
         # create new mentorship relation
@@ -101,9 +115,21 @@ class TasksBaseTestCase(BaseTestCase):
             tasks_list=self.tasks_list_3,
         )
 
+        self.mentorship_relation_w_fourth_user = MentorshipRelationModel(
+            action_user_id=self.fifth_user.id,
+            mentor_user=self.fifth_user,
+            mentee_user=self.fourth_user,
+            creation_date=self.now_datetime.timestamp(),
+            end_date=self.end_date_example.timestamp(),
+            state=MentorshipRelationState.PENDING,
+            notes=self.notes_example,
+            tasks_list=self.tasks_list_3,
+        )
+
         db.session.add(self.mentorship_relation_w_second_user)
         db.session.add(self.mentorship_relation_w_admin_user)
         db.session.add(self.mentorship_relation_without_first_user)
+        db.session.add(self.mentorship_relation_w_fourth_user)
         db.session.commit()
 
         self.description_example = "This is an example of a description"

--- a/tests/tasks/test_dao_complete_task.py
+++ b/tests/tasks/test_dao_complete_task.py
@@ -1,6 +1,7 @@
 import unittest
 
 from app import messages
+from http import HTTPStatus
 from app.api.dao.task import TaskDAO
 from tests.tasks.tasks_base_setup import TasksBaseTestCase
 
@@ -37,6 +38,13 @@ class TestCompleteTasksDao(TasksBaseTestCase):
 
         self.assertEqual(expected_response, actual_response)
 
+    def test_achieve_not_existent_task_in_non_accepted_relationship(self):
+
+        expected_response = messages.UNACCEPTED_STATE_RELATION, HTTPStatus.BAD_REQUEST
+        actual_response = TaskDAO.complete_task(
+        self.fifth_user.id, self.mentorship_relation_w_fourth_user.id, 123123
+        )
+        self.assertEqual(expected_response, actual_response)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -56,3 +56,10 @@ user4 = {
     "password": "user4_pwd",
     "terms_and_conditions_checked": True,
 }
+user5 = {
+    "name": "user5@email.com",
+    "email": "user5@email.com",
+    "username": "user5",
+    "password": "user5_pwd",
+    "terms_and_conditions_checked": True,
+}


### PR DESCRIPTION
### Description
The mentorship relation state (accepted or not) is now checked when someone is trying to complete a task from a relationship that is not accepted. This check is also of higher importance than the existence of the task. So if the relationship is not accepted the user gets a message that the relationship is not accepted.

Fixes #537

### Type of Change:
- Code

### How Has This Been Tested?
All the tests have the same result as before. No extra tests were added.

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
