### PR TITLE
fix: allow admin to remove self admin status when not sole admin

### DIFF
--- a/app/api/dao/admin.py
+++ b/app/api/dao/admin.py
@@ -65,7 +65,10 @@ class AdminDAO:
         """
         admin_user_id = data["user_id"]
 
-        if user_id == admin_user_id:
+        users_list = UserModel.query.filter(UserModel.id != user_id).all()
+        list_of_users = [user.json() for user in users_list if user.is_admin]
+
+        if user_id == admin_user_id and len(list_of_users) == 0:
             return messages.USER_CANNOT_REVOKE_ADMIN_STATUS, HTTPStatus.FORBIDDEN
 
         new_admin_user = UserModel.find_by_id(admin_user_id)

--- a/app/api/dao/admin.py
+++ b/app/api/dao/admin.py
@@ -65,9 +65,9 @@ class AdminDAO:
         """
         admin_user_id = data["user_id"]
 
-        users_list = UserModel.query.filter(UserModel.is_admin == True).count()
+        admin_count = UserModel.query.filter(UserModel.is_admin == True).count()
 
-        if user_id == admin_user_id and users_list == 1:
+        if user_id == admin_user_id and admin_count == 1:
             return messages.USER_CANNOT_REVOKE_ADMIN_STATUS, HTTPStatus.FORBIDDEN
 
         new_admin_user = UserModel.find_by_id(admin_user_id)

--- a/app/api/dao/admin.py
+++ b/app/api/dao/admin.py
@@ -65,10 +65,9 @@ class AdminDAO:
         """
         admin_user_id = data["user_id"]
 
-        users_list = UserModel.query.filter(UserModel.id != user_id).all()
-        list_of_users = [user.json() for user in users_list if user.is_admin]
+        users_list = UserModel.query.filter(UserModel.is_admin == True).count()
 
-        if user_id == admin_user_id and len(list_of_users) == 0:
+        if user_id == admin_user_id and users_list == 1:
             return messages.USER_CANNOT_REVOKE_ADMIN_STATUS, HTTPStatus.FORBIDDEN
 
         new_admin_user = UserModel.find_by_id(admin_user_id)

--- a/tests/admin/test_api_remove_admin_user.py
+++ b/tests/admin/test_api_remove_admin_user.py
@@ -1,0 +1,134 @@
+import unittest
+from datetime import datetime, timedelta
+
+from flask import json
+from flask_restplus import marshal
+
+from app import messages
+from app.api.models.admin import public_admin_user_api_model
+from app.database.models.mentorship_relation import MentorshipRelationModel
+from app.database.models.tasks_list import TasksListModel
+from app.database.models.user import UserModel
+from app.database.sqlalchemy_extension import db
+from app.utils.enum_utils import MentorshipRelationState
+from tests.base_test_case import BaseTestCase
+from tests.test_utils import get_test_request_header
+from tests.test_data import test_admin_user_2, test_admin_user_3
+
+
+class TestRemoveAdminUsersApi(BaseTestCase):
+    def setUp(self):
+        super(TestRemoveAdminUsersApi, self).setUp()
+
+        self.admin_user_1 = UserModel(
+            name=test_admin_user_2["name"],
+            email=test_admin_user_2["email"],
+            username=test_admin_user_2["username"],
+            password=test_admin_user_2["password"],
+            terms_and_conditions_checked=test_admin_user_2[
+                "terms_and_conditions_checked"
+            ],
+        )
+
+        self.admin_user_2 = UserModel(
+            name=test_admin_user_3["name"],
+            email=test_admin_user_3["email"],
+            username=test_admin_user_3["username"],
+            password=test_admin_user_3["password"],
+            terms_and_conditions_checked=test_admin_user_3[
+                "terms_and_conditions_checked"
+            ],
+        )
+
+
+        # creating 3 admin users(first admin user created by basetestcase setup) and 1 normal user
+        self.admin_user_1.is_email_verified = True
+        self.admin_user_2.is_email_verified = True
+
+        self.admin_user_1.is_admin = True
+        self.admin_user_2.is_admin = True
+
+        db.session.add(self.admin_user_1)
+        db.session.add(self.admin_user_2)
+        db.session.commit()
+
+    def test_remove_self_admin_status_with_other_admins_api_resource_auth_admin(self):
+        auth_header = get_test_request_header(self.admin_user_1.id)
+        expected_response = messages.USER_ADMIN_STATUS_WAS_REVOKED
+        actual_response = self.client.post(
+            "/admin/remove",
+            json={
+                "user_id": self.admin_user_1.id,
+            },
+            follow_redirects=True,
+            headers=auth_header
+        )
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_remove_self_admin_status_when_only_admin_api_resource_auth_admin(self):
+        # remove other admins
+        auth_header = get_test_request_header(self.admin_user_1.id)
+        expected_response = messages.USER_ADMIN_STATUS_WAS_REVOKED
+        actual_response = self.client.post(
+            "/admin/remove",
+            json={
+                "user_id": self.admin_user_2.id,
+            },
+            follow_redirects=True,
+            headers=auth_header
+        )
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+        # remove the admin that is always added for tests (id = 1)
+        auth_header = get_test_request_header(self.admin_user_1.id)
+        expected_response = messages.USER_ADMIN_STATUS_WAS_REVOKED
+        actual_response = self.client.post(
+            "/admin/remove",
+            json={
+                "user_id": 1,
+            },
+            follow_redirects=True,
+            headers=auth_header
+        )
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+
+        # remove self
+        auth_header = get_test_request_header(self.admin_user_1.id)
+        expected_response = messages.USER_CANNOT_REVOKE_ADMIN_STATUS
+        actual_response = self.client.post(
+            "/admin/remove",
+            json={
+                "user_id": self.admin_user_1.id,
+            },
+            follow_redirects=True,
+            headers=auth_header
+        )
+
+        self.assertEqual(403, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_remove_admin_status_api_resource_auth_admin(self):
+        auth_header = get_test_request_header(self.admin_user_1.id)
+        expected_response = messages.USER_ADMIN_STATUS_WAS_REVOKED
+        actual_response = self.client.post(
+            "/admin/remove",
+            json={
+                "user_id": self.admin_user_2.id,
+            },
+            follow_redirects=True,
+            headers=auth_header
+        )
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description

According to the test case page on Mentorship backend wiki, a user can revoke her own admin status when she's not the sole admin. However this was previously not supported by the backend.

Fixes #411

### Type of Change:

<!--- **Delete irrelevant options.** --->

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)



### How Has This Been Tested?

I added a new test file `tests/admin/test_api_remove_admin_user.py` which tests an admin's ability to remove its own admin status when they are and are not the sole admin.


### Checklist:

<!-- **Delete irrelevant options.** -->

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**

- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
