### PR TITLE
fix error message for password field being blank

### DIFF
--- a/app/api/resources/user.py
+++ b/app/api/resources/user.py
@@ -30,7 +30,7 @@ DAO = UserDAO()  # User data access object
     % (
         messages.TOKEN_HAS_EXPIRED,
         messages.TOKEN_IS_INVALID,
-        messages.AUTHORISATION_TOKEN_IS_MISSING,
+        messages.AUTHORISATION_TOKEN_IS_MISSING
     ),
 )
 # TODO: @users_ns.response(404, 'User does not exist.')
@@ -252,10 +252,11 @@ class UserRegister(Resource):
     @users_ns.response(HTTPStatus.OK, "%s" % messages.USER_WAS_CREATED_SUCCESSFULLY)
     @users_ns.response(
         HTTPStatus.BAD_REQUEST,
-        "%s\n%s"
+        "%s\n%s\n%s"
         % (
             messages.USER_USES_A_USERNAME_THAT_ALREADY_EXISTS,
             messages.USER_USES_AN_EMAIL_ID_THAT_ALREADY_EXISTS,
+            messages.PASSWORD_INPUT_BY_USER_HAS_INVALID_LENGTH
         ),
     )
     @users_ns.expect(register_user_api_model, validate=True)

--- a/app/messages.py
+++ b/app/messages.py
@@ -1,3 +1,5 @@
+from app.api.validations.user import (PASSWORD_MAX_LENGTH, PASSWORD_MIN_LENGTH)
+
 # Invalid fields
 NAME_INPUT_BY_USER_IS_INVALID = {"message": "Your name is invalid."}
 EMAIL_INPUT_BY_USER_IS_INVALID = {"message": "Your email is invalid."}
@@ -9,6 +11,7 @@ FIELD_NEED_MENTORING_IS_NOT_VALID = {"message": "Field need_mentoring is" " not 
 FIELD_AVAILABLE_TO_MENTOR_IS_INVALID = {
     "message": "Field available_to_mentor" " is not valid."
 }
+PASSWORD_INPUT_BY_USER_HAS_INVALID_LENGTH={"message": f"The password field has to be longer than {PASSWORD_MIN_LENGTH} characters and shorter than {PASSWORD_MAX_LENGTH} characters."}
 
 # Not found
 MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST = {


### PR DESCRIPTION
### Description
Adds the message for an invalid password to the error responses.

Fixes #575 

### Type of Change:

- Code
- Documentation

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
Here is a screenshot showing the error message listed in the 400 responses
![Screenshot from 2020-05-11 20-56-40](https://user-images.githubusercontent.com/42730256/81594707-041e6880-93ca-11ea-9fab-2477a7054dcc.png)


### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] Update Swagger documentation and the exported file at /docs folder

**Code/Quality Assurance Only**

- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes
