### PR TITLE
Setting relative paths to repository files on the README.md file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ To run the unitests run the following command in the terminal (while the virtual
 
 ## Contributing
 
-Please read our [Contributing guidelines](https://github.com/anitab-org/mentorship-backend/blob/develop/.github/CONTRIBUTING.md), [Code of Conduct](http://systers.io/code-of-conduct) and [Reporting Guidelines](http://systers.io/reporting-guidelines)
+Please read our [Contributing guidelines](./.github/CONTRIBUTING.md), [Code of Conduct](http://systers.io/code-of-conduct) and [Reporting Guidelines](http://systers.io/reporting-guidelines)
 
 Please follow our [Commit Message Style Guide](https://github.com/anitab-org/mentorship-backend/wiki/Commit-Message-Style-Guide) while sending PRs.
 


### PR DESCRIPTION
### Description

Setting relative paths to repository files on the README,
so that I can see them properly on my fork README rendering.

On README the links to LICENSE, CONTRIBUTING.md, etc located within the repo, have absolute links to this organization repo, this causes to within our forks, it is linked to these files in the anitab-org organization files instead of on my fork's files.

Fixes #585 

### Type of Change:

<!--- **Delete irrelevant options.** --->

- Code
- Documentation

**Code/Quality Assurance Only**
- This change requires a documentation update (software upgrade on readme file)


### Checklist:

<!-- **Delete irrelevant options.** -->

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged

**Code/Quality Assurance Only**

- [x] My changes generate no new warnings 