### PR TITLE
feat: Add /logout endpoint with blacklist of tokens

### DIFF
--- a/app/api/dao/token.py
+++ b/app/api/dao/token.py
@@ -1,0 +1,47 @@
+
+from app.database.models.token import TokenModel
+from flask_jwt_extended import decode_token
+from datetime import datetime
+
+
+
+def _epoch_utc_to_datetime(epoch_utc):
+    """
+    Helper function for converting epoch timestamps (as stored in JWTs) into
+    python datetime objects (which are easier to use with sqlalchemy).
+
+    """
+    return datetime.fromtimestamp(epoch_utc)
+
+
+class TokenDAO:
+
+    def add_token_to_database(self, encoded_token, identity_claim):
+        """
+        Adds a new token to the database. It is not revoked when it is added.
+        :param identity_claim:
+
+        """
+        decoded_token = decode_token(encoded_token)
+        jti = decoded_token['jti']
+        token_type = decoded_token['type']
+        user_identity = decoded_token[identity_claim]
+        expires = _epoch_utc_to_datetime(decoded_token['exp'])
+        revoked = False
+
+        token = TokenModel(jti, token_type, user_identity, expires, revoked)
+        token.save_to_db()
+
+    def revoke_tokens(self, user_id):
+        """
+        Revokes the given token. Raises a TokenNotFound error if the token does
+        not exist in the database
+
+        """
+        tokens = TokenModel.query.filter_by(user_identity=user_id,revoked=False).all()
+        for token in tokens:
+            token.revoked = True
+            token.commit_to_db()
+        
+
+

--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -11,7 +11,6 @@ from app.database.models.mentorship_relation import MentorshipRelationModel
 from app.database.models.user import UserModel
 from app.utils.decorator_utils import email_verification_required
 from app.utils.enum_utils import MentorshipRelationState
-from app.database.models.mentorship_relation import MentorshipRelationModel
 from app.api.models.mentorship_relation import (
     list_tasks_response_body,
     mentorship_request_response_body_for_user_dashboard_body,

--- a/app/api/jwt_extension.py
+++ b/app/api/jwt_extension.py
@@ -2,6 +2,7 @@ from flask_jwt_extended import JWTManager
 from http import HTTPStatus
 from app import messages
 from app.api.api_extension import api
+from app.database.models.token import TokenModel
 
 jwt = JWTManager()
 
@@ -22,3 +23,11 @@ def my_invalid_token_callback(error_message):
 @jwt.unauthorized_loader
 def my_unauthorized_request_callback(error_message):
     return messages.AUTHORISATION_TOKEN_IS_MISSING, HTTPStatus.UNAUTHORIZED
+
+
+@jwt.token_in_blacklist_loader
+def check_if_token_revoked(decoded_token):
+    jti = decoded_token['jti']
+    token = TokenModel.query.filter_by(jti=jti).one()
+    return token.revoked
+        

--- a/app/database/models/token.py
+++ b/app/database/models/token.py
@@ -1,0 +1,26 @@
+from app.database.sqlalchemy_extension import db
+
+
+class TokenModel(db.Model):
+
+    id = db.Column(db.Integer, primary_key=True)
+    jti = db.Column(db.String(36), nullable=False)
+    token_type = db.Column(db.String(10), nullable=False)
+    user_identity = db.Column(db.Integer, nullable=False)
+    revoked = db.Column(db.Boolean, nullable=False)
+    expires = db.Column(db.DateTime, nullable=False)
+
+    def __init__(self, jti, token_type, user_identity, expires , revoked):
+   
+        self.jti = jti
+        self.token_type = token_type
+        self.user_identity = user_identity
+        self.expires = expires
+        self.revoked = revoked
+
+    def save_to_db(self) -> None:
+        db.session.add(self)
+        db.session.commit()
+
+    def commit_to_db(self):
+        db.session.commit()

--- a/app/messages.py
+++ b/app/messages.py
@@ -201,6 +201,7 @@ TOKEN_SENT_TO_EMAIL_OF_USER = {"message": "Token sent to the user's email."}
 EMAIL_VERIFICATION_MESSAGE = {
     "message": "Check your email, a new verification" " email was sent."
 }
+TOKEN_HAS_BEEN_REVOKED = { "msg": "Token has been revoked"}
 
 # Success messages
 TASK_WAS_ALREADY_ACHIEVED = {"message": "Task was already achieved."}

--- a/config.py
+++ b/config.py
@@ -48,6 +48,8 @@ class BaseConfig(object):
     # Flask JWT settings
     JWT_ACCESS_TOKEN_EXPIRES = timedelta(weeks=1)
     JWT_REFRESH_TOKEN_EXPIRES = timedelta(weeks=4)
+    JWT_BLACKLIST_ENABLED = True
+    JWT_BLACKLIST_TOKEN_CHECKS = ['access', 'refresh']
 
     # Security
     SECRET_KEY = os.getenv("SECRET_KEY", None)


### PR DESCRIPTION
if use the logout endpoint,
all of access tokens and refresh tokens of user will be invalidated(revoked) on the backend
so no one can use the access tokens and the refresh tokens if user logout
(referring to https://github.com/vimalloc/flask-jwt-extended/tree/master/examples/database_blacklist)

### Description

<!--- Include a summary of the change and relevant motivation/context. List any dependencies that are required for this change. --->

Fixes #359

### Type of Change:

<!--- **Delete irrelevant options.** --->

- Code
- Quality Assurance
- User Interface
- Outreach
- Documentation

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Provide instructions or GIFs so we can reproduce. List any relevant details for your test. -->


### Checklist:

<!-- **Delete irrelevant options.** -->

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged
- [ ] Update Postman API at /docs folder
- [ ] Update Swagger documentation and the exported file at /docs folder
- [ ] Update requirements.txt

**Code/Quality Assurance Only**

- [ ] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
