### PR TITLE
 fix: refractor HTTP error codes PUT/mentorship_relation/{request_id}/reject

### DIFF
--- a/app/api/dao/mentorship_relation.py
+++ b/app/api/dao/mentorship_relation.py
@@ -245,15 +245,15 @@ class MentorshipRelationDAO:
 
         # verify if request is in pending state
         if request.state != MentorshipRelationState.PENDING:
-            return messages.NOT_PENDING_STATE_RELATION, HTTPStatus.BAD_REQUEST
+            return messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN
 
         # verify if I'm the receiver of the request
         if request.action_user_id == user_id:
-            return messages.USER_CANT_REJECT_REQUEST_SENT_BY_USER, HTTPStatus.BAD_REQUEST
+            return messages.USER_CANT_REJECT_REQUEST_SENT_BY_USER, HTTPStatus.FORBIDDEN
 
         # verify if I'm involved in this relation
         if not (request.mentee_id == user_id or request.mentor_id == user_id):
-            return messages.CANT_REJECT_UNINVOLVED_RELATION_REQUEST, HTTPStatus.BAD_REQUEST
+            return messages.CANT_REJECT_UNINVOLVED_RELATION_REQUEST, HTTPStatus.FORBIDDEN
 
         # All was checked
         request.state = MentorshipRelationState.REJECTED

--- a/app/api/resources/mentorship_relation.py
+++ b/app/api/resources/mentorship_relation.py
@@ -243,7 +243,7 @@ class RejectMentorshipRelation(Resource):
         HTTPStatus.OK, "%s" % messages.MENTORSHIP_RELATION_WAS_REJECTED_SUCCESSFULLY
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.BAD_REQUEST,
+        HTTPStatus.FORBIDDEN,
         "%s\n%s\n%s"
         % (
             messages.NOT_PENDING_STATE_RELATION,

--- a/tests/mentorship_relation/test_dao_reject_mentorship_request.py
+++ b/tests/mentorship_relation/test_dao_reject_mentorship_request.py
@@ -99,7 +99,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         db.session.commit()
 
         result = DAO.reject_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 400), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 403), result)
 
         self.mentorship_relation.state = MentorshipRelationState.CANCELLED
         db.session.add(self.mentorship_relation)

--- a/tests/mentorship_relation/test_dao_reject_mentorship_request.py
+++ b/tests/mentorship_relation/test_dao_reject_mentorship_request.py
@@ -67,7 +67,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
 
         result = DAO.reject_request(self.first_user.id, self.mentorship_relation.id)
 
-        self.assertEqual((messages.USER_CANT_REJECT_REQUEST_SENT_BY_USER, 400), result)
+        self.assertEqual((messages.USER_CANT_REJECT_REQUEST_SENT_BY_USER, 403), result)
         self.assertEqual(
             MentorshipRelationState.PENDING, self.mentorship_relation.state
         )
@@ -92,7 +92,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         db.session.commit()
 
         result = DAO.reject_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 400), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 403), result)
 
         self.mentorship_relation.state = MentorshipRelationState.COMPLETED
         db.session.add(self.mentorship_relation)

--- a/tests/mentorship_relation/test_dao_reject_mentorship_request.py
+++ b/tests/mentorship_relation/test_dao_reject_mentorship_request.py
@@ -106,11 +106,11 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         db.session.commit()
 
         result = DAO.reject_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 400), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 403), result)
 
         self.mentorship_relation.state = MentorshipRelationState.REJECTED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.reject_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 400), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 403), result)


### PR DESCRIPTION
### Description
Changed 400: Bad Request to 403:FORBIDDEN,
 if the request state is not pending state, the request is sent to themselves, the request is for uninvolved mentor relation.

Fixes #628

### Type of Change:

<!--- **Delete irrelevant options.** --->

- Code
- Documentation

### How Has This Been Tested?
![IMG_20200715_204309](https://user-images.githubusercontent.com/60894542/87562701-ed530580-c6db-11ea-8341-01aab0b4967a.jpg)




### Checklist:

<!-- **Delete irrelevant options.** -->

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**

- [ ] My changes generate no new warnings 

