### PR TITLE
fixed f string mistake in tests

### DIFF
--- a/tests/task_comments/test_api_create_task_comment.py
+++ b/tests/task_comments/test_api_create_task_comment.py
@@ -19,7 +19,7 @@ class TestCreateTaskCommentApi(TasksBaseTestCase):
         auth_header = get_test_request_header(self.admin_user.id)
         expected_response = messages.COMMENT_FIELD_IS_MISSING
         actual_response = self.client.post(
-            f"mentorship_relation/{self.relation_id}/task/{self.task_id}" f"/comment",
+            f"mentorship_relation/{self.relation_id}/task/{self.task_id}/comment",
             follow_redirects=True,
             headers=auth_header,
             content_type="application/json",
@@ -33,7 +33,7 @@ class TestCreateTaskCommentApi(TasksBaseTestCase):
         auth_header = get_test_request_header(self.admin_user.id)
         expected_response = messages.COMMENT_NOT_IN_STRING_FORMAT
         actual_response = self.client.post(
-            f"mentorship_relation/{self.relation_id}/task/{self.task_id}" f"/comment",
+            f"mentorship_relation/{self.relation_id}/task/{self.task_id}/comment",
             follow_redirects=True,
             headers=auth_header,
             content_type="application/json",
@@ -51,7 +51,7 @@ class TestCreateTaskCommentApi(TasksBaseTestCase):
             )
         }
         actual_response = self.client.post(
-            f"mentorship_relation/{self.relation_id}/task/{self.task_id}" f"/comment",
+            f"mentorship_relation/{self.relation_id}/task/{self.task_id}/comment",
             follow_redirects=True,
             headers=auth_header,
             content_type="application/json",
@@ -96,7 +96,7 @@ class TestCreateTaskCommentApi(TasksBaseTestCase):
         auth_header = get_test_request_header(self.admin_user.id)
         expected_response = messages.TASK_COMMENT_WAS_CREATED_SUCCESSFULLY
         actual_response = self.client.post(
-            f"mentorship_relation/{self.relation_id}/task/{self.task_id}" f"/comment",
+            f"mentorship_relation/{self.relation_id}/task/{self.task_id}/comment",
             follow_redirects=True,
             headers=auth_header,
             content_type="application/json",

--- a/tests/task_comments/test_api_delete_task_comment.py
+++ b/tests/task_comments/test_api_delete_task_comment.py
@@ -96,7 +96,7 @@ class TestDeleteTaskCommentApi(TasksBaseTestCase):
         auth_header = get_test_request_header(self.admin_user.id)
         expected_response = messages.TASK_COMMENT_DOES_NOT_EXIST
         actual_response = self.client.delete(
-            f"mentorship_relation/{self.relation_id}/task/{self.task_id}" f"/comment/0",
+            f"mentorship_relation/{self.relation_id}/task/{self.task_id}/comment/0",
             follow_redirects=True,
             headers=auth_header,
             content_type="application/json",

--- a/tests/task_comments/test_api_get_task_comments.py
+++ b/tests/task_comments/test_api_get_task_comments.py
@@ -29,7 +29,7 @@ class TestGetTaskCommentsApi(TasksBaseTestCase):
     def test_task_comment_listing_api_without_auth_header(self):
         expected_response = messages.AUTHORISATION_TOKEN_IS_MISSING
         actual_response = self.client.get(
-            f"mentorship_relation/{self.relation_id}/task/{self.task_id}" f"/comments/",
+            f"mentorship_relation/{self.relation_id}/task/{self.task_id}/comments/",
             follow_redirects=True,
             content_type="application/json",
         )
@@ -70,7 +70,7 @@ class TestGetTaskCommentsApi(TasksBaseTestCase):
             task_comments_model,
         )
         actual_response = self.client.get(
-            f"mentorship_relation/{self.relation_id}/task/{self.task_id}" f"/comments",
+            f"mentorship_relation/{self.relation_id}/task/{self.task_id}/comments",
             follow_redirects=True,
             headers=auth_header,
         )

--- a/tests/task_comments/test_api_modify_task_comment.py
+++ b/tests/task_comments/test_api_modify_task_comment.py
@@ -95,7 +95,7 @@ class TestModifyTaskCommentApi(TasksBaseTestCase):
         auth_header = get_test_request_header(self.admin_user.id)
         expected_response = messages.MENTORSHIP_RELATION_DOES_NOT_EXIST
         actual_response = self.client.put(
-            f"mentorship_relation/0/task/{self.task_id}/comment/" f"{self.comment_id}",
+            f"mentorship_relation/0/task/{self.task_id}/comment/{self.comment_id}",
             follow_redirects=True,
             headers=auth_header,
             content_type="application/json",
@@ -124,7 +124,7 @@ class TestModifyTaskCommentApi(TasksBaseTestCase):
         auth_header = get_test_request_header(self.admin_user.id)
         expected_response = messages.TASK_COMMENT_DOES_NOT_EXIST
         actual_response = self.client.put(
-            f"mentorship_relation/{self.relation_id}/task/{self.task_id}" f"/comment/0",
+            f"mentorship_relation/{self.relation_id}/task/{self.task_id}/comment/0",
             follow_redirects=True,
             headers=auth_header,
             content_type="application/json",


### PR DESCRIPTION
### Description

Improperly formatted f strings were not consistent with up to date standards for readability. This pull request fixes the formatting of f-strings where f is repeated twice in an expression e.g.`f"mentorship_relation/{self.relation_id}/task/{self.task_id}"f"/comment"` and condenses them to expressions without the repeated 'f' e.g. `f"mentorship_relation/{self.relation_id}/task/{self.task_id}/comment"`

Fixes #681  

### Type of Change:

- Code

**Code/Quality Assurance Only**
- Bugfix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- visual inspection of expression changes and running of tests

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**

- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes





