### PR TITLE
fix: refactor HTTP error codes PUT /mentorship_relation/{relation_id}/…

### DIFF
--- a/app/api/dao/task_comment.py
+++ b/app/api/dao/task_comment.py
@@ -14,7 +14,7 @@ def validate_data_for_task_comment(user_id, task_id, relation_id):
         return messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION, HTTPStatus.UNAUTHORIZED
 
     if relation.state != MentorshipRelationState.ACCEPTED:
-        return messages.UNACCEPTED_STATE_RELATION, HTTPStatus.FORBIDDEN
+        return messages.UNACCEPTED_STATE_RELATION, HTTPStatus.BAD_REQUEST
 
     task = relation.tasks_list.find_task_by_id(task_id)
     if task is None:

--- a/app/api/dao/task_comment.py
+++ b/app/api/dao/task_comment.py
@@ -14,7 +14,7 @@ def validate_data_for_task_comment(user_id, task_id, relation_id):
         return messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION, HTTPStatus.UNAUTHORIZED
 
     if relation.state != MentorshipRelationState.ACCEPTED:
-        return messages.UNACCEPTED_STATE_RELATION, HTTPStatus.BAD_REQUEST
+        return messages.UNACCEPTED_STATE_RELATION, HTTPStatus.FORBIDDEN
 
     task = relation.tasks_list.find_task_by_id(task_id)
     if task is None:

--- a/app/api/dao/task_comment.py
+++ b/app/api/dao/task_comment.py
@@ -14,7 +14,7 @@ def validate_data_for_task_comment(user_id, task_id, relation_id):
         return messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION, HTTPStatus.UNAUTHORIZED
 
     if relation.state != MentorshipRelationState.ACCEPTED:
-        return messages.UNACCEPTED_STATE_RELATION, HTTPStatus.BAD_REQUEST
+        return messages.UNACCEPTED_STATE_RELATION, HTTPStatus.FORBIDDEN
 
     task = relation.tasks_list.find_task_by_id(task_id)
     if task is None:
@@ -146,7 +146,7 @@ class TaskCommentDAO:
             return messages.TASK_COMMENT_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND
 
         if task_comment.user_id != user_id:
-            return messages.TASK_COMMENT_WAS_NOT_CREATED_BY_YOU, HTTPStatus.BAD_REQUEST
+            return messages.TASK_COMMENT_WAS_NOT_CREATED_BY_YOU, HTTPStatus.FORBIDDEN
 
         if task_comment.task_id != task_id:
             return messages.TASK_COMMENT_WITH_GIVEN_TASK_ID_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND
@@ -185,7 +185,7 @@ class TaskCommentDAO:
             return messages.TASK_COMMENT_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND
 
         if task_comment.user_id != user_id:
-            return messages.TASK_COMMENT_WAS_NOT_CREATED_BY_YOU_DELETE, HTTPStatus.BAD_REQUEST
+            return messages.TASK_COMMENT_WAS_NOT_CREATED_BY_YOU_DELETE, HTTPStatus.FORBIDDEN
 
         if task_comment.task_id != task_id:
             return messages.TASK_COMMENT_WITH_GIVEN_TASK_ID_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND

--- a/app/api/resources/mentorship_relation.py
+++ b/app/api/resources/mentorship_relation.py
@@ -748,7 +748,7 @@ class TaskComment(Resource):
     @mentorship_relation_ns.doc(
         responses={
             HTTPStatus.OK: f"{messages.TASK_COMMENT_WAS_UPDATED_SUCCESSFULLY}",
-            HTTPStatus.BAD_REQUEST: f"{messages.COMMENT_FIELD_IS_MISSING}<br>"
+            HTTPStatus.FORBIDDEN: f"{messages.COMMENT_FIELD_IS_MISSING}<br>"
             f"{messages.COMMENT_NOT_IN_STRING_FORMAT}<br>"
             f"{ {'message':get_length_validation_error_message('comment', None, COMMENT_MAX_LENGTH)}}<br>"
             f"{messages.UNACCEPTED_STATE_RELATION}<br>"

--- a/tests/task_comments/test_api_delete_task_comment.py
+++ b/tests/task_comments/test_api_delete_task_comment.py
@@ -62,7 +62,7 @@ class TestDeleteTaskCommentApi(TasksBaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(400, actual_response.status_code)
+        self.assertEqual(403, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_deletion_api_with_relation_not_existing(self):

--- a/tests/task_comments/test_api_modify_task_comment.py
+++ b/tests/task_comments/test_api_modify_task_comment.py
@@ -88,7 +88,7 @@ class TestModifyTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(comment="comment")),
         )
 
-        self.assertEqual(400, actual_response.status_code)
+        self.assertEqual(403, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_modification_api_with_relation_not_existing(self):


### PR DESCRIPTION
…task/{task_id}/comment/{comment_id}

### Description

For PUT /mentorship_relation/{relation_id}/task/{task_id}/comment/{comment_id}, changed 400: BAD_REQUEST to 403:FORBIDDEN

Fixes #634 

### Type of Change:

<!--- **Delete irrelevant options.** --->

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bugfix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Provide instructions or GIFs so we can reproduce. List any relevant details for your test. -->
![Screenshot from 2020-07-22 01-41-33](https://user-images.githubusercontent.com/48416306/88110024-8b533e00-cbbc-11ea-858b-ecbfcf9ebc21.png)

### Checklist:

<!-- **Delete irrelevant options.** -->

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**

- [x] My changes generate no new warnings 