### PR TITLE
Chore: Use `--no-cache-dir` flag to `pip` in Dockerfiles, to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7
 COPY ./requirements.txt /dockerBuild/requirements.txt
 WORKDIR /dockerBuild
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 COPY . /dockerBuild
 CMD ["flask", "run", "--host", "0.0.0.0"]


### PR DESCRIPTION
### Description

Using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Fix : #737 

### Type of Change:

- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### Checklist:

- [* ] My PR follows the style guidelines of this project
- [* ] I have performed a self-review of my own code or materials


Signed-off-by: Pratik Raj <rajpratik71@gmail.com>