### PR TITLE
Style: Change to f-strings (fix#741)

### DIFF
--- a/app/api/resources/admin.py
+++ b/app/api/resources/admin.py
@@ -13,19 +13,14 @@ add_models_to_namespace(admin_ns)
 
 
 @admin_ns.route("admin/new")
-@admin_ns.response(HTTPStatus.FORBIDDEN, "%s" % messages.USER_IS_NOW_AN_ADMIN)
-@admin_ns.response(HTTPStatus.BAD_REQUEST, "%s" % messages.USER_IS_ALREADY_AN_ADMIN)
+@admin_ns.response(HTTPStatus.FORBIDDEN, f"{messages.USER_IS_NOW_AN_ADMIN}")
+@admin_ns.response(HTTPStatus.BAD_REQUEST, f"{messages.USER_IS_ALREADY_AN_ADMIN}")
 @admin_ns.response(
     HTTPStatus.UNAUTHORIZED,
-    "%s\n%s\n%s"
-    % (
-        messages.TOKEN_HAS_EXPIRED,
-        messages.TOKEN_IS_INVALID,
-        messages.AUTHORISATION_TOKEN_IS_MISSING,
-    ),
+    f"{messages.TOKEN_HAS_EXPIRED}\n{messages.TOKEN_IS_INVALID}\n{messages.AUTHORISATION_TOKEN_IS_MISSING}"
 )
-@admin_ns.response(HTTPStatus.FORBIDDEN, "%s" % messages.USER_ASSIGN_NOT_ADMIN)
-@admin_ns.response(HTTPStatus.NOT_FOUND, "%s" % messages.USER_DOES_NOT_EXIST)
+@admin_ns.response(HTTPStatus.FORBIDDEN, f"{messages.USER_ASSIGN_NOT_ADMIN}")
+@admin_ns.response(HTTPStatus.NOT_FOUND, f"{messages.USER_DOES_NOT_EXIST}")
 class AssignNewUserAdmin(Resource):
     @classmethod
     @jwt_required
@@ -50,19 +45,15 @@ class AssignNewUserAdmin(Resource):
 
 
 @admin_ns.route("admin/remove")
-@admin_ns.response(HTTPStatus.OK, "%s" % messages.USER_ADMIN_STATUS_WAS_REVOKED)
-@admin_ns.response(HTTPStatus.BAD_REQUEST, "%s" % messages.USER_IS_NOT_AN_ADMIN)
+@admin_ns.response(HTTPStatus.OK, f"{messages.USER_ADMIN_STATUS_WAS_REVOKED}")
+@admin_ns.response(HTTPStatus.BAD_REQUEST, f"{messages.USER_IS_NOT_AN_ADMIN}")
 @admin_ns.response(
     HTTPStatus.UNAUTHORIZED,
-    "%s\n%s\n%s"
-    % (
-        messages.TOKEN_HAS_EXPIRED,
-        messages.TOKEN_IS_INVALID,
-        messages.AUTHORISATION_TOKEN_IS_MISSING,
-    ),
+    f"{messages.TOKEN_HAS_EXPIRED}\n{messages.TOKEN_IS_INVALID}\n{messages.AUTHORISATION_TOKEN_IS_MISSING}"
+
 )
-@admin_ns.response(HTTPStatus.FORBIDDEN, "%s" % messages.USER_REVOKE_NOT_ADMIN)
-@admin_ns.response(HTTPStatus.NOT_FOUND, "%s" % messages.USER_DOES_NOT_EXIST)
+@admin_ns.response(HTTPStatus.FORBIDDEN, f"{messages.USER_REVOKE_NOT_ADMIN}")
+@admin_ns.response(HTTPStatus.NOT_FOUND, f"{messages.USER_DOES_NOT_EXIST}")
 class RevokeUserAdmin(Resource):
     @classmethod
     @jwt_required
@@ -99,7 +90,7 @@ class ListAdmins(Resource):
             f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}"
         }
     )
-    @admin_ns.response(HTTPStatus.FORBIDDEN, "%s" % messages.USER_IS_NOT_AN_ADMIN)
+    @admin_ns.response(HTTPStatus.FORBIDDEN, f"{messages.USER_IS_NOT_AN_ADMIN}")
     @admin_ns.expect(auth_header_parser)
     def get(cls):
         """


### PR DESCRIPTION
## Style: Change all %-formatting to f-strings

### Description

<!--- Include a summary of the change and relevant motivation/context. List any dependencies that are required for this change. --->

Fixes #741 

To start, the file <code>app/api/resources/admin.py</code> contained %-formatted strings for the descriptions of the code responses, for example:

```python
@admin_ns.route("admin/new")
@admin_ns.response(HTTPStatus.FORBIDDEN, "%s" % messages.USER_IS_NOW_AN_ADMIN)
@admin_ns.response(HTTPStatus.BAD_REQUEST, "%s" % messages.USER_IS_ALREADY_AN_ADMIN)
@admin_ns.response(
    HTTPStatus.UNAUTHORIZED,
    "%s\n%s\n%s"
    % (
        messages.TOKEN_HAS_EXPIRED,
        messages.TOKEN_IS_INVALID,
        messages.AUTHORISATION_TOKEN_IS_MISSING,
    ),
)
```

Any instance of this was changed to use f-strings, as described in the [Coding Standards](https://github.com/anitab-org/mentorship-backend/blob/develop/docs/coding_standards.md).

For example:

```python
@admin_ns.route("admin/new")
@admin_ns.response(HTTPStatus.FORBIDDEN, f"{messages.USER_IS_NOW_AN_ADMIN}")
@admin_ns.response(HTTPStatus.BAD_REQUEST, f"{messages.USER_IS_ALREADY_AN_ADMIN}")
@admin_ns.response(
    HTTPStatus.UNAUTHORIZED,
    f"{messages.TOKEN_HAS_EXPIRED}\n{messages.TOKEN_IS_INVALID}\n{messages.AUTHORISATION_TOKEN_IS_MISSING}"
)
@admin_ns.response(HTTPStatus.FORBIDDEN, f"{messages.USER_ASSIGN_NOT_ADMIN}")
@admin_ns.response(HTTPStatus.NOT_FOUND, f"{messages.USER_DOES_NOT_EXIST}")
```

### Type of Change:

<!--- **Delete irrelevant options.** --->

- Style (formatting)


### How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Provide instructions or GIFs so we can reproduce. List any relevant details for your test. -->

I had the program open in my browser and kept checking to make sure that there were no errors on the page or in the terminal.

### Checklist:

<!-- **Delete irrelevant options.** -->

- [x ] My PR follows the style guidelines of this project
- [x ] I have performed a self-review of my own code or materials

