### PR TITLE
fixed the missing module type_ignore for python3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -70,4 +70,4 @@ tzlocal==1.5.1
 urllib3==1.22
 wcwidth==0.1.7
 websocket-client==0.48.0
-Werkzeug==0.15.3
+Werkzeug==0.16.1


### PR DESCRIPTION
### Description
Updated the version of Werkzeug module from 0.15.3 to 0.16.1 in requirement.txt
<!--- Include a summary of the change and relevant motivation/context. List any dependencies that are required for this change. --->

Fixes #746

### Type of Change:

<!--- **Delete irrelevant options.** --->

- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Provide instructions or GIFs so we can reproduce. List any relevant details for your test. -->
After modification, I ran the program and the tests. Everything was successful.

### Checklist:

<!-- **Delete irrelevant options.** -->

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] Update requirements.txt

**Code/Quality Assurance Only**

- [ ] My changes generate no new warnings 
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
