### PR TITLE
fix: add error message in the responses

### DIFF
--- a/app/api/resources/user.py
+++ b/app/api/resources/user.py
@@ -322,7 +322,7 @@ class UserEmailConfirmation(Resource):
 @users_ns.response(HTTPStatus.OK, "%s" % messages.EMAIL_VERIFICATION_MESSAGE)
 @users_ns.response(HTTPStatus.BAD_REQUEST, "Invalid input.")
 @users_ns.response(HTTPStatus.FORBIDDEN, "%s" % messages.USER_ALREADY_CONFIRMED_ACCOUNT)
-@users_ns.response(HTTPStatus.NOT_FOUND, "%s" % messages.USER_DOES_NOT_EXIST)
+@users_ns.response(HTTPStatus.NOT_FOUND, "%s" % messages.USER_IS_NOT_REGISTERED_IN_THE_SYSTEM)
 class UserResendEmailConfirmation(Resource):
     @classmethod
     @users_ns.expect(resend_email_request_body_model)

--- a/app/messages.py
+++ b/app/messages.py
@@ -147,7 +147,7 @@ USER_USES_AN_EMAIL_ID_THAT_ALREADY_EXISTS = {
     "message": "A user with that " "email already exists."
 }
 USER_IS_NOT_REGISTERED_IN_THE_SYSTEM = {
-    "message": "You are not registered in" "the system."
+    "message": "You are not registered in the system."
 }
 NAME_LENGTH_GREATER_THAN_MAX_LIMIT = {
     "message": "The {field_name} field has"


### PR DESCRIPTION
### Description
Added a valid error message in the responses for **user-Sends the user a new verification email** if the user is not registered.

Fixes #721 

### Type of Change:
- Code
- Quality Assurance


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (software upgrade on readme file)
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
![changed](https://user-images.githubusercontent.com/45794450/92527754-28d60000-f245-11ea-9042-e071b6dfe409.JPG)



### Checklist:

<!-- **Delete irrelevant options.** -->

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged
- [ ] Update Postman API at /docs folder
- [ ] Update Swagger documentation and the exported file at /docs folder
- [ ] Update requirements.txt

**Code/Quality Assurance Only**

- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
