### PR TITLE
Fix: Fixed the error shown in PUT/user Updates user profile

### DIFF
--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -216,12 +216,10 @@ class UserDAO:
         username = data.get("username", None)
         if username:
             user_with_same_username = UserModel.find_by_username(username)
-
-            # username should be unique
-            if user_with_same_username:
-                return messages.USER_USES_A_USERNAME_THAT_ALREADY_EXISTS, HTTPStatus.BAD_REQUEST
-
-            user.username = username
+            
+        #if username is different only then it will update username in db else username remains same and other details gets updated
+            if not user_with_same_username:
+                user.username = username
 
         if "name" in data and data["name"]:
             user.name = data["name"]

--- a/tests/users/test_api_update_user.py
+++ b/tests/users/test_api_update_user.py
@@ -46,7 +46,7 @@ class TestUpdateUserApi(BaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(400, actual_response.status_code)
+        self.assertEqual(200, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_update_username_not_taken(self):

--- a/tests/users/test_api_update_user.py
+++ b/tests/users/test_api_update_user.py
@@ -37,7 +37,7 @@ class TestUpdateUserApi(BaseTestCase):
         db.session.commit()
 
         auth_header = get_test_request_header(self.first_user.id)
-        expected_response = messages.USER_USES_A_USERNAME_THAT_ALREADY_EXISTS
+        expected_response = messages.USER_SUCCESSFULLY_UPDATED
         actual_response = self.client.put(
             "/user",
             follow_redirects=True,


### PR DESCRIPTION
 **Description**

Removed 400:Bad Request shown when user uses same username while updating users profile and changed it to 200:user was updated successfully ,allowing users to change the details even if they use same username and update other details **removing  bug in the current logic which makes it compulsory for user to change their username on each update** . No 400:ERROR will be shown but the changed details will be reflected in users updated profile.

PS:If user can even change username on update along with other details or they can also use the already existing username and update other details.

Fixes #596 

 **Type of Change:**

- Code
- Documentation

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

 **How Has This Been Tested?**

- Before this commit we would get the following result that is 400:Bad Request when user uses already existing username

![Before_commit](https://user-images.githubusercontent.com/43921225/92596696-dbe53e80-f2c3-11ea-804e-6069355b644c.png)

- After this commit it shows 200:users updated successfully even if the user uses already existing username and changes other details

![After_commit](https://user-images.githubusercontent.com/43921225/92596810-0505cf00-f2c4-11ea-9a64-e1b2c0391516.png)

 **Checklist:**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] Update Swagger documentation and the exported file at /docs folder

**Code/Quality Assurance Only**

- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
