### PR TITLE
 Fix Delete relation when the user did not create the request #771

### DIFF
--- a/app/api/dao/mentorship_relation.py
+++ b/app/api/dao/mentorship_relation.py
@@ -317,13 +317,13 @@ class MentorshipRelationDAO:
         if request is None:
             return messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND
 
-        # verify if request is in pending state
-        if request.state != MentorshipRelationState.PENDING:
-            return messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN
-
         # verify if user created the mentorship request
         if request.action_user_id != user_id:
             return messages.CANT_DELETE_UNINVOLVED_REQUEST, HTTPStatus.FORBIDDEN
+
+        # verify if request is in pending state
+        if request.state != MentorshipRelationState.PENDING:
+            return messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN
 
         # All was checked
         request.delete_from_db()


### PR DESCRIPTION
### Description
Existing code checks whether the relationship is in pending state before checking whether the relationship belongs to the user who created the request, this will throw a wrong error message if the relationship is in the accepted state and another user (who does not own this relationship) tries to delete this relationship. Thus, adjusting the sequence of the code will first check whether the relationship belongs to the rightful user, which results in the correct error message.   

When 
Fixes #771  
Fix wrong Error message response when user deletes a relationship that is not created by them.

### Type of Change:
- Code


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)




### How Has This Been Tested?

I have tested this by reproducing the behaviour stated by @rpattath.


### Checklist:

<!-- **Delete irrelevant options.** -->

- [/] My PR follows the style guidelines of this project
- [/] I have performed a self-review of my own code or materials
- [/] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas


**Code/Quality Assurance Only**

- [ /] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [/] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
