### PR TITLE
Fixed, searching based on both the username and name #745

### DIFF
--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -179,7 +179,8 @@ class UserDAO:
             UserModel.query.filter(
                 UserModel.id != user_id,
                 not is_verified or UserModel.is_email_verified,
-                func.lower(UserModel.name).contains(search_query.lower()),
+                func.lower(UserModel.name).contains(search_query.lower())
+                | func.lower(UserModel.username).contains(search_query.lower()),
             )
             .order_by(UserModel.id)
             .paginate(

--- a/tests/tasks/test_api_create_task.py
+++ b/tests/tasks/test_api_create_task.py
@@ -29,8 +29,7 @@ class TestCreateTaskApi(TasksBaseTestCase):
         auth_header = get_test_request_header(self.first_user.id)
         expected_response = messages.DESCRIPTION_FIELD_IS_MISSING
         actual_response = self.client.post(
-            f"/mentorship_relation/{self.mentorship_relation_w_second_user.id}"
-            "/task",
+            f"/mentorship_relation/{self.mentorship_relation_w_second_user.id}/task",
             follow_redirects=True,
             headers=auth_header,
             content_type="application/json",
@@ -48,8 +47,7 @@ class TestCreateTaskApi(TasksBaseTestCase):
         )
         expected_response = messages.TOKEN_HAS_EXPIRED
         actual_response = self.client.post(
-            f"/mentorship_relation/{self.mentorship_relation_w_second_user.id}"
-            "/task",
+            f"/mentorship_relation/{self.mentorship_relation_w_second_user.id}/task",
             follow_redirects=True,
             headers=auth_header,
             content_type="application/json",
@@ -61,8 +59,7 @@ class TestCreateTaskApi(TasksBaseTestCase):
     def test_create_task_api_resource_non_auth(self):
         expected_response = messages.AUTHORISATION_TOKEN_IS_MISSING
         actual_response = self.client.post(
-            f"/mentorship_relation/{self.mentorship_relation_w_second_user.id}"
-            "/task",
+            f"/mentorship_relation/{self.mentorship_relation_w_second_user.id}/task",
             follow_redirects=True,
         )
 
@@ -77,8 +74,7 @@ class TestCreateTaskApi(TasksBaseTestCase):
         auth_header = get_test_request_header(self.first_user.id)
         expected_response = messages.TASK_WAS_CREATED_SUCCESSFULLY
         actual_response = self.client.post(
-            f"/mentorship_relation/{self.mentorship_relation_w_second_user.id}"
-            "/task",
+            f"/mentorship_relation/{self.mentorship_relation_w_second_user.id}/task",
             follow_redirects=True,
             headers=auth_header,
             content_type="application/json",

--- a/tests/tasks/test_api_list_tasks.py
+++ b/tests/tasks/test_api_list_tasks.py
@@ -39,8 +39,7 @@ class TestListTasksApi(TasksBaseTestCase):
         auth_header = get_test_request_header(self.first_user.id)
         expected_response = marshal(self.tasks_list_2.tasks, list_tasks_response_body)
         actual_response = self.client.get(
-            f"/mentorship_relation/{self.mentorship_relation_w_admin_user.id}"
-            "/tasks",
+            f"/mentorship_relation/{self.mentorship_relation_w_admin_user.id}/tasks",
             follow_redirects=True,
             headers=auth_header,
         )
@@ -53,8 +52,7 @@ class TestListTasksApi(TasksBaseTestCase):
         auth_header = get_test_request_header(self.second_user.id)
         expected_response = messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION
         actual_response = self.client.get(
-            f"/mentorship_relation/{self.mentorship_relation_w_admin_user.id}"
-            "/tasks",
+            f"/mentorship_relation/{self.mentorship_relation_w_admin_user.id}/tasks",
             follow_redirects=True,
             headers=auth_header,
         )

--- a/tests/users/test_api_list_users.py
+++ b/tests/users/test_api_list_users.py
@@ -260,6 +260,18 @@ class TestListUsersApi(BaseTestCase):
         self.assertEqual(200, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
+    def test_list_users_api_with_a_search_query_with_username_resource_auth(self):
+        auth_header = get_test_request_header(self.admin_user.id)
+        expected_response = [marshal(self.verified_user, public_user_api_model)]
+        actual_response = self.client.get(
+            f"/users?search={self.verified_user.username}",
+            follow_redirects=True,
+            headers=auth_header,
+        )
+
+        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Now the search function finds the mentor/mentee based on both username and name.

To solve this issue added a OR operator to search on basis of username as well as name.

Tests: Manually tested by searching for user with the username and name

Fixes #745

checklist : 
- [x] Implemented searching on basis of username.
