### PR TITLE
feat: add user.name and sent_by_me to GET /comments response

### DIFF
--- a/app/api/models/mentorship_relation.py
+++ b/app/api/models/mentorship_relation.py
@@ -18,6 +18,7 @@ def add_models_to_namespace(api_namespace):
     ] = mentorship_request_response_body_for_user_dashboard_body
     api_namespace.models[user_dashboard_user_details.name] = user_dashboard_user_details
     api_namespace.models[task_comment_model.name] = task_comment_model
+    api_namespace.models[user_detail.name] = user_detail
     api_namespace.models[task_comments_model.name] = task_comments_model
 
 
@@ -164,11 +165,20 @@ task_comment_model = Model(
     {"comment": fields.String(required=True, description="Task comment.")},
 )
 
+user_detail = Model(
+    "User detail model.",
+    {
+        "id": fields.Integer(required=True, description="User's id."),
+        "name": fields.String(required=True, description="User's name.")
+    },
+)
 task_comments_model = Model(
     "Task comments model.",
     {
         "id": fields.Integer(required=True, description="Task comment's id."),
-        "user_id": fields.Integer(required=True, description="User's id."),
+        "sent_by_me": fields.Boolean(
+            required=True, description="Comment is done by current user indication"),
+        "user": fields.Nested(user_detail),
         "task_id": fields.Integer(required=True, description="Task's id."),
         "relation_id": fields.Integer(required=True, description="Relation's id."),
         "creation_date": fields.Float(

--- a/app/api/resources/mentorship_relation.py
+++ b/app/api/resources/mentorship_relation.py
@@ -507,7 +507,7 @@ class CreateTask(Resource):
         messages.TOKEN_HAS_EXPIRED,
         messages.TOKEN_IS_INVALID,
         messages.AUTHORISATION_TOKEN_IS_MISSING
-    )
+        )
     )
     @mentorship_relation_ns.response(403, '%s'%messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION)
     def post(cls, request_id):

--- a/app/api/resources/mentorship_relation.py
+++ b/app/api/resources/mentorship_relation.py
@@ -507,7 +507,7 @@ class CreateTask(Resource):
         messages.TOKEN_HAS_EXPIRED,
         messages.TOKEN_IS_INVALID,
         messages.AUTHORISATION_TOKEN_IS_MISSING
-        )
+    )
     )
     @mentorship_relation_ns.response(403, '%s'%messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION)
     def post(cls, request_id):
@@ -836,12 +836,17 @@ class TaskComments(Resource):
         """
         Lists the task comments.
         """
+        user_id = get_jwt_identity()
 
         response = TaskCommentDAO.get_all_task_comments_by_task_id(
-            get_jwt_identity(), task_id, relation_id
+            user_id, task_id, relation_id
         )
 
         if isinstance(response, tuple):
             return response
-        else:
-            return marshal(response, task_comments_model), HTTPStatus.OK
+
+        for task in response:
+            task['user'] = userDAO.get_user(task['user_id'])
+            task['sent_by_me'] = user_id == task['user_id']
+            
+        return marshal(response, task_comments_model), HTTPStatus.OK

--- a/tests/task_comments/test_api_get_task_comments.py
+++ b/tests/task_comments/test_api_get_task_comments.py
@@ -66,9 +66,16 @@ class TestGetTaskCommentsApi(TasksBaseTestCase):
     def test_task_comment_listing_api(self):
         auth_header = get_test_request_header(self.admin_user.id)
         expected_response = marshal(
-            TaskCommentDAO.get_all_task_comments_by_task_id(1, 1, 2),
+            TaskCommentDAO.get_all_task_comments_by_task_id(self.admin_user.id, self.task_id, self.relation_id),
             task_comments_model,
         )
+
+        # all tasks are added by admin_user in relation #this.relation_id
+        for task in expected_response:
+            task['user'] = {"id": self.admin_user.id,
+                            "name": self.admin_user.name}
+            task['sent_by_me'] = True 
+
         actual_response = self.client.get(
             f"mentorship_relation/{self.relation_id}/task/{self.task_id}/comments",
             follow_redirects=True,


### PR DESCRIPTION
### Description

Fix #685 Improve GET (...)/comments response to include user.name and sent_by_me

### Type of Change:

<!--- **Delete irrelevant options.** --->

- Code

**Code/Quality Assurance Only**




### How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Provide instructions or GIFs so we can reproduce. List any relevant details for your test. -->

I created a task for a relationship and added a comment for the task. Then checked comments for both users for the same task. It was behaving as expected.


### Checklist:

<!-- **Delete irrelevant options.** -->

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation


**Code/Quality Assurance Only**

- [x] I have added (**updated**) tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
