### PR TITLE
Added error message under BAD REQUEST responses

### DIFF
--- a/app/api/resources/user.py
+++ b/app/api/resources/user.py
@@ -129,7 +129,13 @@ class MyUserProfile(Resource):
     @users_ns.doc("update_user_profile")
     @users_ns.expect(auth_header_parser, update_user_request_body_model)
     @users_ns.response(HTTPStatus.OK, "%s" % messages.USER_SUCCESSFULLY_UPDATED)
-    @users_ns.response(HTTPStatus.BAD_REQUEST, "Invalid input.")
+    @users_ns.response(
+        HTTPStatus.BAD_REQUEST, 
+        "%s"
+    % (
+        messages.NAME_INPUT_BY_USER_IS_INVALID,
+        ),
+)
     def put(cls):
         """
         Updates user profile

--- a/app/api/resources/user.py
+++ b/app/api/resources/user.py
@@ -129,13 +129,7 @@ class MyUserProfile(Resource):
     @users_ns.doc("update_user_profile")
     @users_ns.expect(auth_header_parser, update_user_request_body_model)
     @users_ns.response(HTTPStatus.OK, "%s" % messages.USER_SUCCESSFULLY_UPDATED)
-    @users_ns.response(
-        HTTPStatus.BAD_REQUEST, 
-        "%s"
-    % (
-        messages.NAME_INPUT_BY_USER_IS_INVALID,
-        ),
-)
+    @users_ns.response(HTTPStatus.BAD_REQUEST, "%s" % messages.NAME_INPUT_BY_USER_IS_INVALID)
     def put(cls):
         """
         Updates user profile

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,10 +18,6 @@ click==6.7
 colorama==0.3.9
 coverage==4.5.1
 cryptography==2.8
-docker==3.4.0
-docker-compose==1.21.2
-docker-pycreds==0.3.0
-dockerpty==0.4.1
 docopt==0.6.2
 docutils==0.14
 entrypoints==0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,10 @@ click==6.7
 colorama==0.3.9
 coverage==4.5.1
 cryptography==2.8
+docker==3.4.0
+docker-compose==1.21.2
+docker-pycreds==0.3.0
+dockerpty==0.4.1
 docopt==0.6.2
 docutils==0.14
 entrypoints==0.3
@@ -66,4 +70,4 @@ tzlocal==1.5.1
 urllib3==1.22
 wcwidth==0.1.7
 websocket-client==0.48.0
-Werkzeug==0.16.1
+Werkzeug==0.15.3


### PR DESCRIPTION
### Description
When we enter numericals instead of characters for name, while updating user profile it should show a proper error message and should be listed under responses.



Fixes #606 

### Type of Change:

<!--- **Delete irrelevant options.** --->

- Code







### How Has This Been Tested?

![Screenshot (367)](https://user-images.githubusercontent.com/50888936/93503199-5f8ed300-f935-11ea-946a-b811cf1703cd.png)


### Checklist:

<!-- **Delete irrelevant options.** -->

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials


