### PR TITLE
Added error message under BAD REQUEST responses

### DIFF
--- a/app/api/resources/user.py
+++ b/app/api/resources/user.py
@@ -129,7 +129,7 @@ class MyUserProfile(Resource):
     @users_ns.doc("update_user_profile")
     @users_ns.expect(auth_header_parser, update_user_request_body_model)
     @users_ns.response(HTTPStatus.OK, "%s" % messages.USER_SUCCESSFULLY_UPDATED)
-    @users_ns.response(HTTPStatus.BAD_REQUEST, "Invalid input.")
+    @users_ns.response(HTTPStatus.BAD_REQUEST, "%s" % messages.NAME_INPUT_BY_USER_IS_INVALID)
     def put(cls):
         """
         Updates user profile


### PR DESCRIPTION
### Description

When we enter numerical instead of characters for the name, while updating the user profile it should show a proper error message and should be listed under responses.

Fixes #606 

### Type of Change:

<!--- **Delete irrelevant options.** --->

- Code
- Documentation




### How Has This Been Tested?

![Screenshot (367)](https://user-images.githubusercontent.com/50888936/93686309-05c40f80-fad3-11ea-87bf-d9f149bba2e8.png)


### Checklist:

<!-- **Delete irrelevant options.** -->

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials


