### PR TITLE
Performed manual testing and report GET /user/confirm_email/{token} A…

### DIFF
--- a/app/api/resources/user.py
+++ b/app/api/resources/user.py
@@ -311,7 +311,7 @@ class UserEmailConfirmation(Resource):
 
         This endpoint is called when a new user clicks the verification link
         sent on the users' email. It takes the verification token through URL
-        as input parameter.The verification token is valid for 24 hours. A success or
+        as input parameter.The verification token is valid for 30 days. A success or
         failure response is returned by the API.
         """
 
@@ -330,7 +330,7 @@ class UserResendEmailConfirmation(Resource):
         """Sends the user a new verification email.
 
         This endpoint is called when a user wants the verification email to be
-        resent. The verification token is valid for 24 hours. A success or
+        resent. The verification token is valid for 30 days. A success or
         failure response is returned by the API.
         """
 

--- a/docs/manual_tests/test_confirmation_token.md
+++ b/docs/manual_tests/test_confirmation_token.md
@@ -1,0 +1,48 @@
+* Test 1 : Verification token entered is one sent on user's registered email within 24 hrs
+
+     _Screenshot/gif_: 
+     
+     ![test_1](https://user-images.githubusercontent.com/56037184/94105745-91cd9280-fe57-11ea-90e7-6e514cb3ada2.png)
+
+
+     _Expected Result_: SUCCESS (message: You have confirmed your account. Thanks!)
+
+     _Actual Result_: SUCCESS (message: You have confirmed your account. Thanks!)
+
+
+* Test 2:  Verification token of already confirmed users account entered
+
+     _Screenshot/gif_: 
+     
+     ![test_2](https://user-images.githubusercontent.com/56037184/94105790-a90c8000-fe57-11ea-8044-aee26039567e.png)
+
+
+     _Expected Result_:  SUCCESS (message: Account already confirmed)
+
+     _Actual Result_: SUCCESS (message: Account already confirmed)
+
+
+* Test 3:  Verification token of un-confirmed users account entered after 24 hrs of email being sent
+
+     _Screenshot/gif_: 
+     
+    ![test_3](https://user-images.githubusercontent.com/56037184/94105821-bf1a4080-fe57-11ea-9f9f-2d895a62fffb.png)
+
+
+     _Expected Result_:  Failure (message: The confirmation link is invalid or the token has expired.)
+
+     _Actual Result_: SUCCESS (message: You have confirmed your account. Thanks!)
+
+    _Reason_: I tested it and it is valid for 30days.
+
+
+* Test 4:  Incorrect verification token entered in request body
+
+     _Screenshot/gif_: 
+     
+    ![test_4](https://user-images.githubusercontent.com/56037184/94105890-e83ad100-fe57-11ea-92c9-95951ae57bb1.png)
+
+
+     _Expected Result_:  Failure (message: The confirmation link is invalid or the token has expired.)
+
+     _Actual Result_: FAILURE (message: The confirmation link is invalid or the token has expired.)


### PR DESCRIPTION
…PI #870

tested confirm_email/{token} part when a user register on the portal.
considered all cases like:
1. valid token of newly registered users within 24 hours.
2. invalid token.
3. token of already confirmed email id.
4. valid token of newly registered users after 24 hours

Resources:
* Quality Assurance test cases: [/docs/quality-assurance-test-cases.md#confirmation-of-users-email](https://github.com/anitab-org/mentorship-backend/blob/develop/docs/quality-assurance-test-cases.md#confirmation-of-users-email)

Task Done:
- [x] Test GET /user/confirm_email/{token} API
- [x] Create a markdown file under /docs/manual_tests with the content mentioned above (at least 2 tests)
Fixes #870

