### PR TITLE
fix : Responses does not list 'Notes field is missing.' error message

### DIFF
--- a/app/api/resources/mentorship_relation.py
+++ b/app/api/resources/mentorship_relation.py
@@ -39,7 +39,7 @@ class SendRequest(Resource):
     )
     @mentorship_relation_ns.response(
         HTTPStatus.BAD_REQUEST,
-        "%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s"
+        "%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s"
         % (
             messages.MATCH_EITHER_MENTOR_OR_MENTEE,
             messages.MENTOR_ID_SAME_AS_MENTEE_ID,
@@ -52,6 +52,7 @@ class SendRequest(Resource):
             messages.MENTEE_ALREADY_IN_A_RELATION,
             messages.MENTOR_ID_FIELD_IS_MISSING,
             messages.MENTEE_ID_FIELD_IS_MISSING,
+            messages.NOTES_FIELD_IS_MISSING,
         ),
     )
     @mentorship_relation_ns.response(


### PR DESCRIPTION
### Description

Fix issue - Responses does not list "Notes field is missing." error message.

Fixes #613

### Type of Change:

<!--- **Delete irrelevant options.** --->

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Run the app locally and select Mentorship Relation. Go to 'Mentorship relation- send request' and scroll down to the Responses section.  
The error message is showing in the list under HTTPStatus.BAD_REQUEST
![image](https://user-images.githubusercontent.com/42821217/96078082-3d21a400-0e66-11eb-979f-677a8081d61c.png)


### Checklist:

<!-- **Delete irrelevant options.** -->

- [ ] My PR follows the style guidelines of this project


**Code/Quality Assurance Only**

- [ ] My changes generate no new warnings 
- [ ] New and existing unit tests pass locally with my changes

