### PR TITLE
fix: Password accepting empty spaces fixed

### DIFF
--- a/app/api/resources/user.py
+++ b/app/api/resources/user.py
@@ -185,7 +185,8 @@ class MyUserProfile(Resource):
 
 @users_ns.response(HTTPStatus.CREATED, "%s" % messages.PASSWORD_SUCCESSFULLY_UPDATED)
 @users_ns.response(
-    HTTPStatus.BAD_REQUEST, "%s" % messages.USER_ENTERED_INCORRECT_PASSWORD
+    HTTPStatus.BAD_REQUEST,
+    f"{messages.USER_ENTERED_INCORRECT_PASSWORD}\n{messages.USER_INPUTS_SPACE_IN_PASSWORD}",
 )
 @users_ns.response(
     HTTPStatus.UNAUTHORIZED,
@@ -283,12 +284,7 @@ class UserRegister(Resource):
     )
     @users_ns.response(
         HTTPStatus.BAD_REQUEST,
-        "%s\n%s\n%s"
-        % (
-            messages.USERNAME_FIELD_IS_EMPTY,
-            messages.PASSWORD_INPUT_BY_USER_HAS_INVALID_LENGTH,
-            messages.EMAIL_INPUT_BY_USER_IS_INVALID,
-        ),
+        f"{messages.USERNAME_FIELD_IS_EMPTY}\n{messages.PASSWORD_INPUT_BY_USER_HAS_INVALID_LENGTH}\n{messages.USER_INPUTS_SPACE_IN_PASSWORD}\n{messages.EMAIL_INPUT_BY_USER_IS_INVALID}",
     )
     @users_ns.response(
         HTTPStatus.CONFLICT,

--- a/app/api/validations/user.py
+++ b/app/api/validations/user.py
@@ -52,6 +52,9 @@ def validate_user_registration_request_data(data):
     ):
         return messages.NAME_USERNAME_AND_PASSWORD_NOT_IN_STRING_FORMAT
 
+    if " " in password:
+        return messages.USER_INPUTS_SPACE_IN_PASSWORD
+
     is_valid = validate_length(
         len(get_stripped_string(name)), NAME_MIN_LENGTH, NAME_MAX_LENGTH, "name"
     )

--- a/tests/users/test_validation_request_data.py
+++ b/tests/users/test_validation_request_data.py
@@ -296,6 +296,20 @@ class TestUserApiRequestDataValidation(unittest.TestCase):
 
         self.assertEqual(expected_result, actual_result)
 
+    def test_password_to_one_with_empty_spaces(self):
+        password = "password with spaces"
+        request_body = dict(
+            name=user1["name"],
+            username=user1["username"],
+            password=password,
+            email=user1["email"],
+            terms_and_conditions_checked=user1["terms_and_conditions_checked"],
+        )
+        expected_result = messages.USER_INPUTS_SPACE_IN_PASSWORD
+        actual_result = validate_user_registration_request_data(request_body)
+
+        self.assertEqual(expected_result, actual_result)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description

<!--- Include a summary of the change and relevant motivation/context. List any dependencies that are required for this change. --->
Register endpoint was accepting empty spaces in password while change password did not. This PR fixes the issue and now neither register endpoint nor change password accepts spaces in password.


Fixes #918 

### Type of Change:

<!--- **Delete irrelevant options.** --->

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Provide instructions or GIFs so we can reproduce. List any relevant details for your test. -->

Locally tested by running `python -m unittest discover tests`

### Checklist:

<!-- **Delete irrelevant options.** -->

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**

- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes