### PR TITLE
feat: return user registration_time from get /users

### DIFF
--- a/app/api/models/user.py
+++ b/app/api/models/user.py
@@ -60,6 +60,9 @@ public_user_api_model = Model(
             required=True,
             description="User availability to mentor or to be mentored indication",
         ),
+        "registration_date": fields.Float(
+            required=True, description="User registration date"
+        ),
     },
 )
 

--- a/app/api/resources/user.py
+++ b/app/api/resources/user.py
@@ -64,7 +64,7 @@ class UserList(Resource):
         doesn't take any other input. A JSON array having an object for each user is
         returned. The array contains id, username, name, slack_username, bio,
         location, occupation, organization, interests, skills, need_mentoring,
-        available_to_mentor. The current user's details are not returned.
+        available_to_mentor, registration_date. The current user's details are not returned.
         """
 
         page = request.args.get("page", default=UserDAO.DEFAULT_PAGE, type=int)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 APScheduler==3.6.3
 coverage==5.3
 Flask==1.0.2
-Flask-JWT-Extended==3.24.1
+Flask-JWT-Extended==3.25.0
 Flask-Mail==0.9.1
 Flask-Migrate==2.5.3
 flask-restx==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 APScheduler==3.6.3
 coverage==5.3
 Flask==1.0.2
-Flask-JWT-Extended==3.25.0
+Flask-JWT-Extended==3.24.1
 Flask-Mail==0.9.1
 Flask-Migrate==2.5.3
 flask-restx==0.2.0


### PR DESCRIPTION
### Description

- added registration_date in get /users endpoint response

Fixes #395 

### Type of Change:

- Code


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- ran `python -m unittest discover tests` locally and all tests passed
- tested manually  (both GET /users and GET /users/verified)
Before:
![image](https://user-images.githubusercontent.com/24480679/103303976-b3668900-4a07-11eb-927c-100d32dc081c.png)
After:
![image](https://user-images.githubusercontent.com/24480679/103303797-320ef680-4a07-11eb-99a4-e43b98e15f48.png)

### Checklist:

<!-- **Delete irrelevant options.** -->

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have made corresponding changes to the documentation

**Code/Quality Assurance Only**

- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes
