### PR TITLE
Updating Enum representation of status codes to real value in admin.py

### DIFF
--- a/app/api/resources/admin.py
+++ b/app/api/resources/admin.py
@@ -15,7 +15,10 @@ add_models_to_namespace(admin_ns)
 @admin_ns.route("admin/new")
 @admin_ns.response(HTTPStatus.FORBIDDEN.value, f"{messages.USER_IS_NOW_AN_ADMIN}")
 @admin_ns.response(HTTPStatus.BAD_REQUEST.value, f"{messages.USER_IS_ALREADY_AN_ADMIN}")
-@admin_ns.response(HTTPStatus.UNAUTHORIZED.value,f"{messages.TOKEN_HAS_EXPIRED}\n{messages.TOKEN_IS_INVALID}\n{messages.AUTHORISATION_TOKEN_IS_MISSING}")
+@admin_ns.response(
+    HTTPStatus.UNAUTHORIZED.value,
+    f"{messages.TOKEN_HAS_EXPIRED}\n{messages.TOKEN_IS_INVALID}\n{messages.AUTHORISATION_TOKEN_IS_MISSING}",
+)
 @admin_ns.response(HTTPStatus.FORBIDDEN.value, f"{messages.USER_ASSIGN_NOT_ADMIN}")
 @admin_ns.response(HTTPStatus.NOT_FOUND.value, f"{messages.USER_DOES_NOT_EXIST}")
 class AssignNewUserAdmin(Resource):
@@ -44,13 +47,18 @@ class AssignNewUserAdmin(Resource):
 @admin_ns.route("admin/remove")
 @admin_ns.response(HTTPStatus.OK.value, f"{messages.USER_ADMIN_STATUS_WAS_REVOKED}")
 @admin_ns.response(HTTPStatus.BAD_REQUEST.value, f"{messages.USER_IS_NOT_AN_ADMIN}")
-@admin_ns.response(HTTPStatus.UNAUTHORIZED.value,f"{messages.TOKEN_HAS_EXPIRED}\n{messages.TOKEN_IS_INVALID}\n{messages.AUTHORISATION_TOKEN_IS_MISSING}")
+@admin_ns.response(
+    HTTPStatus.UNAUTHORIZED.value,
+    f"{messages.TOKEN_HAS_EXPIRED}\n{messages.TOKEN_IS_INVALID}\n{messages.AUTHORISATION_TOKEN_IS_MISSING}",
+)
 @admin_ns.response(HTTPStatus.FORBIDDEN.value, f"{messages.USER_REVOKE_NOT_ADMIN}")
 @admin_ns.response(HTTPStatus.NOT_FOUND.value, f"{messages.USER_DOES_NOT_EXIST}")
 class RevokeUserAdmin(Resource):
     @classmethod
     @jwt_required
-    @admin_ns.expect(auth_header_parser, assign_and_revoke_user_admin_request_body, validate=True)
+    @admin_ns.expect(
+        auth_header_parser, assign_and_revoke_user_admin_request_body, validate=True
+    )
     def post(cls):
         """
         Revoke admin status from another User Admin.

--- a/app/api/resources/admin.py
+++ b/app/api/resources/admin.py
@@ -13,14 +13,11 @@ add_models_to_namespace(admin_ns)
 
 
 @admin_ns.route("admin/new")
-@admin_ns.response(HTTPStatus.FORBIDDEN, f"{messages.USER_IS_NOW_AN_ADMIN}")
-@admin_ns.response(HTTPStatus.BAD_REQUEST, f"{messages.USER_IS_ALREADY_AN_ADMIN}")
-@admin_ns.response(
-    HTTPStatus.UNAUTHORIZED,
-    f"{messages.TOKEN_HAS_EXPIRED}\n{messages.TOKEN_IS_INVALID}\n{messages.AUTHORISATION_TOKEN_IS_MISSING}",
-)
-@admin_ns.response(HTTPStatus.FORBIDDEN, f"{messages.USER_ASSIGN_NOT_ADMIN}")
-@admin_ns.response(HTTPStatus.NOT_FOUND, f"{messages.USER_DOES_NOT_EXIST}")
+@admin_ns.response(HTTPStatus.FORBIDDEN.value, f"{messages.USER_IS_NOW_AN_ADMIN}")
+@admin_ns.response(HTTPStatus.BAD_REQUEST.value, f"{messages.USER_IS_ALREADY_AN_ADMIN}")
+@admin_ns.response(HTTPStatus.UNAUTHORIZED.value,f"{messages.TOKEN_HAS_EXPIRED}\n{messages.TOKEN_IS_INVALID}\n{messages.AUTHORISATION_TOKEN_IS_MISSING}")
+@admin_ns.response(HTTPStatus.FORBIDDEN.value, f"{messages.USER_ASSIGN_NOT_ADMIN}")
+@admin_ns.response(HTTPStatus.NOT_FOUND.value, f"{messages.USER_DOES_NOT_EXIST}")
 class AssignNewUserAdmin(Resource):
     @classmethod
     @jwt_required
@@ -45,20 +42,15 @@ class AssignNewUserAdmin(Resource):
 
 
 @admin_ns.route("admin/remove")
-@admin_ns.response(HTTPStatus.OK, f"{messages.USER_ADMIN_STATUS_WAS_REVOKED}")
-@admin_ns.response(HTTPStatus.BAD_REQUEST, f"{messages.USER_IS_NOT_AN_ADMIN}")
-@admin_ns.response(
-    HTTPStatus.UNAUTHORIZED,
-    f"{messages.TOKEN_HAS_EXPIRED}\n{messages.TOKEN_IS_INVALID}\n{messages.AUTHORISATION_TOKEN_IS_MISSING}",
-)
-@admin_ns.response(HTTPStatus.FORBIDDEN, f"{messages.USER_REVOKE_NOT_ADMIN}")
-@admin_ns.response(HTTPStatus.NOT_FOUND, f"{messages.USER_DOES_NOT_EXIST}")
+@admin_ns.response(HTTPStatus.OK.value, f"{messages.USER_ADMIN_STATUS_WAS_REVOKED}")
+@admin_ns.response(HTTPStatus.BAD_REQUEST.value, f"{messages.USER_IS_NOT_AN_ADMIN}")
+@admin_ns.response(HTTPStatus.UNAUTHORIZED.value,f"{messages.TOKEN_HAS_EXPIRED}\n{messages.TOKEN_IS_INVALID}\n{messages.AUTHORISATION_TOKEN_IS_MISSING}")
+@admin_ns.response(HTTPStatus.FORBIDDEN.value, f"{messages.USER_REVOKE_NOT_ADMIN}")
+@admin_ns.response(HTTPStatus.NOT_FOUND.value, f"{messages.USER_DOES_NOT_EXIST}")
 class RevokeUserAdmin(Resource):
     @classmethod
     @jwt_required
-    @admin_ns.expect(
-        auth_header_parser, assign_and_revoke_user_admin_request_body, validate=True
-    )
+    @admin_ns.expect(auth_header_parser, assign_and_revoke_user_admin_request_body, validate=True)
     def post(cls):
         """
         Revoke admin status from another User Admin.
@@ -81,15 +73,15 @@ class ListAdmins(Resource):
     @classmethod
     @jwt_required
     @admin_ns.doc("get_list_of_admins")
-    @admin_ns.response(HTTPStatus.OK, "Success.", public_admin_user_api_model)
+    @admin_ns.response(HTTPStatus.OK.value, "Success.", public_admin_user_api_model)
     @admin_ns.doc(
         responses={
-            HTTPStatus.UNAUTHORIZED: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
+            HTTPStatus.UNAUTHORIZED.value: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
             f"{messages.TOKEN_IS_INVALID['message']}<br>"
             f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}"
         }
     )
-    @admin_ns.response(HTTPStatus.FORBIDDEN, f"{messages.USER_IS_NOT_AN_ADMIN}")
+    @admin_ns.response(HTTPStatus.FORBIDDEN.value, f"{messages.USER_IS_NOT_AN_ADMIN}")
     @admin_ns.expect(auth_header_parser)
     def get(cls):
         """


### PR DESCRIPTION
### Description

<!--- Include a summary of the change and relevant motivation/context. List any dependencies that are required for this change. --->
The values of HTTPStatus codes shown on Swagger UI of Admin API changed to be in number format instead of Enum Representations.

Fixes #956

### Type of Change:

<!--- **Delete irrelevant options.** --->
- Code
-  User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. Provide instructions or GIFs so we can reproduce. List any relevant details for your test. -->
Steps to reproduce the behavior:

1.  Go to `https://mentorship-backend-temp.herokuapp.com/`
2.  Click on Admins API
3.  .See the results

![task3](https://user-images.githubusercontent.com/71868375/103501575-951fe380-4e74-11eb-869e-41391ab8d07e.jpg)

**Desktop (please complete the following information):**

- OS: Windows 10
- Browser: Chrome Web Browser
- Version : 87.0

### Checklist:

<!-- **Delete irrelevant options.** -->

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**

- [ ] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)

