### PR TITLE
Refactor: change response status codes for invalid inputs (409 to 400) in register endpoint

### DIFF
--- a/app/api/resources/user.py
+++ b/app/api/resources/user.py
@@ -285,15 +285,14 @@ class UserRegister(Resource):
     )
     @users_ns.response(
         HTTPStatus.BAD_REQUEST,
-        f"{messages.USERNAME_FIELD_IS_EMPTY}\n{messages.PASSWORD_INPUT_BY_USER_HAS_INVALID_LENGTH}\n{messages.USER_INPUTS_SPACE_IN_PASSWORD}\n{messages.EMAIL_INPUT_BY_USER_IS_INVALID}",
+        f"{messages.USERNAME_HAS_INVALID_LENGTH}\n{messages.PASSWORD_INPUT_BY_USER_HAS_INVALID_LENGTH}\n{messages.USER_INPUTS_SPACE_IN_PASSWORD}\n{messages.EMAIL_INPUT_BY_USER_IS_INVALID}\n{messages.TERMS_AND_CONDITIONS_ARE_NOT_CHECKED}",
     )
     @users_ns.response(
         HTTPStatus.CONFLICT,
-        "%s\n%s\n%s"
+        "%s\n%s"
         % (
             messages.USER_USES_A_USERNAME_THAT_ALREADY_EXISTS,
             messages.USER_USES_AN_EMAIL_ID_THAT_ALREADY_EXISTS,
-            messages.TERMS_AND_CONDITIONS_ARE_NOT_CHECKED,
         ),
     )
     @users_ns.expect(register_user_api_model, validate=True)
@@ -312,7 +311,7 @@ class UserRegister(Resource):
         is_valid = validate_user_registration_request_data(data)
 
         if is_valid != {}:
-            return is_valid, HTTPStatus.CONFLICT
+            return is_valid, HTTPStatus.BAD_REQUEST
 
         result = DAO.create_user(data)
 

--- a/app/messages.py
+++ b/app/messages.py
@@ -17,7 +17,7 @@ FIELD_AVAILABLE_TO_MENTOR_IS_INVALID = {
     "message": "Field available_to_mentor" " is not valid."
 }
 PASSWORD_INPUT_BY_USER_HAS_INVALID_LENGTH = {
-    "message": f"The password field has to be longer than {PASSWORD_MIN_LENGTH} characters and shorter than {PASSWORD_MAX_LENGTH} characters."
+    "message": f"The password field has to be longer than {PASSWORD_MIN_LENGTH - 1} characters and shorter than {PASSWORD_MAX_LENGTH + 1} characters."
 }
 
 # Not found
@@ -54,8 +54,8 @@ NEW_PASSWORD_FIELD_IS_MISSING = {"message": "New password field is missing."}
 AUTHORISATION_TOKEN_IS_MISSING = {"message": "The authorization token is" " missing!"}
 DESCRIPTION_FIELD_IS_MISSING = {"message": "Description field is missing."}
 COMMENT_FIELD_IS_MISSING = {"message": "Comment field is missing."}
-USERNAME_FIELD_IS_EMPTY = {
-    "message": f"The username field has to be longer than {USERNAME_MIN_LENGTH} characters and shorter than {USERNAME_MAX_LENGTH} characters."
+USERNAME_HAS_INVALID_LENGTH = {
+    "message": f"The username field has to be longer than {USERNAME_MIN_LENGTH - 1} characters and shorter than {USERNAME_MAX_LENGTH + 1} characters."
 }
 
 # Admin

--- a/tests/users/test_api_resources.py
+++ b/tests/users/test_api_resources.py
@@ -2,10 +2,18 @@ import unittest
 from unittest.mock import patch
 
 from flask import json
-
 from tests.base_test_case import BaseTestCase
 from app.database.models.user import UserModel
-
+from app.messages import (
+    USER_WAS_CREATED_SUCCESSFULLY,
+    USERNAME_HAS_INVALID_LENGTH,
+    PASSWORD_INPUT_BY_USER_HAS_INVALID_LENGTH,
+    USER_INPUTS_SPACE_IN_PASSWORD,
+    EMAIL_INPUT_BY_USER_IS_INVALID,
+    USER_USES_A_USERNAME_THAT_ALREADY_EXISTS,
+    USER_USES_AN_EMAIL_ID_THAT_ALREADY_EXISTS,
+    TERMS_AND_CONDITIONS_ARE_NOT_CHECKED,
+)
 
 # Testing User API resources
 #
@@ -136,6 +144,204 @@ class TestUserRegistrationApi(BaseTestCase):
             user = UserModel.query.filter_by(email=user1["email"]).first()
             self.assertTrue(user.need_mentoring)
             self.assertFalse(user.available_to_mentor)
+
+    # new tests to verify response status codes
+    # BAD_REQUEST status
+    @patch("flask_mail._MailMixin.send", side_effect=mail_send_mocked)
+    def test_user_registration_with_invalid_length_username(self, send_email_function):
+        with self.client:
+            # invalid username and password length
+            response = self.client.post(
+                "/register",
+                data=json.dumps(
+                    dict(
+                        name=user1["name"],
+                        username="test",
+                        password=user1["email"],
+                        email=user1["email"],
+                        terms_and_conditions_checked=user1[
+                            "terms_and_conditions_checked"
+                        ],
+                    )
+                ),
+                follow_redirects=True,
+                content_type="application/json",
+            )
+
+            user = UserModel.query.filter_by(username="test").first()
+            message = json.loads(response.get_data(as_text=True)).get("message")
+            self.assertIsNone(user)
+            self.assertEqual(message, USERNAME_HAS_INVALID_LENGTH.get("message"))
+            self.assertEqual(response.status_code, 400)
+
+    @patch("flask_mail._MailMixin.send", side_effect=mail_send_mocked)
+    def test_user_registration_with_invalid_length_password(self, send_email_function):
+        with self.client:
+            # invalid username and password length
+            response = self.client.post(
+                "/register",
+                data=json.dumps(
+                    dict(
+                        name=user1["name"],
+                        username=user1["username"],
+                        password="test",
+                        email=user1["email"],
+                        terms_and_conditions_checked=user1[
+                            "terms_and_conditions_checked"
+                        ],
+                    )
+                ),
+                follow_redirects=True,
+                content_type="application/json",
+            )
+
+            user = UserModel.query.filter_by(username=user1["username"]).first()
+            message = json.loads(response.get_data(as_text=True)).get("message")
+            self.assertIsNone(user)
+            self.assertEqual(
+                message, PASSWORD_INPUT_BY_USER_HAS_INVALID_LENGTH.get("message")
+            )
+            self.assertEqual(response.status_code, 400)
+
+    @patch("flask_mail._MailMixin.send", side_effect=mail_send_mocked)
+    def test_user_registration_with_space_in_password(self, send_email_function):
+        with self.client:
+            # invalid username and password length
+            response = self.client.post(
+                "/register",
+                data=json.dumps(
+                    dict(
+                        name=user1["name"],
+                        username=user1["username"],
+                        password="test password",
+                        email=user1["email"],
+                        terms_and_conditions_checked=user1[
+                            "terms_and_conditions_checked"
+                        ],
+                    )
+                ),
+                follow_redirects=True,
+                content_type="application/json",
+            )
+
+            user = UserModel.query.filter_by(username=user1["username"]).first()
+            message = json.loads(response.get_data(as_text=True)).get("message")
+            self.assertIsNone(user)
+            self.assertEqual(message, USER_INPUTS_SPACE_IN_PASSWORD.get("message"))
+            self.assertEqual(response.status_code, 400)
+
+    @patch("flask_mail._MailMixin.send", side_effect=mail_send_mocked)
+    def test_user_registration_with_invalid_email(self, send_email_function):
+        with self.client:
+            # invalid username and password length
+            response = self.client.post(
+                "/register",
+                data=json.dumps(
+                    dict(
+                        name=user1["name"],
+                        username=user1["username"],
+                        password=user1["password"],
+                        email="testemail",
+                        terms_and_conditions_checked=user1[
+                            "terms_and_conditions_checked"
+                        ],
+                    )
+                ),
+                follow_redirects=True,
+                content_type="application/json",
+            )
+            message = json.loads(response.get_data(as_text=True)).get("message")
+            user = UserModel.query.filter_by(email="testemail").first()
+            self.assertIsNone(user)
+            self.assertEqual(message, EMAIL_INPUT_BY_USER_IS_INVALID.get("message"))
+            self.assertEqual(response.status_code, 400)
+
+    @patch("flask_mail._MailMixin.send", side_effect=mail_send_mocked)
+    def test_user_registration_with_unckecked_terms_and_conditions(
+        self, send_email_function
+    ):
+        with self.client:
+            # invalid username and password length
+            response = self.client.post(
+                "/register",
+                data=json.dumps(
+                    dict(
+                        name=user1["name"],
+                        username=user1["username"],
+                        password=user1["password"],
+                        email="testemail",
+                        terms_and_conditions_checked=False,
+                    )
+                ),
+                follow_redirects=True,
+                content_type="application/json",
+            )
+            message = json.loads(response.get_data(as_text=True)).get("message")
+            user = UserModel.query.filter_by(username=user1["username"]).first()
+            self.assertIsNone(user)
+            self.assertEqual(
+                message, TERMS_AND_CONDITIONS_ARE_NOT_CHECKED.get("message")
+            )
+            self.assertEqual(response.status_code, 400)
+
+    # CONFLICT status code
+    @patch("flask_mail._MailMixin.send", side_effect=mail_send_mocked)
+    def test_user_registration_with_taken_username(self, send_email_function):
+        user = UserModel.query.first()
+        username = user.username
+        with self.client:
+            response = self.client.post(
+                "/register",
+                data=json.dumps(
+                    dict(
+                        name=user1["name"],
+                        username=username,
+                        password=user1["password"],
+                        email=user1["email"],
+                        terms_and_conditions_checked=user1[
+                            "terms_and_conditions_checked"
+                        ],
+                    )
+                ),
+                follow_redirects=True,
+                content_type="application/json",
+            )
+            message = json.loads(response.get_data(as_text=True)).get("message")
+            users_count = UserModel.query.filter_by(username=username).count()
+            self.assertEqual(users_count, 1)
+            self.assertEqual(
+                message, USER_USES_A_USERNAME_THAT_ALREADY_EXISTS.get("message")
+            )
+            self.assertEqual(response.status_code, 409)
+
+    @patch("flask_mail._MailMixin.send", side_effect=mail_send_mocked)
+    def test_user_registration_with_taken_email(self, send_email_function):
+        user = UserModel.query.first()
+        email = user.email
+        with self.client:
+            response = self.client.post(
+                "/register",
+                data=json.dumps(
+                    dict(
+                        name=user1["name"],
+                        username=user1["username"],
+                        password=user1["password"],
+                        email=email,
+                        terms_and_conditions_checked=user1[
+                            "terms_and_conditions_checked"
+                        ],
+                    )
+                ),
+                follow_redirects=True,
+                content_type="application/json",
+            )
+            message = json.loads(response.get_data(as_text=True)).get("message")
+            users_count = UserModel.query.filter_by(email=email).count()
+            self.assertEqual(users_count, 1)
+            self.assertEqual(
+                message, USER_USES_AN_EMAIL_ID_THAT_ALREADY_EXISTS.get("message")
+            )
+            self.assertEqual(response.status_code, 409)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description

Change response status code for the scenario when the user provides invalid input in register action (shorter username/password, space in the username....). Status codes for this situation are changed to 400 (`BAD_REQUEST`). 
Fixes #653

### Type of Change:
- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)



### How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Provide instructions or GIFs so we can reproduce. List any relevant details for your test. -->
Tested with:
1. Swagger UI 
![image](https://user-images.githubusercontent.com/16724101/103768980-c854a500-5023-11eb-8ae1-7cf836455690.png)
![image](https://user-images.githubusercontent.com/16724101/103769017-d9051b00-5023-11eb-924c-4711334a9514.png)
<hr>
Executed twice:

![image](https://user-images.githubusercontent.com/16724101/103769486-a9a2de00-5024-11eb-940a-42d62ef2a061.png)
![image](https://user-images.githubusercontent.com/16724101/103769513-b7586380-5024-11eb-8a84-c93743d3c3d8.png)

2. with unit-tests.  Added to [resources test](https://github.com/NenadPantelic/mentorship-backend/blob/653-fix-response-status-codes-in-register/tests/users/test_api_resources.py) - methods `test_user_registration_with_invalid_inputs_bad_request` and `test_user_registration_with_invalid_inputs_conflict_username`

### Checklist:

<!-- **Delete irrelevant options.** -->

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas


**Code/Quality Assurance Only**

- [x] My changes generate no new warnings 
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

