### PR TITLE
test: replaced hardcoded response values with HTTPStatus

### DIFF
--- a/tests/mentorship_relation/test_api_accept_request.py
+++ b/tests/mentorship_relation/test_api_accept_request.py
@@ -2,6 +2,7 @@ import json
 import unittest
 from unittest.mock import patch
 from datetime import datetime, timedelta
+from http import HTTPStatus
 
 from app import messages
 from app.database.models.tasks_list import TasksListModel
@@ -52,7 +53,7 @@ class TestAcceptMentorshipRequestApi(MentorshipRelationBaseTestCase):
                 headers=get_test_request_header(self.second_user.id),
             )
 
-            self.assertEqual(200, response.status_code)
+            self.assertEqual(HTTPStatus.OK, response.status_code)
             self.assertEqual(
                 MentorshipRelationState.ACCEPTED, self.mentorship_relation.state
             )
@@ -89,7 +90,7 @@ class TestAcceptMentorshipRequestApi(MentorshipRelationBaseTestCase):
                 f"/mentorship_relation/{self.mentorship_relation.id}/accept",
                 headers=get_test_request_header(self.second_user.id),
             )
-            self.assertEqual(403, response.status_code)
+            self.assertEqual(HTTPStatus.FORBIDDEN, response.status_code)
             self.assertEqual(
                 MentorshipRelationState.ACCEPTED, mentorship_relation_current.state
             )  # current
@@ -112,7 +113,7 @@ class TestAcceptMentorshipRequestApi(MentorshipRelationBaseTestCase):
                 f"/mentorship_relation/{self.mentorship_relation.id}/accept",
                 headers=get_test_request_header(self.first_user.id),
             )
-            self.assertEqual(403, response.status_code)
+            self.assertEqual(HTTPStatus.FORBIDDEN, response.status_code)
             self.assertEqual(
                 MentorshipRelationState.PENDING, self.mentorship_relation.state
             )
@@ -134,7 +135,7 @@ class TestAcceptMentorshipRequestApi(MentorshipRelationBaseTestCase):
                 f"/mentorship_relation/{self.mentorship_relation.id}/accept",
                 headers=get_test_request_header(self.admin_user.id),
             )
-            self.assertEqual(403, response.status_code)
+            self.assertEqual(HTTPStatus.FORBIDDEN, response.status_code)
             self.assertEqual(
                 MentorshipRelationState.PENDING, self.mentorship_relation.state
             )
@@ -153,7 +154,7 @@ class TestAcceptMentorshipRequestApi(MentorshipRelationBaseTestCase):
             response = self.client.put(
                 f"/mentorship_relation/{self.mentorship_relation.id}/accept"
             )
-            self.assertEqual(401, response.status_code)
+            self.assertEqual(HTTPStatus.UNAUTHORIZED, response.status_code)
             self.assertEqual(
                 MentorshipRelationState.PENDING, self.mentorship_relation.state
             )
@@ -176,7 +177,7 @@ class TestAcceptMentorshipRequestApi(MentorshipRelationBaseTestCase):
                 f"/mentorship_relation/{self.mentorship_relation.id}/accept",
                 headers=auth_header,
             )
-            self.assertEqual(401, response.status_code)
+            self.assertEqual(HTTPStatus.UNAUTHORIZED, response.status_code)
             self.assertEqual(
                 MentorshipRelationState.PENDING, self.mentorship_relation.state
             )

--- a/tests/mentorship_relation/test_api_cancel_relation.py
+++ b/tests/mentorship_relation/test_api_cancel_relation.py
@@ -1,6 +1,7 @@
 import json
 import unittest
 from datetime import datetime, timedelta
+from http import HTTPStatus
 
 from app import messages
 from app.database.models.tasks_list import TasksListModel
@@ -51,7 +52,7 @@ class TestCancelMentorshipRelationApi(MentorshipRelationBaseTestCase):
                 headers=get_test_request_header(self.first_user.id),
             )
 
-            self.assertEqual(200, response.status_code)
+            self.assertEqual(HTTPStatus.OK, response.status_code)
             self.assertEqual(
                 MentorshipRelationState.CANCELLED, self.mentorship_relation.state
             )
@@ -70,7 +71,7 @@ class TestCancelMentorshipRelationApi(MentorshipRelationBaseTestCase):
                 headers=get_test_request_header(self.second_user.id),
             )
 
-            self.assertEqual(200, response.status_code)
+            self.assertEqual(HTTPStatus.OK, response.status_code)
             self.assertEqual(
                 MentorshipRelationState.CANCELLED, self.mentorship_relation.state
             )
@@ -91,7 +92,7 @@ class TestCancelMentorshipRelationApi(MentorshipRelationBaseTestCase):
                 f"/mentorship_relation/{self.mentorship_relation.id}/cancel"
             )
 
-            self.assertEqual(401, response.status_code)
+            self.assertEqual(HTTPStatus.UNAUTHORIZED, response.status_code)
             self.assertDictEqual(expected_response, json.loads(response.data))
 
     # Valid user tries to cancel valid task with authentication token expired (FAIL)
@@ -109,7 +110,7 @@ class TestCancelMentorshipRelationApi(MentorshipRelationBaseTestCase):
                 ),
             )
 
-            self.assertEqual(401, response.status_code)
+            self.assertEqual(HTTPStatus.UNAUTHORIZED, response.status_code)
             self.assertDictEqual(expected_response, json.loads(response.data))
 
     # User1 cancel a mentorship relation which the User1 is not involved with (FAIL)
@@ -125,7 +126,7 @@ class TestCancelMentorshipRelationApi(MentorshipRelationBaseTestCase):
                 headers=get_test_request_header(self.admin_user.id),
             )
 
-            self.assertEqual(400, response.status_code)
+            self.assertEqual(HTTPStatus.BAD_REQUEST, response.status_code)
             self.assertDictEqual(expected_response, json.loads(response.data))
 
 

--- a/tests/mentorship_relation/test_api_delete_request.py
+++ b/tests/mentorship_relation/test_api_delete_request.py
@@ -55,7 +55,6 @@ class TestDeleteMentorshipRequestApi(MentorshipRelationBaseTestCase):
                 f"/mentorship_relation/{request_id}",
                 headers=get_test_request_header(self.first_user.id),
             )
-
         self.assertEqual(HTTPStatus.OK, response.status_code)
         self.assertDictEqual(
             messages.MENTORSHIP_RELATION_WAS_DELETED_SUCCESSFULLY,
@@ -80,7 +79,6 @@ class TestDeleteMentorshipRequestApi(MentorshipRelationBaseTestCase):
                 f"/mentorship_relation/{request_id}",
                 headers=get_test_request_header(self.second_user.id),
             )
-
         self.assertEqual(HTTPStatus.FORBIDDEN, response.status_code)
         self.assertDictEqual(
             messages.CANT_DELETE_UNINVOLVED_REQUEST, json.loads(response.data)

--- a/tests/mentorship_relation/test_api_delete_request.py
+++ b/tests/mentorship_relation/test_api_delete_request.py
@@ -1,6 +1,7 @@
 import json
 import unittest
 from datetime import datetime, timedelta
+from http import HTTPStatus
 
 from app import messages
 from app.database.models.tasks_list import TasksListModel
@@ -55,7 +56,7 @@ class TestDeleteMentorshipRequestApi(MentorshipRelationBaseTestCase):
                 headers=get_test_request_header(self.first_user.id),
             )
 
-        self.assertEqual(200, response.status_code)
+        self.assertEqual(HTTPStatus.OK, response.status_code)
         self.assertDictEqual(
             messages.MENTORSHIP_RELATION_WAS_DELETED_SUCCESSFULLY,
             json.loads(response.data),
@@ -80,7 +81,7 @@ class TestDeleteMentorshipRequestApi(MentorshipRelationBaseTestCase):
                 headers=get_test_request_header(self.second_user.id),
             )
 
-        self.assertEqual(403, response.status_code)
+        self.assertEqual(HTTPStatus.FORBIDDEN, response.status_code)
         self.assertDictEqual(
             messages.CANT_DELETE_UNINVOLVED_REQUEST, json.loads(response.data)
         )

--- a/tests/mentorship_relation/test_api_list_relations.py
+++ b/tests/mentorship_relation/test_api_list_relations.py
@@ -1,6 +1,7 @@
 import json
 import unittest
 from datetime import datetime, timedelta
+from http import HTTPStatus
 
 from flask_restx import marshal
 
@@ -87,7 +88,7 @@ class TestListMentorshipRelationsApi(MentorshipRelationBaseTestCase):
                 marshal(self.past_mentorship_relation, mentorship_request_response_body)
             ]
 
-            self.assertEqual(200, response.status_code)
+            self.assertEqual(HTTPStatus.OK, response.status_code)
             self.assertEqual(expected_response, json.loads(response.data))
 
     def test_list_pending_mentorship_relations(self):
@@ -103,7 +104,7 @@ class TestListMentorshipRelationsApi(MentorshipRelationBaseTestCase):
                 )
             ]
 
-            self.assertEqual(200, response.status_code)
+            self.assertEqual(HTTPStatus.OK, response.status_code)
             self.assertEqual(expected_response, json.loads(response.data))
 
     def test_list_current_mentorship_relation(self):
@@ -117,7 +118,7 @@ class TestListMentorshipRelationsApi(MentorshipRelationBaseTestCase):
                 mentorship_request_response_body,
             )
 
-            self.assertEqual(200, response.status_code)
+            self.assertEqual(HTTPStatus.OK, response.status_code)
             self.assertEqual(expected_response, json.loads(response.data))
 
     def test_list_all_mentorship_relations(self):
@@ -133,7 +134,7 @@ class TestListMentorshipRelationsApi(MentorshipRelationBaseTestCase):
                 )
             ]
 
-            self.assertEqual(200, response.status_code)
+            self.assertEqual(HTTPStatus.OK, response.status_code)
             self.assertEqual(expected_response, json.loads(response.data))
 
     def test_list_current_mentorship_relation_sent_by_current_user(self):
@@ -147,7 +148,7 @@ class TestListMentorshipRelationsApi(MentorshipRelationBaseTestCase):
                 mentorship_request_response_body,
             )
 
-            self.assertEqual(200, response.status_code)
+            self.assertEqual(HTTPStatus.OK, response.status_code)
             self.assertEqual(expected_response, json.loads(response.data))
             self.assertFalse(self.future_accepted_mentorship_relation.sent_by_me)
 
@@ -162,7 +163,7 @@ class TestListMentorshipRelationsApi(MentorshipRelationBaseTestCase):
                 mentorship_request_response_body,
             )
 
-            self.assertEqual(200, response.status_code)
+            self.assertEqual(HTTPStatus.OK, response.status_code)
             self.assertEqual(expected_response, json.loads(response.data))
             self.assertTrue(self.future_accepted_mentorship_relation.sent_by_me)
 
@@ -192,7 +193,7 @@ class TestListMentorshipRelationsApi(MentorshipRelationBaseTestCase):
                 ),
             ]
 
-            self.assertEqual(200, response.status_code)
+            self.assertEqual(HTTPStatus.OK, response.status_code)
             self.assertEqual(expected_response, json.loads(response.data))
 
     # When relation_state = 'accepted'.
@@ -209,7 +210,7 @@ class TestListMentorshipRelationsApi(MentorshipRelationBaseTestCase):
                 )
             ]
 
-            self.assertEqual(200, response.status_code)
+            self.assertEqual(HTTPStatus.OK, response.status_code)
             self.assertEqual(expected_response, json.loads(response.data))
 
     # When relation_state = 'pending'.
@@ -229,7 +230,7 @@ class TestListMentorshipRelationsApi(MentorshipRelationBaseTestCase):
                 ),
             ]
 
-            self.assertEqual(200, response.status_code)
+            self.assertEqual(HTTPStatus.OK, response.status_code)
             self.assertEqual(expected_response, json.loads(response.data))
 
     # When relation_state = 'invalid_param'.
@@ -241,7 +242,7 @@ class TestListMentorshipRelationsApi(MentorshipRelationBaseTestCase):
             )
             expected_response = []
 
-            self.assertEqual(400, response.status_code)
+            self.assertEqual(HTTPStatus.BAD_REQUEST, response.status_code)
             self.assertEqual(expected_response, json.loads(response.data))
 
 

--- a/tests/mentorship_relation/test_api_reject_request.py
+++ b/tests/mentorship_relation/test_api_reject_request.py
@@ -1,6 +1,7 @@
 import json
 import unittest
 from datetime import datetime, timedelta
+from http import HTTPStatus
 
 from app import messages
 from app.database.models.tasks_list import TasksListModel
@@ -49,7 +50,7 @@ class TestRejectMentorshipRequestApi(MentorshipRelationBaseTestCase):
                 headers=get_test_request_header(self.second_user.id),
             )
 
-            self.assertEqual(200, response.status_code)
+            self.assertEqual(HTTPStatus.OK, response.status_code)
             self.assertEqual(
                 MentorshipRelationState.REJECTED, self.mentorship_relation.state
             )

--- a/tests/mentorship_relation/test_api_send_request.py
+++ b/tests/mentorship_relation/test_api_send_request.py
@@ -49,7 +49,7 @@ class TestSendRequestApi(MentorshipRelationBaseTestCase):
             content_type="application/json",
             data=json.dumps(test_payload),
         )
-        self.assertEqual(404, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_fail_send_request_bad_mentor_id(self):
@@ -67,7 +67,7 @@ class TestSendRequestApi(MentorshipRelationBaseTestCase):
             content_type="application/json",
             data=json.dumps(test_payload),
         )
-        self.assertEqual(404, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     # In case if a user tries to send request on behalf of some other user
@@ -86,7 +86,7 @@ class TestSendRequestApi(MentorshipRelationBaseTestCase):
             content_type="application/json",
             data=json.dumps(test_payload),
         )
-        self.assertEqual(400, actual_response.status_code)
+        self.assertEqual(HTTPStatus.BAD_REQUEST, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
 

--- a/tests/mentorship_relation/test_dao_accept_request.py
+++ b/tests/mentorship_relation/test_dao_accept_request.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from http import HTTPStatus
 
 from app import messages
 from app.api.dao.mentorship_relation import MentorshipRelationDAO
@@ -71,7 +72,7 @@ class TestMentorshipRelationAcceptRequestDAO(MentorshipRelationBaseTestCase):
         result = DAO.accept_request(self.first_user.id, 123)
 
         self.assertEqual(
-            (messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, 404), result
+            (messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND), result
         )
         self.assertEqual(
             MentorshipRelationState.PENDING, self.mentorship_relation.state
@@ -82,7 +83,7 @@ class TestMentorshipRelationAcceptRequestDAO(MentorshipRelationBaseTestCase):
 
         result = DAO.accept_request(self.first_user.id, self.mentorship_relation.id)
 
-        self.assertEqual((messages.CANT_ACCEPT_MENTOR_REQ_SENT_BY_USER, 403), result)
+        self.assertEqual((messages.CANT_ACCEPT_MENTOR_REQ_SENT_BY_USER, HTTPStatus.FORBIDDEN), result)
         self.assertEqual(
             MentorshipRelationState.PENDING, self.mentorship_relation.state
         )
@@ -93,7 +94,7 @@ class TestMentorshipRelationAcceptRequestDAO(MentorshipRelationBaseTestCase):
         result = DAO.accept_request(self.second_user.id, self.mentorship_relation.id)
 
         self.assertEqual(
-            (messages.MENTORSHIP_RELATION_WAS_ACCEPTED_SUCCESSFULLY, 200), result
+            (messages.MENTORSHIP_RELATION_WAS_ACCEPTED_SUCCESSFULLY, HTTPStatus.OK), result
         )
         self.assertEqual(
             MentorshipRelationState.ACCEPTED, self.mentorship_relation.state
@@ -104,7 +105,7 @@ class TestMentorshipRelationAcceptRequestDAO(MentorshipRelationBaseTestCase):
 
         result = DAO.accept_request(123, self.mentorship_relation.id)
 
-        self.assertEqual((messages.USER_DOES_NOT_EXIST, 404), result)
+        self.assertEqual((messages.USER_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND), result)
         self.assertEqual(
             MentorshipRelationState.PENDING, self.mentorship_relation.state
         )
@@ -117,28 +118,28 @@ class TestMentorshipRelationAcceptRequestDAO(MentorshipRelationBaseTestCase):
         db.session.commit()
 
         result = DAO.accept_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 403), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result)
 
         self.mentorship_relation.state = MentorshipRelationState.COMPLETED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.accept_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 403), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result)
 
         self.mentorship_relation.state = MentorshipRelationState.CANCELLED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.accept_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 403), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result)
 
         self.mentorship_relation.state = MentorshipRelationState.REJECTED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.accept_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 403), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result)
 
     def test_dao_mentor_user_already_in_relationship(self):
         DAO = MentorshipRelationDAO()
@@ -146,7 +147,7 @@ class TestMentorshipRelationAcceptRequestDAO(MentorshipRelationBaseTestCase):
         result2 = DAO.accept_request(self.first_user.id, self.mentorship_relation2.id)
 
         self.assertEqual(
-            (messages.MENTORSHIP_RELATION_WAS_ACCEPTED_SUCCESSFULLY, 200), result2
+            (messages.MENTORSHIP_RELATION_WAS_ACCEPTED_SUCCESSFULLY, HTTPStatus.OK), result2
         )
         self.assertEqual(
             MentorshipRelationState.ACCEPTED, self.mentorship_relation2.state
@@ -154,7 +155,7 @@ class TestMentorshipRelationAcceptRequestDAO(MentorshipRelationBaseTestCase):
 
         result = DAO.accept_request(self.second_user.id, self.mentorship_relation.id)
 
-        self.assertEqual((messages.MENTOR_ALREADY_IN_A_RELATION, 400), result)
+        self.assertEqual((messages.MENTOR_ALREADY_IN_A_RELATION, HTTPStatus.BAD_REQUEST), result)
         self.assertEqual(
             MentorshipRelationState.PENDING, self.mentorship_relation.state
         )
@@ -165,7 +166,7 @@ class TestMentorshipRelationAcceptRequestDAO(MentorshipRelationBaseTestCase):
         result = DAO.accept_request(self.second_user.id, self.mentorship_relation.id)
 
         self.assertEqual(
-            (messages.MENTORSHIP_RELATION_WAS_ACCEPTED_SUCCESSFULLY, 200), result
+            (messages.MENTORSHIP_RELATION_WAS_ACCEPTED_SUCCESSFULLY, HTTPStatus.OK), result
         )
         self.assertEqual(
             MentorshipRelationState.ACCEPTED, self.mentorship_relation.state
@@ -173,7 +174,7 @@ class TestMentorshipRelationAcceptRequestDAO(MentorshipRelationBaseTestCase):
 
         result3 = DAO.accept_request(self.third_user.id, self.mentorship_relation3.id)
 
-        self.assertEqual((messages.MENTEE_ALREADY_IN_A_RELATION, 400), result3)
+        self.assertEqual((messages.MENTEE_ALREADY_IN_A_RELATION, HTTPStatus.BAD_REQUEST), result3)
         self.assertEqual(
             MentorshipRelationState.PENDING, self.mentorship_relation3.state
         )

--- a/tests/mentorship_relation/test_dao_accept_request.py
+++ b/tests/mentorship_relation/test_dao_accept_request.py
@@ -72,7 +72,8 @@ class TestMentorshipRelationAcceptRequestDAO(MentorshipRelationBaseTestCase):
         result = DAO.accept_request(self.first_user.id, 123)
 
         self.assertEqual(
-            (messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND), result
+            (messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND),
+            result,
         )
         self.assertEqual(
             MentorshipRelationState.PENDING, self.mentorship_relation.state
@@ -83,7 +84,9 @@ class TestMentorshipRelationAcceptRequestDAO(MentorshipRelationBaseTestCase):
 
         result = DAO.accept_request(self.first_user.id, self.mentorship_relation.id)
 
-        self.assertEqual((messages.CANT_ACCEPT_MENTOR_REQ_SENT_BY_USER, HTTPStatus.FORBIDDEN), result)
+        self.assertEqual(
+            (messages.CANT_ACCEPT_MENTOR_REQ_SENT_BY_USER, HTTPStatus.FORBIDDEN), result
+        )
         self.assertEqual(
             MentorshipRelationState.PENDING, self.mentorship_relation.state
         )
@@ -94,7 +97,8 @@ class TestMentorshipRelationAcceptRequestDAO(MentorshipRelationBaseTestCase):
         result = DAO.accept_request(self.second_user.id, self.mentorship_relation.id)
 
         self.assertEqual(
-            (messages.MENTORSHIP_RELATION_WAS_ACCEPTED_SUCCESSFULLY, HTTPStatus.OK), result
+            (messages.MENTORSHIP_RELATION_WAS_ACCEPTED_SUCCESSFULLY, HTTPStatus.OK),
+            result,
         )
         self.assertEqual(
             MentorshipRelationState.ACCEPTED, self.mentorship_relation.state
@@ -118,28 +122,36 @@ class TestMentorshipRelationAcceptRequestDAO(MentorshipRelationBaseTestCase):
         db.session.commit()
 
         result = DAO.accept_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result)
+        self.assertEqual(
+            (messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result
+        )
 
         self.mentorship_relation.state = MentorshipRelationState.COMPLETED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.accept_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result)
+        self.assertEqual(
+            (messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result
+        )
 
         self.mentorship_relation.state = MentorshipRelationState.CANCELLED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.accept_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result)
+        self.assertEqual(
+            (messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result
+        )
 
         self.mentorship_relation.state = MentorshipRelationState.REJECTED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.accept_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result)
+        self.assertEqual(
+            (messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result
+        )
 
     def test_dao_mentor_user_already_in_relationship(self):
         DAO = MentorshipRelationDAO()
@@ -147,7 +159,8 @@ class TestMentorshipRelationAcceptRequestDAO(MentorshipRelationBaseTestCase):
         result2 = DAO.accept_request(self.first_user.id, self.mentorship_relation2.id)
 
         self.assertEqual(
-            (messages.MENTORSHIP_RELATION_WAS_ACCEPTED_SUCCESSFULLY, HTTPStatus.OK), result2
+            (messages.MENTORSHIP_RELATION_WAS_ACCEPTED_SUCCESSFULLY, HTTPStatus.OK),
+            result2,
         )
         self.assertEqual(
             MentorshipRelationState.ACCEPTED, self.mentorship_relation2.state
@@ -155,7 +168,9 @@ class TestMentorshipRelationAcceptRequestDAO(MentorshipRelationBaseTestCase):
 
         result = DAO.accept_request(self.second_user.id, self.mentorship_relation.id)
 
-        self.assertEqual((messages.MENTOR_ALREADY_IN_A_RELATION, HTTPStatus.BAD_REQUEST), result)
+        self.assertEqual(
+            (messages.MENTOR_ALREADY_IN_A_RELATION, HTTPStatus.BAD_REQUEST), result
+        )
         self.assertEqual(
             MentorshipRelationState.PENDING, self.mentorship_relation.state
         )
@@ -166,7 +181,8 @@ class TestMentorshipRelationAcceptRequestDAO(MentorshipRelationBaseTestCase):
         result = DAO.accept_request(self.second_user.id, self.mentorship_relation.id)
 
         self.assertEqual(
-            (messages.MENTORSHIP_RELATION_WAS_ACCEPTED_SUCCESSFULLY, HTTPStatus.OK), result
+            (messages.MENTORSHIP_RELATION_WAS_ACCEPTED_SUCCESSFULLY, HTTPStatus.OK),
+            result,
         )
         self.assertEqual(
             MentorshipRelationState.ACCEPTED, self.mentorship_relation.state
@@ -174,7 +190,9 @@ class TestMentorshipRelationAcceptRequestDAO(MentorshipRelationBaseTestCase):
 
         result3 = DAO.accept_request(self.third_user.id, self.mentorship_relation3.id)
 
-        self.assertEqual((messages.MENTEE_ALREADY_IN_A_RELATION, HTTPStatus.BAD_REQUEST), result3)
+        self.assertEqual(
+            (messages.MENTEE_ALREADY_IN_A_RELATION, HTTPStatus.BAD_REQUEST), result3
+        )
         self.assertEqual(
             MentorshipRelationState.PENDING, self.mentorship_relation3.state
         )

--- a/tests/mentorship_relation/test_dao_cancel_relation.py
+++ b/tests/mentorship_relation/test_dao_cancel_relation.py
@@ -47,7 +47,8 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         result = DAO.cancel_relation(self.first_user.id, 123)
 
         self.assertEqual(
-            (messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND), result
+            (messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND),
+            result,
         )
         self.assertEqual(
             MentorshipRelationState.PENDING, self.mentorship_relation.state
@@ -72,7 +73,8 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         result = DAO.cancel_relation(self.second_user.id, self.mentorship_relation.id)
 
         self.assertEqual(
-            (messages.MENTORSHIP_RELATION_WAS_CANCELLED_SUCCESSFULLY, HTTPStatus.OK), result
+            (messages.MENTORSHIP_RELATION_WAS_CANCELLED_SUCCESSFULLY, HTTPStatus.OK),
+            result,
         )
         self.assertEqual(
             MentorshipRelationState.CANCELLED, self.mentorship_relation.state
@@ -87,7 +89,8 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         result = DAO.cancel_relation(self.first_user.id, self.mentorship_relation.id)
 
         self.assertEqual(
-            (messages.MENTORSHIP_RELATION_WAS_CANCELLED_SUCCESSFULLY, HTTPStatus.OK), result
+            (messages.MENTORSHIP_RELATION_WAS_CANCELLED_SUCCESSFULLY, HTTPStatus.OK),
+            result,
         )
         self.assertEqual(
             MentorshipRelationState.CANCELLED, self.mentorship_relation.state
@@ -101,25 +104,33 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         db.session.commit()
 
         result = DAO.cancel_relation(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.UNACCEPTED_STATE_RELATION, HTTPStatus.BAD_REQUEST), result)
+        self.assertEqual(
+            (messages.UNACCEPTED_STATE_RELATION, HTTPStatus.BAD_REQUEST), result
+        )
 
         self.mentorship_relation.state = MentorshipRelationState.COMPLETED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.cancel_relation(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.UNACCEPTED_STATE_RELATION, HTTPStatus.BAD_REQUEST), result)
+        self.assertEqual(
+            (messages.UNACCEPTED_STATE_RELATION, HTTPStatus.BAD_REQUEST), result
+        )
 
         self.mentorship_relation.state = MentorshipRelationState.CANCELLED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.cancel_relation(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.UNACCEPTED_STATE_RELATION, HTTPStatus.BAD_REQUEST), result)
+        self.assertEqual(
+            (messages.UNACCEPTED_STATE_RELATION, HTTPStatus.BAD_REQUEST), result
+        )
 
         self.mentorship_relation.state = MentorshipRelationState.REJECTED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.cancel_relation(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.UNACCEPTED_STATE_RELATION, HTTPStatus.BAD_REQUEST), result)
+        self.assertEqual(
+            (messages.UNACCEPTED_STATE_RELATION, HTTPStatus.BAD_REQUEST), result
+        )

--- a/tests/mentorship_relation/test_dao_cancel_relation.py
+++ b/tests/mentorship_relation/test_dao_cancel_relation.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from http import HTTPStatus
 
 from app import messages
 from app.api.dao.mentorship_relation import MentorshipRelationDAO
@@ -46,7 +47,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         result = DAO.cancel_relation(self.first_user.id, 123)
 
         self.assertEqual(
-            (messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, 404), result
+            (messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND), result
         )
         self.assertEqual(
             MentorshipRelationState.PENDING, self.mentorship_relation.state
@@ -57,7 +58,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
 
         result = DAO.cancel_relation(123, self.mentorship_relation.id)
 
-        self.assertEqual((messages.USER_DOES_NOT_EXIST, 404), result)
+        self.assertEqual((messages.USER_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND), result)
         self.assertEqual(
             MentorshipRelationState.PENDING, self.mentorship_relation.state
         )
@@ -71,7 +72,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         result = DAO.cancel_relation(self.second_user.id, self.mentorship_relation.id)
 
         self.assertEqual(
-            (messages.MENTORSHIP_RELATION_WAS_CANCELLED_SUCCESSFULLY, 200), result
+            (messages.MENTORSHIP_RELATION_WAS_CANCELLED_SUCCESSFULLY, HTTPStatus.OK), result
         )
         self.assertEqual(
             MentorshipRelationState.CANCELLED, self.mentorship_relation.state
@@ -86,7 +87,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         result = DAO.cancel_relation(self.first_user.id, self.mentorship_relation.id)
 
         self.assertEqual(
-            (messages.MENTORSHIP_RELATION_WAS_CANCELLED_SUCCESSFULLY, 200), result
+            (messages.MENTORSHIP_RELATION_WAS_CANCELLED_SUCCESSFULLY, HTTPStatus.OK), result
         )
         self.assertEqual(
             MentorshipRelationState.CANCELLED, self.mentorship_relation.state
@@ -100,25 +101,25 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         db.session.commit()
 
         result = DAO.cancel_relation(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.UNACCEPTED_STATE_RELATION, 400), result)
+        self.assertEqual((messages.UNACCEPTED_STATE_RELATION, HTTPStatus.BAD_REQUEST), result)
 
         self.mentorship_relation.state = MentorshipRelationState.COMPLETED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.cancel_relation(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.UNACCEPTED_STATE_RELATION, 400), result)
+        self.assertEqual((messages.UNACCEPTED_STATE_RELATION, HTTPStatus.BAD_REQUEST), result)
 
         self.mentorship_relation.state = MentorshipRelationState.CANCELLED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.cancel_relation(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.UNACCEPTED_STATE_RELATION, 400), result)
+        self.assertEqual((messages.UNACCEPTED_STATE_RELATION, HTTPStatus.BAD_REQUEST), result)
 
         self.mentorship_relation.state = MentorshipRelationState.REJECTED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.cancel_relation(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.UNACCEPTED_STATE_RELATION, 400), result)
+        self.assertEqual((messages.UNACCEPTED_STATE_RELATION, HTTPStatus.BAD_REQUEST), result)

--- a/tests/mentorship_relation/test_dao_creation.py
+++ b/tests/mentorship_relation/test_dao_creation.py
@@ -1,5 +1,6 @@
 import unittest
 from datetime import datetime, timedelta
+from http import HTTPStatus
 
 from app import messages
 from app.api.dao.mentorship_relation import MentorshipRelationDAO
@@ -186,7 +187,7 @@ class TestMentorshipRelationCreationDAO(MentorshipRelationBaseTestCase):
 
         result = dao.create_mentorship_relation(self.first_user.id, data)
 
-        self.assertEqual((messages.MENTEE_ALREADY_IN_A_RELATION, 400), result)
+        self.assertEqual((messages.MENTEE_ALREADY_IN_A_RELATION, HTTPStatus.BAD_REQUEST), result)
 
         query_mentorship_relations = MentorshipRelationModel.query.all()
 
@@ -221,7 +222,7 @@ class TestMentorshipRelationCreationDAO(MentorshipRelationBaseTestCase):
 
         result = dao.create_mentorship_relation(self.second_user.id, data)
 
-        self.assertEqual((messages.MENTOR_ALREADY_IN_A_RELATION, 400), result)
+        self.assertEqual((messages.MENTOR_ALREADY_IN_A_RELATION, HTTPStatus.BAD_REQUEST), result)
 
         query_mentorship_relations = MentorshipRelationModel.query.all()
 
@@ -242,7 +243,7 @@ class TestMentorshipRelationCreationDAO(MentorshipRelationBaseTestCase):
         result = dao.create_mentorship_relation(self.first_user.id, data)
 
         self.assertEqual(messages.INVALID_END_DATE, result[0])
-        self.assertEqual(400, result[1])
+        self.assertEqual(HTTPStatus.BAD_REQUEST, result[1])
 
 
 if __name__ == "__main__":

--- a/tests/mentorship_relation/test_dao_creation.py
+++ b/tests/mentorship_relation/test_dao_creation.py
@@ -187,7 +187,9 @@ class TestMentorshipRelationCreationDAO(MentorshipRelationBaseTestCase):
 
         result = dao.create_mentorship_relation(self.first_user.id, data)
 
-        self.assertEqual((messages.MENTEE_ALREADY_IN_A_RELATION, HTTPStatus.BAD_REQUEST), result)
+        self.assertEqual(
+            (messages.MENTEE_ALREADY_IN_A_RELATION, HTTPStatus.BAD_REQUEST), result
+        )
 
         query_mentorship_relations = MentorshipRelationModel.query.all()
 
@@ -222,7 +224,9 @@ class TestMentorshipRelationCreationDAO(MentorshipRelationBaseTestCase):
 
         result = dao.create_mentorship_relation(self.second_user.id, data)
 
-        self.assertEqual((messages.MENTOR_ALREADY_IN_A_RELATION, HTTPStatus.BAD_REQUEST), result)
+        self.assertEqual(
+            (messages.MENTOR_ALREADY_IN_A_RELATION, HTTPStatus.BAD_REQUEST), result
+        )
 
         query_mentorship_relations = MentorshipRelationModel.query.all()
 

--- a/tests/mentorship_relation/test_dao_delete_request.py
+++ b/tests/mentorship_relation/test_dao_delete_request.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from http import HTTPStatus
 
 from app import messages
 from app.api.dao.mentorship_relation import MentorshipRelationDAO
@@ -72,7 +73,7 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
         result = MentorshipRelationDAO.delete_request(self.first_user.id, 123)
 
         self.assertEqual(
-            (messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, 404), result
+            (messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND), result
         )
         self.assertIsNotNone(
             MentorshipRelationModel.query.filter_by(
@@ -84,7 +85,7 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
 
         result = MentorshipRelationDAO.delete_request(123, self.mentorship_relation.id)
 
-        self.assertEqual((messages.USER_DOES_NOT_EXIST, 404), result)
+        self.assertEqual((messages.USER_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND), result)
         self.assertIsNotNone(
             MentorshipRelationModel.query.filter_by(
                 id=self.mentorship_relation.id
@@ -97,7 +98,7 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
             self.second_user.id, self.mentorship_relation.id
         )
 
-        self.assertEqual((messages.CANT_DELETE_UNINVOLVED_REQUEST, 403), result)
+        self.assertEqual((messages.CANT_DELETE_UNINVOLVED_REQUEST, HTTPStatus.FORBIDDEN), result)
         self.assertIsNotNone(
             MentorshipRelationModel.query.filter_by(
                 id=self.mentorship_relation.id
@@ -113,7 +114,7 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
 
         result = MentorshipRelationDAO.delete_request(self.first_user.id, relation_id)
         self.assertEqual(
-            (messages.MENTORSHIP_RELATION_WAS_DELETED_SUCCESSFULLY, 200), result
+            (messages.MENTORSHIP_RELATION_WAS_DELETED_SUCCESSFULLY, HTTPStatus.OK), result
         )
 
         self.assertIsNone(
@@ -126,7 +127,7 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
             self.admin_user.id, self.mentorship_relation.id
         )
 
-        self.assertEqual((messages.CANT_DELETE_UNINVOLVED_REQUEST, 403), result)
+        self.assertEqual((messages.CANT_DELETE_UNINVOLVED_REQUEST, HTTPStatus.FORBIDDEN), result)
         self.assertIsNotNone(
             MentorshipRelationModel.query.filter_by(
                 id=self.mentorship_relation.id
@@ -143,7 +144,7 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
         result = MentorshipRelationDAO.delete_request(
             self.first_user.id, self.mentorship_relation.id
         )
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 403), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result)
         self.assertIsNotNone(
             MentorshipRelationModel.query.filter_by(id=relation_id).first()
         )
@@ -155,7 +156,7 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
         result = MentorshipRelationDAO.delete_request(
             self.first_user.id, self.mentorship_relation.id
         )
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 403), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result)
         self.assertIsNotNone(
             MentorshipRelationModel.query.filter_by(id=relation_id).first()
         )
@@ -167,7 +168,7 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
         result = MentorshipRelationDAO.delete_request(
             self.first_user.id, self.mentorship_relation.id
         )
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 403), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result)
         self.assertIsNotNone(
             MentorshipRelationModel.query.filter_by(id=relation_id).first()
         )
@@ -179,7 +180,7 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
         result = MentorshipRelationDAO.delete_request(
             self.first_user.id, self.mentorship_relation.id
         )
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 403), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result)
         self.assertIsNotNone(
             MentorshipRelationModel.query.filter_by(id=relation_id).first()
         )

--- a/tests/mentorship_relation/test_dao_delete_request.py
+++ b/tests/mentorship_relation/test_dao_delete_request.py
@@ -73,7 +73,8 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
         result = MentorshipRelationDAO.delete_request(self.first_user.id, 123)
 
         self.assertEqual(
-            (messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND), result
+            (messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND),
+            result,
         )
         self.assertIsNotNone(
             MentorshipRelationModel.query.filter_by(
@@ -98,7 +99,9 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
             self.second_user.id, self.mentorship_relation.id
         )
 
-        self.assertEqual((messages.CANT_DELETE_UNINVOLVED_REQUEST, HTTPStatus.FORBIDDEN), result)
+        self.assertEqual(
+            (messages.CANT_DELETE_UNINVOLVED_REQUEST, HTTPStatus.FORBIDDEN), result
+        )
         self.assertIsNotNone(
             MentorshipRelationModel.query.filter_by(
                 id=self.mentorship_relation.id
@@ -114,7 +117,8 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
 
         result = MentorshipRelationDAO.delete_request(self.first_user.id, relation_id)
         self.assertEqual(
-            (messages.MENTORSHIP_RELATION_WAS_DELETED_SUCCESSFULLY, HTTPStatus.OK), result
+            (messages.MENTORSHIP_RELATION_WAS_DELETED_SUCCESSFULLY, HTTPStatus.OK),
+            result,
         )
 
         self.assertIsNone(
@@ -127,7 +131,9 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
             self.admin_user.id, self.mentorship_relation.id
         )
 
-        self.assertEqual((messages.CANT_DELETE_UNINVOLVED_REQUEST, HTTPStatus.FORBIDDEN), result)
+        self.assertEqual(
+            (messages.CANT_DELETE_UNINVOLVED_REQUEST, HTTPStatus.FORBIDDEN), result
+        )
         self.assertIsNotNone(
             MentorshipRelationModel.query.filter_by(
                 id=self.mentorship_relation.id
@@ -144,7 +150,9 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
         result = MentorshipRelationDAO.delete_request(
             self.first_user.id, self.mentorship_relation.id
         )
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result)
+        self.assertEqual(
+            (messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result
+        )
         self.assertIsNotNone(
             MentorshipRelationModel.query.filter_by(id=relation_id).first()
         )
@@ -156,7 +164,9 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
         result = MentorshipRelationDAO.delete_request(
             self.first_user.id, self.mentorship_relation.id
         )
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result)
+        self.assertEqual(
+            (messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result
+        )
         self.assertIsNotNone(
             MentorshipRelationModel.query.filter_by(id=relation_id).first()
         )
@@ -168,7 +178,9 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
         result = MentorshipRelationDAO.delete_request(
             self.first_user.id, self.mentorship_relation.id
         )
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result)
+        self.assertEqual(
+            (messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result
+        )
         self.assertIsNotNone(
             MentorshipRelationModel.query.filter_by(id=relation_id).first()
         )
@@ -180,7 +192,9 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
         result = MentorshipRelationDAO.delete_request(
             self.first_user.id, self.mentorship_relation.id
         )
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result)
+        self.assertEqual(
+            (messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result
+        )
         self.assertIsNotNone(
             MentorshipRelationModel.query.filter_by(id=relation_id).first()
         )

--- a/tests/mentorship_relation/test_dao_list_relations.py
+++ b/tests/mentorship_relation/test_dao_list_relations.py
@@ -1,5 +1,6 @@
 import unittest
 from datetime import datetime, timedelta
+from http import HTTPStatus
 
 from app import messages
 from app.api.dao.mentorship_relation import MentorshipRelationDAO
@@ -85,7 +86,7 @@ class TestListMentorshipRelationsDAO(MentorshipRelationBaseTestCase):
         result = MentorshipRelationDAO.list_current_mentorship_relation(
             user_id=self.admin_user.id
         )
-        expected_response = (messages.NOT_IN_MENTORED_RELATION_CURRENTLY, 200)
+        expected_response = (messages.NOT_IN_MENTORED_RELATION_CURRENTLY, HTTPStatus.OK)
 
         self.assertEqual(expected_response, result)
 
@@ -97,7 +98,7 @@ class TestListMentorshipRelationsDAO(MentorshipRelationBaseTestCase):
         expected_response = [self.future_pending_mentorship_relation]
 
         self.assertEqual(expected_response, result[0])
-        self.assertEqual(200, result[1])
+        self.assertEqual(HTTPStatus.OK, result[1])
 
 
 if __name__ == "__main__":

--- a/tests/mentorship_relation/test_dao_listing.py
+++ b/tests/mentorship_relation/test_dao_listing.py
@@ -1,5 +1,6 @@
 import unittest
 from datetime import datetime, timedelta
+from http import HTTPStatus
 
 from app.api.dao.mentorship_relation import MentorshipRelationDAO
 from app.database.models.mentorship_relation import MentorshipRelationModel
@@ -48,7 +49,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         result = DAO.list_mentorship_relations(
             user_id=self.first_user.id, state=self.mentorship_relation.state.name
         )
-        expected_response = [self.mentorship_relation], 200
+        expected_response = [self.mentorship_relation], HTTPStatus.OK
 
         self.assertEqual(expected_response, result)
 
@@ -62,7 +63,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         result = DAO.list_mentorship_relations(
             user_id=self.first_user.id, state=self.mentorship_relation.state.name
         )
-        expected_response = [self.mentorship_relation], 200
+        expected_response = [self.mentorship_relation], HTTPStatus.OK
 
         self.assertEqual(expected_response, result)
 
@@ -76,7 +77,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         result = DAO.list_mentorship_relations(
             user_id=self.first_user.id, state=self.mentorship_relation.state.name
         )
-        expected_response = [self.mentorship_relation], 200
+        expected_response = [self.mentorship_relation], HTTPStatus.OK
 
         self.assertEqual(expected_response, result)
 
@@ -90,7 +91,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         result = DAO.list_mentorship_relations(
             user_id=self.first_user.id, state=self.mentorship_relation.state.name
         )
-        expected_response = [self.mentorship_relation], 200
+        expected_response = [self.mentorship_relation], HTTPStatus.OK
 
         self.assertEqual(expected_response, result)
 
@@ -104,7 +105,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         result = DAO.list_mentorship_relations(
             user_id=self.first_user.id, state=self.mentorship_relation.state.name
         )
-        expected_response = [self.mentorship_relation], 200
+        expected_response = [self.mentorship_relation], HTTPStatus.OK
 
         self.assertEqual(expected_response, result)
 
@@ -112,7 +113,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         DAO = MentorshipRelationDAO()
 
         result = DAO.list_mentorship_relations(user_id=self.first_user.id, state=None)
-        expected_response = [self.mentorship_relation], 200
+        expected_response = [self.mentorship_relation], HTTPStatus.OK
 
         self.assertEqual(expected_response, result)
 
@@ -122,7 +123,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         result = DAO.list_mentorship_relations(
             user_id=self.first_user.id, state="anything"
         )
-        expected_response = [], 400
+        expected_response = [], HTTPStatus.BAD_REQUEST
 
         self.assertEqual(expected_response, result)
 
@@ -134,7 +135,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         db.session.commit()
 
         result = DAO.list_mentorship_relations(user_id=self.first_user.id)
-        expected_response = [self.mentorship_relation], 200
+        expected_response = [self.mentorship_relation], HTTPStatus.OK
 
         self.assertEqual(expected_response, result)
         self.assertIsNotNone(result)

--- a/tests/mentorship_relation/test_dao_reject_mentorship_request.py
+++ b/tests/mentorship_relation/test_dao_reject_mentorship_request.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from http import HTTPStatus
 
 from app import messages
 from app.api.dao.mentorship_relation import MentorshipRelationDAO
@@ -46,7 +47,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         result = DAO.reject_request(self.first_user.id, 123)
 
         self.assertEqual(
-            (messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, 404), result
+            (messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND), result
         )
         self.assertEqual(
             MentorshipRelationState.PENDING, self.mentorship_relation.state
@@ -57,7 +58,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
 
         result = DAO.reject_request(123, self.mentorship_relation.id)
 
-        self.assertEqual((messages.USER_DOES_NOT_EXIST, 404), result)
+        self.assertEqual((messages.USER_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND), result)
         self.assertEqual(
             MentorshipRelationState.PENDING, self.mentorship_relation.state
         )
@@ -67,7 +68,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
 
         result = DAO.reject_request(self.first_user.id, self.mentorship_relation.id)
 
-        self.assertEqual((messages.USER_CANT_REJECT_REQUEST_SENT_BY_USER, 403), result)
+        self.assertEqual((messages.USER_CANT_REJECT_REQUEST_SENT_BY_USER, HTTPStatus.FORBIDDEN), result)
         self.assertEqual(
             MentorshipRelationState.PENDING, self.mentorship_relation.state
         )
@@ -78,7 +79,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         result = DAO.reject_request(self.second_user.id, self.mentorship_relation.id)
 
         self.assertEqual(
-            (messages.MENTORSHIP_RELATION_WAS_REJECTED_SUCCESSFULLY, 200), result
+            (messages.MENTORSHIP_RELATION_WAS_REJECTED_SUCCESSFULLY, HTTPStatus.OK), result
         )
         self.assertEqual(
             MentorshipRelationState.REJECTED, self.mentorship_relation.state
@@ -92,25 +93,25 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         db.session.commit()
 
         result = DAO.reject_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 403), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result)
 
         self.mentorship_relation.state = MentorshipRelationState.COMPLETED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.reject_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 403), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result)
 
         self.mentorship_relation.state = MentorshipRelationState.CANCELLED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.reject_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 403), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result)
 
         self.mentorship_relation.state = MentorshipRelationState.REJECTED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.reject_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, 403), result)
+        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result)

--- a/tests/mentorship_relation/test_dao_reject_mentorship_request.py
+++ b/tests/mentorship_relation/test_dao_reject_mentorship_request.py
@@ -47,7 +47,8 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         result = DAO.reject_request(self.first_user.id, 123)
 
         self.assertEqual(
-            (messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND), result
+            (messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND),
+            result,
         )
         self.assertEqual(
             MentorshipRelationState.PENDING, self.mentorship_relation.state
@@ -68,7 +69,10 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
 
         result = DAO.reject_request(self.first_user.id, self.mentorship_relation.id)
 
-        self.assertEqual((messages.USER_CANT_REJECT_REQUEST_SENT_BY_USER, HTTPStatus.FORBIDDEN), result)
+        self.assertEqual(
+            (messages.USER_CANT_REJECT_REQUEST_SENT_BY_USER, HTTPStatus.FORBIDDEN),
+            result,
+        )
         self.assertEqual(
             MentorshipRelationState.PENDING, self.mentorship_relation.state
         )
@@ -79,7 +83,8 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         result = DAO.reject_request(self.second_user.id, self.mentorship_relation.id)
 
         self.assertEqual(
-            (messages.MENTORSHIP_RELATION_WAS_REJECTED_SUCCESSFULLY, HTTPStatus.OK), result
+            (messages.MENTORSHIP_RELATION_WAS_REJECTED_SUCCESSFULLY, HTTPStatus.OK),
+            result,
         )
         self.assertEqual(
             MentorshipRelationState.REJECTED, self.mentorship_relation.state
@@ -93,25 +98,33 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
         db.session.commit()
 
         result = DAO.reject_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result)
+        self.assertEqual(
+            (messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result
+        )
 
         self.mentorship_relation.state = MentorshipRelationState.COMPLETED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.reject_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result)
+        self.assertEqual(
+            (messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result
+        )
 
         self.mentorship_relation.state = MentorshipRelationState.CANCELLED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.reject_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result)
+        self.assertEqual(
+            (messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result
+        )
 
         self.mentorship_relation.state = MentorshipRelationState.REJECTED
         db.session.add(self.mentorship_relation)
         db.session.commit()
 
         result = DAO.reject_request(self.second_user.id, self.mentorship_relation.id)
-        self.assertEqual((messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result)
+        self.assertEqual(
+            (messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN), result
+        )


### PR DESCRIPTION
### Description

Replaced harcoded response codes inside `tests/mentorship_relation` with their corresponding HTTPStatus enum values.

Fixes #967 

### Type of Change:

<!--- **Delete irrelevant options.** --->

- Code
- Quality Assurance


### How Has This Been Tested?

![tests](https://user-images.githubusercontent.com/17108695/104576810-adff7480-567e-11eb-861d-922e123017c4.PNG)



### Checklist:

<!-- **Delete irrelevant options.** -->

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**

- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes

