### PR TITLE
test : Replaced Hardcoded Response Values with HTTPStatus in tests/admin

### DIFF
--- a/tests/admin/test_api_list_admin_users.py
+++ b/tests/admin/test_api_list_admin_users.py
@@ -71,7 +71,7 @@ class TestListAdminUsersApi(BaseTestCase):
         expected_response = messages.AUTHORISATION_TOKEN_IS_MISSING
         actual_response = self.client.get("/admins")
 
-        self.assertEqual(HTTPStatus.UNAUTHORIZED.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     """
@@ -88,7 +88,7 @@ class TestListAdminUsersApi(BaseTestCase):
             "/admins", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     """
@@ -103,7 +103,7 @@ class TestListAdminUsersApi(BaseTestCase):
         )
 
         # import pdb; pdb.set_trace()
-        self.assertEqual(HTTPStatus.FORBIDDEN.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.FORBIDDEN, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
 

--- a/tests/admin/test_api_list_admin_users.py
+++ b/tests/admin/test_api_list_admin_users.py
@@ -14,6 +14,7 @@ from app.utils.enum_utils import MentorshipRelationState
 from tests.base_test_case import BaseTestCase
 from tests.test_utils import get_test_request_header
 from tests.test_data import user1, test_admin_user, test_admin_user_2, test_admin_user_3
+from http import HTTPStatus
 
 
 class TestListAdminUsersApi(BaseTestCase):
@@ -70,7 +71,7 @@ class TestListAdminUsersApi(BaseTestCase):
         expected_response = messages.AUTHORISATION_TOKEN_IS_MISSING
         actual_response = self.client.get("/admins")
 
-        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     """
@@ -87,7 +88,7 @@ class TestListAdminUsersApi(BaseTestCase):
             "/admins", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     """
@@ -102,7 +103,7 @@ class TestListAdminUsersApi(BaseTestCase):
         )
 
         # import pdb; pdb.set_trace()
-        self.assertEqual(403, actual_response.status_code)
+        self.assertEqual(HTTPStatus.FORBIDDEN, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
 

--- a/tests/admin/test_api_list_admin_users.py
+++ b/tests/admin/test_api_list_admin_users.py
@@ -71,7 +71,7 @@ class TestListAdminUsersApi(BaseTestCase):
         expected_response = messages.AUTHORISATION_TOKEN_IS_MISSING
         actual_response = self.client.get("/admins")
 
-        self.assertEqual(HTTPStatus.UNAUTHORIZED, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     """
@@ -88,7 +88,7 @@ class TestListAdminUsersApi(BaseTestCase):
             "/admins", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     """
@@ -103,7 +103,7 @@ class TestListAdminUsersApi(BaseTestCase):
         )
 
         # import pdb; pdb.set_trace()
-        self.assertEqual(HTTPStatus.FORBIDDEN, actual_response.status_code)
+        self.assertEqual(HTTPStatus.FORBIDDEN.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
 

--- a/tests/admin/test_api_remove_admin_user.py
+++ b/tests/admin/test_api_remove_admin_user.py
@@ -62,7 +62,7 @@ class TestRemoveAdminUsersApi(BaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_remove_self_admin_status_when_only_admin_api_resource_auth_admin(self):
@@ -76,7 +76,7 @@ class TestRemoveAdminUsersApi(BaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
         # remove the admin that is always added for tests (id = 1)
@@ -89,7 +89,7 @@ class TestRemoveAdminUsersApi(BaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
         # remove self
@@ -102,7 +102,7 @@ class TestRemoveAdminUsersApi(BaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(HTTPStatus.FORBIDDEN.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.FORBIDDEN, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_remove_admin_status_api_resource_auth_admin(self):
@@ -115,7 +115,7 @@ class TestRemoveAdminUsersApi(BaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
 

--- a/tests/admin/test_api_remove_admin_user.py
+++ b/tests/admin/test_api_remove_admin_user.py
@@ -62,7 +62,7 @@ class TestRemoveAdminUsersApi(BaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_remove_self_admin_status_when_only_admin_api_resource_auth_admin(self):
@@ -76,7 +76,7 @@ class TestRemoveAdminUsersApi(BaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
         # remove the admin that is always added for tests (id = 1)
@@ -89,7 +89,7 @@ class TestRemoveAdminUsersApi(BaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
         # remove self
@@ -102,7 +102,7 @@ class TestRemoveAdminUsersApi(BaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(HTTPStatus.FORBIDDEN, actual_response.status_code)
+        self.assertEqual(HTTPStatus.FORBIDDEN.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_remove_admin_status_api_resource_auth_admin(self):
@@ -115,7 +115,7 @@ class TestRemoveAdminUsersApi(BaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
 

--- a/tests/admin/test_api_remove_admin_user.py
+++ b/tests/admin/test_api_remove_admin_user.py
@@ -14,6 +14,7 @@ from app.utils.enum_utils import MentorshipRelationState
 from tests.base_test_case import BaseTestCase
 from tests.test_utils import get_test_request_header
 from tests.test_data import test_admin_user_2, test_admin_user_3
+from http import HTTPStatus
 
 
 class TestRemoveAdminUsersApi(BaseTestCase):
@@ -61,7 +62,7 @@ class TestRemoveAdminUsersApi(BaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_remove_self_admin_status_when_only_admin_api_resource_auth_admin(self):
@@ -75,7 +76,7 @@ class TestRemoveAdminUsersApi(BaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
         # remove the admin that is always added for tests (id = 1)
@@ -88,7 +89,7 @@ class TestRemoveAdminUsersApi(BaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
         # remove self
@@ -101,7 +102,7 @@ class TestRemoveAdminUsersApi(BaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(403, actual_response.status_code)
+        self.assertEqual(HTTPStatus.FORBIDDEN, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_remove_admin_status_api_resource_auth_admin(self):
@@ -114,7 +115,7 @@ class TestRemoveAdminUsersApi(BaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
 

--- a/tests/admin/test_dao.py
+++ b/tests/admin/test_dao.py
@@ -114,7 +114,8 @@ class TestAdminDao(BaseTestCase):
         dao_result = dao.assign_new_user(1, data)
 
         self.assertEqual(
-            (messages.USER_IS_ALREADY_AN_ADMIN, HTTPStatus.BAD_REQUEST.value), dao_result
+            (messages.USER_IS_ALREADY_AN_ADMIN, HTTPStatus.BAD_REQUEST.value),
+            dao_result,
         )
 
     """
@@ -143,7 +144,10 @@ class TestAdminDao(BaseTestCase):
         dao_result = dao.assign_new_user(2, data)
 
         self.assertEqual(
-            (messages.USER_CANNOT_BE_ASSIGNED_ADMIN_BY_USER, HTTPStatus.FORBIDDEN.value),
+            (
+                messages.USER_CANNOT_BE_ASSIGNED_ADMIN_BY_USER,
+                HTTPStatus.FORBIDDEN.value,
+            ),
             dao_result,
         )
 
@@ -258,7 +262,8 @@ class TestAdminDao(BaseTestCase):
         dao_result = dao.revoke_admin_user(1, data)
 
         self.assertEqual(
-            (messages.USER_CANNOT_REVOKE_ADMIN_STATUS, HTTPStatus.FORBIDDEN.value), dao_result
+            (messages.USER_CANNOT_REVOKE_ADMIN_STATUS, HTTPStatus.FORBIDDEN.value),
+            dao_result,
         )
 
 

--- a/tests/admin/test_dao.py
+++ b/tests/admin/test_dao.py
@@ -66,7 +66,7 @@ class TestAdminDao(BaseTestCase):
         dao_result = dao.assign_new_user(2, data)
 
         self.assertEqual(
-            (messages.USER_ASSIGN_NOT_ADMIN, HTTPStatus.FORBIDDEN.value), dao_result
+            (messages.USER_ASSIGN_NOT_ADMIN, HTTPStatus.FORBIDDEN), dao_result
         )
 
     """
@@ -82,7 +82,7 @@ class TestAdminDao(BaseTestCase):
         dao_result = dao.assign_new_user(1, data)
 
         self.assertEqual(
-            (messages.USER_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND.value), dao_result
+            (messages.USER_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND), dao_result
         )
 
     """
@@ -114,7 +114,7 @@ class TestAdminDao(BaseTestCase):
         dao_result = dao.assign_new_user(1, data)
 
         self.assertEqual(
-            (messages.USER_IS_ALREADY_AN_ADMIN, HTTPStatus.BAD_REQUEST.value),
+            (messages.USER_IS_ALREADY_AN_ADMIN, HTTPStatus.BAD_REQUEST),
             dao_result,
         )
 
@@ -146,7 +146,7 @@ class TestAdminDao(BaseTestCase):
         self.assertEqual(
             (
                 messages.USER_CANNOT_BE_ASSIGNED_ADMIN_BY_USER,
-                HTTPStatus.FORBIDDEN.value,
+                HTTPStatus.FORBIDDEN,
             ),
             dao_result,
         )
@@ -204,7 +204,7 @@ class TestAdminDao(BaseTestCase):
         dao_result = dao.revoke_admin_user(2, data)
 
         self.assertEqual(
-            (messages.USER_REVOKE_NOT_ADMIN, HTTPStatus.FORBIDDEN.value), dao_result
+            (messages.USER_REVOKE_NOT_ADMIN, HTTPStatus.FORBIDDEN), dao_result
         )
 
     """
@@ -220,7 +220,7 @@ class TestAdminDao(BaseTestCase):
         dao_result = dao.revoke_admin_user(1, data)
 
         self.assertEqual(
-            (messages.USER_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND.value), dao_result
+            (messages.USER_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND), dao_result
         )
 
     """
@@ -247,7 +247,7 @@ class TestAdminDao(BaseTestCase):
         dao_result = dao.revoke_admin_user(1, data)
 
         self.assertEqual(
-            (messages.USER_IS_NOT_AN_ADMIN, HTTPStatus.BAD_REQUEST.value), dao_result
+            (messages.USER_IS_NOT_AN_ADMIN, HTTPStatus.BAD_REQUEST), dao_result
         )
 
     """
@@ -262,7 +262,7 @@ class TestAdminDao(BaseTestCase):
         dao_result = dao.revoke_admin_user(1, data)
 
         self.assertEqual(
-            (messages.USER_CANNOT_REVOKE_ADMIN_STATUS, HTTPStatus.FORBIDDEN.value),
+            (messages.USER_CANNOT_REVOKE_ADMIN_STATUS, HTTPStatus.FORBIDDEN),
             dao_result,
         )
 

--- a/tests/admin/test_dao.py
+++ b/tests/admin/test_dao.py
@@ -66,7 +66,7 @@ class TestAdminDao(BaseTestCase):
         dao_result = dao.assign_new_user(2, data)
 
         self.assertEqual(
-            (messages.USER_ASSIGN_NOT_ADMIN, HTTPStatus.FORBIDDEN), dao_result
+            (messages.USER_ASSIGN_NOT_ADMIN, HTTPStatus.FORBIDDEN.value), dao_result
         )
 
     """
@@ -82,7 +82,7 @@ class TestAdminDao(BaseTestCase):
         dao_result = dao.assign_new_user(1, data)
 
         self.assertEqual(
-            (messages.USER_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND), dao_result
+            (messages.USER_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND.value), dao_result
         )
 
     """
@@ -114,7 +114,7 @@ class TestAdminDao(BaseTestCase):
         dao_result = dao.assign_new_user(1, data)
 
         self.assertEqual(
-            (messages.USER_IS_ALREADY_AN_ADMIN, HTTPStatus.BAD_REQUEST), dao_result
+            (messages.USER_IS_ALREADY_AN_ADMIN, HTTPStatus.BAD_REQUEST.value), dao_result
         )
 
     """
@@ -143,7 +143,7 @@ class TestAdminDao(BaseTestCase):
         dao_result = dao.assign_new_user(2, data)
 
         self.assertEqual(
-            (messages.USER_CANNOT_BE_ASSIGNED_ADMIN_BY_USER, HTTPStatus.FORBIDDEN),
+            (messages.USER_CANNOT_BE_ASSIGNED_ADMIN_BY_USER, HTTPStatus.FORBIDDEN.value),
             dao_result,
         )
 
@@ -200,7 +200,7 @@ class TestAdminDao(BaseTestCase):
         dao_result = dao.revoke_admin_user(2, data)
 
         self.assertEqual(
-            (messages.USER_REVOKE_NOT_ADMIN, HTTPStatus.FORBIDDEN), dao_result
+            (messages.USER_REVOKE_NOT_ADMIN, HTTPStatus.FORBIDDEN.value), dao_result
         )
 
     """
@@ -216,7 +216,7 @@ class TestAdminDao(BaseTestCase):
         dao_result = dao.revoke_admin_user(1, data)
 
         self.assertEqual(
-            (messages.USER_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND), dao_result
+            (messages.USER_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND.value), dao_result
         )
 
     """
@@ -243,7 +243,7 @@ class TestAdminDao(BaseTestCase):
         dao_result = dao.revoke_admin_user(1, data)
 
         self.assertEqual(
-            (messages.USER_IS_NOT_AN_ADMIN, HTTPStatus.BAD_REQUEST), dao_result
+            (messages.USER_IS_NOT_AN_ADMIN, HTTPStatus.BAD_REQUEST.value), dao_result
         )
 
     """
@@ -258,7 +258,7 @@ class TestAdminDao(BaseTestCase):
         dao_result = dao.revoke_admin_user(1, data)
 
         self.assertEqual(
-            (messages.USER_CANNOT_REVOKE_ADMIN_STATUS, HTTPStatus.FORBIDDEN), dao_result
+            (messages.USER_CANNOT_REVOKE_ADMIN_STATUS, HTTPStatus.FORBIDDEN.value), dao_result
         )
 
 

--- a/tests/admin/test_dao.py
+++ b/tests/admin/test_dao.py
@@ -7,6 +7,7 @@ from app import messages
 from app.database.models.user import UserModel
 from app.api.dao.admin import AdminDAO
 from app.database.sqlalchemy_extension import db
+from http import HTTPStatus
 
 
 class TestAdminDao(BaseTestCase):
@@ -64,7 +65,9 @@ class TestAdminDao(BaseTestCase):
         data = dict(user_id=1)
         dao_result = dao.assign_new_user(2, data)
 
-        self.assertEqual((messages.USER_ASSIGN_NOT_ADMIN, 403), dao_result)
+        self.assertEqual(
+            (messages.USER_ASSIGN_NOT_ADMIN, HTTPStatus.FORBIDDEN), dao_result
+        )
 
     """
     Checks whether a user tries to assign admin rights to a non existing user.
@@ -78,7 +81,9 @@ class TestAdminDao(BaseTestCase):
 
         dao_result = dao.assign_new_user(1, data)
 
-        self.assertEqual((messages.USER_DOES_NOT_EXIST, 404), dao_result)
+        self.assertEqual(
+            (messages.USER_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND), dao_result
+        )
 
     """
     Checks whether a user tries to assign admin rights to existing admin user.
@@ -108,7 +113,9 @@ class TestAdminDao(BaseTestCase):
 
         dao_result = dao.assign_new_user(1, data)
 
-        self.assertEqual((messages.USER_IS_ALREADY_AN_ADMIN, 400), dao_result)
+        self.assertEqual(
+            (messages.USER_IS_ALREADY_AN_ADMIN, HTTPStatus.BAD_REQUEST), dao_result
+        )
 
     """
     Checks if a user tries to self-assign admin role.  
@@ -136,7 +143,8 @@ class TestAdminDao(BaseTestCase):
         dao_result = dao.assign_new_user(2, data)
 
         self.assertEqual(
-            (messages.USER_CANNOT_BE_ASSIGNED_ADMIN_BY_USER, 403), dao_result
+            (messages.USER_CANNOT_BE_ASSIGNED_ADMIN_BY_USER, HTTPStatus.FORBIDDEN),
+            dao_result,
         )
 
     """
@@ -191,7 +199,9 @@ class TestAdminDao(BaseTestCase):
         data = dict(user_id=1)
         dao_result = dao.revoke_admin_user(2, data)
 
-        self.assertEqual((messages.USER_REVOKE_NOT_ADMIN, 403), dao_result)
+        self.assertEqual(
+            (messages.USER_REVOKE_NOT_ADMIN, HTTPStatus.FORBIDDEN), dao_result
+        )
 
     """
     Checks whether a user tries to revoke admin rights from a non existing user.
@@ -205,7 +215,9 @@ class TestAdminDao(BaseTestCase):
 
         dao_result = dao.revoke_admin_user(1, data)
 
-        self.assertEqual((messages.USER_DOES_NOT_EXIST, 404), dao_result)
+        self.assertEqual(
+            (messages.USER_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND), dao_result
+        )
 
     """
     Checks whether a user tries to revoke admin rights of a non admin user.
@@ -230,7 +242,9 @@ class TestAdminDao(BaseTestCase):
 
         dao_result = dao.revoke_admin_user(1, data)
 
-        self.assertEqual((messages.USER_IS_NOT_AN_ADMIN, 400), dao_result)
+        self.assertEqual(
+            (messages.USER_IS_NOT_AN_ADMIN, HTTPStatus.BAD_REQUEST), dao_result
+        )
 
     """
     Checks whether a user tries to revoke their own admin status.
@@ -243,7 +257,9 @@ class TestAdminDao(BaseTestCase):
 
         dao_result = dao.revoke_admin_user(1, data)
 
-        self.assertEqual((messages.USER_CANNOT_REVOKE_ADMIN_STATUS, 403), dao_result)
+        self.assertEqual(
+            (messages.USER_CANNOT_REVOKE_ADMIN_STATUS, HTTPStatus.FORBIDDEN), dao_result
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description
Replaced Hardcoded Response Values in tests/admin with their corresponding HTTPStatus enum values.

Fixes #966 

### Type of Change:

<!--- **Delete irrelevant options.** --->

- Code
- Quality Assurance

### How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Provide instructions or GIFs so we can reproduce. List any relevant details for your test. -->
This has been tested locally by using existing tests and attached the screenshot of the same.

![Screenshot from 2021-01-15 18-30-42](https://user-images.githubusercontent.com/44670961/104731015-13c42d00-5761-11eb-9fb5-469b85a4fc92.png)


### Checklist:

<!-- **Delete irrelevant options.** -->

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**

- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes

