### PR TITLE
test: replace hardcoded response values with HTTPStatus

### DIFF
--- a/tests/tasks/test_api_complete_task.py
+++ b/tests/tasks/test_api_complete_task.py
@@ -1,5 +1,6 @@
 import unittest
 from flask import json
+from http import HTTPStatus
 
 from app import messages
 from app.database.models.mentorship_relation import MentorshipRelationModel
@@ -16,7 +17,7 @@ class TestCompleteTaskApi(TasksBaseTestCase):
             follow_redirects=True,
         )
 
-        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_complete_task_api(self):
@@ -38,7 +39,7 @@ class TestCompleteTaskApi(TasksBaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
         relation = MentorshipRelationModel.find_by_id(

--- a/tests/tasks/test_api_create_task.py
+++ b/tests/tasks/test_api_create_task.py
@@ -1,5 +1,6 @@
 import unittest
 from flask import json
+from http import HTTPStatus
 
 from app import messages
 from tests.tasks.tasks_base_setup import TasksBaseTestCase
@@ -9,7 +10,7 @@ from datetime import timedelta
 
 class TestCreateTaskApi(TasksBaseTestCase):
     # User not involved in mentorship relation tries to create a task (FAIL)
-    # gives 404, MENTORSHIP_RELATION_DOES_NOT_EXIST response
+    # gives 404 (HTTP Status NOT_FOUND), MENTORSHIP_RELATION_DOES_NOT_EXIST response
     def test_create_task_api_not_in_relation(self):
         auth_header = get_test_request_header(self.first_user.id)
         expected_response = messages.MENTORSHIP_RELATION_DOES_NOT_EXIST
@@ -20,11 +21,11 @@ class TestCreateTaskApi(TasksBaseTestCase):
             content_type="application/json",
             data=json.dumps(dict(description=self.test_description)),
         )
-        self.assertEqual(404, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     # Valid user tries to create task without description in the body (FAIL)
-    # gives 400, DESCRIPTION_FIELD_IS_MISSING response
+    # gives 400 (HTTP Status BAD_REQUEST), DESCRIPTION_FIELD_IS_MISSING response
     def test_create_task_api_no_description(self):
         auth_header = get_test_request_header(self.first_user.id)
         expected_response = messages.DESCRIPTION_FIELD_IS_MISSING
@@ -35,11 +36,11 @@ class TestCreateTaskApi(TasksBaseTestCase):
             content_type="application/json",
             data=json.dumps(dict()),
         )
-        self.assertEqual(400, actual_response.status_code)
+        self.assertEqual(HTTPStatus.BAD_REQUEST, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     # Valid user tries to create a task with authentication token expired (FAIL)
-    # gives 401, TOKEN_HAS_EXPIRED response
+    # gives 401 (HTTP Status Unauthorized), TOKEN_HAS_EXPIRED response
     def test_create_task_api_token_expired(self):
         # generate expired token
         auth_header = get_test_request_header(
@@ -53,7 +54,7 @@ class TestCreateTaskApi(TasksBaseTestCase):
             content_type="application/json",
             data=json.dumps(dict(description=self.test_description)),
         )
-        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_create_task_api_resource_non_auth(self):
@@ -63,7 +64,7 @@ class TestCreateTaskApi(TasksBaseTestCase):
             follow_redirects=True,
         )
 
-        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_full_task_creation_api(self):
@@ -81,7 +82,7 @@ class TestCreateTaskApi(TasksBaseTestCase):
             data=json.dumps(dict(description=self.test_description)),
         )
 
-        self.assertEqual(201, actual_response.status_code)
+        self.assertEqual(HTTPStatus.CREATED, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
         new_task = self.tasks_list_1.find_task_by_id(3)

--- a/tests/tasks/test_api_delete_task.py
+++ b/tests/tasks/test_api_delete_task.py
@@ -1,5 +1,6 @@
 import unittest
 from flask import json
+from http import HTTPStatus
 
 from app import messages
 from tests.tasks.tasks_base_setup import TasksBaseTestCase
@@ -15,7 +16,7 @@ class TestDeleteTaskApi(TasksBaseTestCase):
             follow_redirects=True,
         )
 
-        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_delete_task_api_w_user_not_belonging_to_mentorship_relation_1(self):
@@ -28,7 +29,7 @@ class TestDeleteTaskApi(TasksBaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_delete_task_api_w_user_not_belonging_to_mentorship_relation_2(self):
@@ -41,7 +42,7 @@ class TestDeleteTaskApi(TasksBaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_full_task_deletion_api(self):
@@ -58,7 +59,7 @@ class TestDeleteTaskApi(TasksBaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
         deleted_task = self.tasks_list_1.find_task_by_id(2)
@@ -74,7 +75,7 @@ class TestDeleteTaskApi(TasksBaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(404, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
 

--- a/tests/tasks/test_api_list_tasks.py
+++ b/tests/tasks/test_api_list_tasks.py
@@ -1,6 +1,7 @@
 import unittest
 from flask import json
 from flask_restx import marshal
+from http import HTTPStatus
 
 from app import messages
 from app.api.models.mentorship_relation import list_tasks_response_body
@@ -17,7 +18,7 @@ class TestListTasksApi(TasksBaseTestCase):
             follow_redirects=True,
         )
 
-        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_tasks_api_first_mentorship_relation(self):
@@ -31,7 +32,7 @@ class TestListTasksApi(TasksBaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_tasks_api_second_mentorship_relation(self):
@@ -44,7 +45,7 @@ class TestListTasksApi(TasksBaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_tasks_api_w_user_not_belonging_to_mentorship_relation(self):
@@ -57,7 +58,7 @@ class TestListTasksApi(TasksBaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_tasks_api_mentorship_relation_without_tasks(self):
@@ -71,7 +72,7 @@ class TestListTasksApi(TasksBaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
 

--- a/tests/tasks/test_dao_complete_task.py
+++ b/tests/tasks/test_dao_complete_task.py
@@ -1,4 +1,5 @@
 import unittest
+from http import HTTPStatus
 
 from app import messages
 from app.api.dao.task import TaskDAO
@@ -9,7 +10,7 @@ class TestCompleteTasksDao(TasksBaseTestCase):
     def test_achieve_not_achieved_task(self):
         self.assertFalse(self.tasks_list_1.find_task_by_id(1).get("is_done"))
 
-        expected_response = messages.TASK_WAS_ACHIEVED_SUCCESSFULLY, 200
+        expected_response = messages.TASK_WAS_ACHIEVED_SUCCESSFULLY, HTTPStatus.OK
         actual_response = TaskDAO.complete_task(
             self.first_user.id, self.mentorship_relation_w_second_user.id, 1
         )
@@ -20,7 +21,10 @@ class TestCompleteTasksDao(TasksBaseTestCase):
     def test_achieve_achieved_task(self):
         self.assertTrue(self.tasks_list_1.find_task_by_id(2).get("is_done"))
 
-        expected_response = messages.TASK_WAS_ALREADY_ACHIEVED, 403
+        expected_response = (
+            messages.TASK_WAS_ALREADY_ACHIEVED,
+            HTTPStatus.FORBIDDEN,
+        )
         actual_response = TaskDAO.complete_task(
             self.first_user.id, self.mentorship_relation_w_second_user.id, 2
         )
@@ -30,7 +34,7 @@ class TestCompleteTasksDao(TasksBaseTestCase):
 
     def test_achieve_not_existent_task(self):
 
-        expected_response = messages.TASK_DOES_NOT_EXIST, 404
+        expected_response = messages.TASK_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND
         actual_response = TaskDAO.complete_task(
             self.first_user.id, self.mentorship_relation_w_second_user.id, 123123
         )

--- a/tests/tasks/test_dao_create_task.py
+++ b/tests/tasks/test_dao_create_task.py
@@ -1,4 +1,5 @@
 import unittest
+from http import HTTPStatus
 
 from app import messages
 from app.api.dao.task import TaskDAO
@@ -9,7 +10,10 @@ from tests.tasks.tasks_base_setup import TasksBaseTestCase
 class TestListTasksDao(TasksBaseTestCase):
     def test_create_task(self):
 
-        expected_response = messages.TASK_WAS_CREATED_SUCCESSFULLY, 201
+        expected_response = (
+            messages.TASK_WAS_CREATED_SUCCESSFULLY,
+            HTTPStatus.CREATED,
+        )
 
         non_existent_task = self.tasks_list_1.find_task_by_id(3)
         self.assertIsNone(non_existent_task)
@@ -28,7 +32,10 @@ class TestListTasksDao(TasksBaseTestCase):
 
     def test_create_task_with_non_existing_mentorship_relation(self):
 
-        expected_response = messages.MENTORSHIP_RELATION_DOES_NOT_EXIST, 404
+        expected_response = (
+            messages.MENTORSHIP_RELATION_DOES_NOT_EXIST,
+            HTTPStatus.NOT_FOUND,
+        )
 
         actual_response = TaskDAO.create_task(
             user_id=self.first_user.id,
@@ -40,7 +47,10 @@ class TestListTasksDao(TasksBaseTestCase):
 
     def test_create_task_with_mentorship_relation_non_accepted_state(self):
 
-        expected_response = messages.UNACCEPTED_STATE_RELATION, 403
+        expected_response = (
+            messages.UNACCEPTED_STATE_RELATION,
+            HTTPStatus.FORBIDDEN,
+        )
         self.mentorship_relation_w_second_user.state = MentorshipRelationState.CANCELLED
 
         actual_response = TaskDAO.create_task(
@@ -53,7 +63,10 @@ class TestListTasksDao(TasksBaseTestCase):
 
     def test_create_task_with_user_not_involved_in_mentorship(self):
 
-        expected_response = messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION, 403
+        expected_response = (
+            messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION,
+            HTTPStatus.FORBIDDEN,
+        )
         self.mentorship_relation_w_second_user.state = MentorshipRelationState.ACCEPTED
 
         actual_response = TaskDAO.create_task(

--- a/tests/tasks/test_dao_delete_task.py
+++ b/tests/tasks/test_dao_delete_task.py
@@ -1,4 +1,5 @@
 import unittest
+from http import HTTPStatus
 
 from app import messages
 from app.api.dao.task import TaskDAO
@@ -8,7 +9,7 @@ from tests.tasks.tasks_base_setup import TasksBaseTestCase
 class TestDeleteTasksDao(TasksBaseTestCase):
     def test_delete_existent_task(self):
 
-        expected_response = messages.TASK_WAS_DELETED_SUCCESSFULLY, 200
+        expected_response = messages.TASK_WAS_DELETED_SUCCESSFULLY, HTTPStatus.OK
         first_task_id = 1
 
         not_deleted_yet_task = self.tasks_list_1.find_task_by_id(task_id=first_task_id)
@@ -24,7 +25,7 @@ class TestDeleteTasksDao(TasksBaseTestCase):
 
     def test_delete_non_existent_task(self):
 
-        expected_response = messages.TASK_DOES_NOT_EXIST, 404
+        expected_response = messages.TASK_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND
         actual_response = TaskDAO.delete_task(
             self.first_user.id, self.mentorship_relation_w_second_user.id, 123123
         )

--- a/tests/tasks/test_dao_list_tasks.py
+++ b/tests/tasks/test_dao_list_tasks.py
@@ -1,4 +1,5 @@
 import unittest
+from http import HTTPStatus
 
 from app import messages
 from app.api.dao.task import TaskDAO
@@ -26,14 +27,17 @@ class TestListTasksDao(TasksBaseTestCase):
 
     def test_list_tasks_with_non_existent_relation(self):
 
-        expected_response = messages.MENTORSHIP_RELATION_DOES_NOT_EXIST, 404
+        expected_response = (
+            messages.MENTORSHIP_RELATION_DOES_NOT_EXIST,
+            HTTPStatus.NOT_FOUND,
+        )
         actual_response = TaskDAO.list_tasks(self.first_user.id, 123123)
 
         self.assertEqual(expected_response, actual_response)
 
     def test_list_tasks_with_non_existent_user(self):
 
-        expected_response = messages.USER_DOES_NOT_EXIST, 404
+        expected_response = messages.USER_DOES_NOT_EXIST, HTTPStatus.NOT_FOUND
         actual_response = TaskDAO.list_tasks(
             123123, self.mentorship_relation_w_second_user.id
         )
@@ -42,7 +46,10 @@ class TestListTasksDao(TasksBaseTestCase):
 
     def test_list_tasks_with_user_not_involved(self):
 
-        expected_response = messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION, 401
+        expected_response = (
+            messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION,
+            HTTPStatus.UNAUTHORIZED,
+        )
         actual_response = TaskDAO.list_tasks(
             self.admin_user.id, self.mentorship_relation_w_second_user.id
         )

--- a/tests/user_journey/test_happy_path_1.py
+++ b/tests/user_journey/test_happy_path_1.py
@@ -1,5 +1,6 @@
 import unittest
 from datetime import datetime, timedelta
+from http import HTTPStatus
 
 from flask import json
 from flask_restx import marshal
@@ -83,7 +84,7 @@ class TestHappyPath1(BaseTestCase):
             data=json.dumps(request_body),
         )
 
-        self.assertEqual(201, send_request_response.status_code)
+        self.assertEqual(HTTPStatus.CREATED, send_request_response.status_code)
 
         request_sent_response = self.client.get(
             "/mentorship_relations",
@@ -106,7 +107,7 @@ class TestHappyPath1(BaseTestCase):
             f"/mentorship_relation/{request_id}/accept", headers=mentor_auth_header
         )
 
-        self.assertEqual(200, accept_response.status_code)
+        self.assertEqual(HTTPStatus.OK, accept_response.status_code)
 
         mentee_current_relation = self.client.get(
             f"/mentorship_relations/current", headers=mentee_auth_header
@@ -115,8 +116,8 @@ class TestHappyPath1(BaseTestCase):
             f"/mentorship_relations/current", headers=mentor_auth_header
         )
 
-        self.assertEqual(200, mentee_current_relation.status_code)
-        self.assertEqual(200, mentor_current_relation.status_code)
+        self.assertEqual(HTTPStatus.OK, mentee_current_relation.status_code)
+        self.assertEqual(HTTPStatus.OK, mentor_current_relation.status_code)
         self.assertFalse(json.loads(mentor_current_relation.data)["sent_by_me"])
         self.assertTrue(json.loads(mentee_current_relation.data)["sent_by_me"])
         self.assertEqual(
@@ -150,13 +151,13 @@ class TestHappyPath1(BaseTestCase):
             data=task_request_body,
         )
 
-        self.assertEqual(201, task_creation_response.status_code)
+        self.assertEqual(HTTPStatus.CREATED, task_creation_response.status_code)
 
         tasks_response = self.client.get(
             f"/mentorship_relation/{request_id}/tasks", headers=mentor_auth_header
         )
 
-        self.assertEqual(200, tasks_response.status_code)
+        self.assertEqual(HTTPStatus.OK, tasks_response.status_code)
 
         tasks = json.loads(tasks_response.data)
         new_task = tasks[0]
@@ -178,13 +179,13 @@ class TestHappyPath1(BaseTestCase):
             headers=mentee_auth_header,
         )
 
-        self.assertEqual(200, complete_task_response.status_code)
+        self.assertEqual(HTTPStatus.OK, complete_task_response.status_code)
 
         tasks_response = self.client.get(
             f"/mentorship_relation/{request_id}/tasks", headers=mentor_auth_header
         )
 
-        self.assertEqual(200, tasks_response.status_code)
+        self.assertEqual(HTTPStatus.OK, tasks_response.status_code)
 
         tasks = json.loads(tasks_response.data)
         updated_task = tasks[0]


### PR DESCRIPTION
### Description

<!--- Include a summary of the change and relevant motivation/context. List any dependencies that are required for this change. --->
This patch replaces the hardcoded response codes in tests/tasks and tests/user_journey with their corresponding HTTPStatus codes. This will help in better readability and scalability.

Fixes #969

### Type of Change:

<!--- **Delete irrelevant options.** --->
- Documentation

### How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Provide instructions or GIFs so we can reproduce. List any relevant details for your test. -->
Ran unittests on local machine and they returned OK status.

### Checklist:

<!-- **Delete irrelevant options.** -->

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged
