### PR TITLE
test : Refactor hard-coded status codes to HTTPstatus in tests

### DIFF
--- a/tests/task_comments/test_api_create_task_comment.py
+++ b/tests/task_comments/test_api_create_task_comment.py
@@ -7,6 +7,7 @@ from app.api.validations.task_comment import COMMENT_MAX_LENGTH
 from app.utils.validation_utils import get_length_validation_error_message
 from tests.tasks.tasks_base_setup import TasksBaseTestCase
 from tests.test_utils import get_test_request_header
+from http import HTTPStatus
 
 
 class TestCreateTaskCommentApi(TasksBaseTestCase):
@@ -26,7 +27,7 @@ class TestCreateTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(example="example")),
         )
 
-        self.assertEqual(400, actual_response.status_code)
+        self.assertEqual(HTTPStatus.BAD_REQUEST.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_creation_api_with_comment_not_string(self):
@@ -40,7 +41,7 @@ class TestCreateTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(comment=5)),
         )
 
-        self.assertEqual(400, actual_response.status_code)
+        self.assertEqual(HTTPStatus.BAD_REQUEST.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_creation_api_with_comment_too_long(self):
@@ -58,7 +59,7 @@ class TestCreateTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(comment="a" * 500)),
         )
 
-        self.assertEqual(400, actual_response.status_code)
+        self.assertEqual(HTTPStatus.BAD_REQUEST.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_creation_api_with_relation_not_existing(self):
@@ -72,7 +73,7 @@ class TestCreateTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(comment="comment")),
         )
 
-        self.assertEqual(404, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_creation_api_with_task_not_existing(self):
@@ -86,7 +87,7 @@ class TestCreateTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(comment="comment")),
         )
 
-        self.assertEqual(404, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_full_task_comment_creation_api(self):
@@ -103,7 +104,7 @@ class TestCreateTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(comment="comment")),
         )
 
-        self.assertEqual(201, actual_response.status_code)
+        self.assertEqual(HTTPStatus.CREATED.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
         new_comment = TaskCommentDAO.get_task_comment(1, 1)[0]

--- a/tests/task_comments/test_api_delete_task_comment.py
+++ b/tests/task_comments/test_api_delete_task_comment.py
@@ -6,6 +6,7 @@ from app.api.dao.task_comment import TaskCommentDAO
 from app.database.sqlalchemy_extension import db
 from tests.tasks.tasks_base_setup import TasksBaseTestCase
 from tests.test_utils import get_test_request_header
+from http import HTTPStatus
 
 
 class TestDeleteTaskCommentApi(TasksBaseTestCase):
@@ -34,7 +35,7 @@ class TestDeleteTaskCommentApi(TasksBaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_deletion_api_user_not_involved(self):
@@ -48,7 +49,7 @@ class TestDeleteTaskCommentApi(TasksBaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_deletion_api_not_created_by_user(self):
@@ -62,7 +63,7 @@ class TestDeleteTaskCommentApi(TasksBaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(403, actual_response.status_code)
+        self.assertEqual(HTTPStatus.FORBIDDEN.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_deletion_api_with_relation_not_existing(self):
@@ -75,7 +76,7 @@ class TestDeleteTaskCommentApi(TasksBaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(404, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_deletion_api_with_task_not_existing(self):
@@ -89,7 +90,7 @@ class TestDeleteTaskCommentApi(TasksBaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(404, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_deletion_api_with_comment_not_existing(self):
@@ -102,7 +103,7 @@ class TestDeleteTaskCommentApi(TasksBaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(404, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_modification_api_with_wrong_task_id(self):
@@ -116,7 +117,7 @@ class TestDeleteTaskCommentApi(TasksBaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(404, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_deletion_api(self):
@@ -130,12 +131,12 @@ class TestDeleteTaskCommentApi(TasksBaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
         modified_comment = TaskCommentDAO.get_task_comment(1, 1)
         self.assertEqual(modified_comment[0], messages.TASK_COMMENT_DOES_NOT_EXIST)
-        self.assertEqual(modified_comment[1], 404)
+        self.assertEqual(modified_comment[1], HTTPStatus.NOT_FOUND.value)
 
     if __name__ == "__main__":
         unittest.main()

--- a/tests/task_comments/test_api_get_task_comments.py
+++ b/tests/task_comments/test_api_get_task_comments.py
@@ -8,6 +8,7 @@ from app.api.dao.task_comment import TaskCommentDAO
 from app.api.models.mentorship_relation import task_comments_model
 from tests.tasks.tasks_base_setup import TasksBaseTestCase
 from tests.test_utils import get_test_request_header
+from http import HTTPStatus
 
 
 class TestGetTaskCommentsApi(TasksBaseTestCase):
@@ -34,7 +35,7 @@ class TestGetTaskCommentsApi(TasksBaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_listing_api_with_task_not_existing(self):
@@ -47,7 +48,7 @@ class TestGetTaskCommentsApi(TasksBaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(404, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_listing_api_with_relation_not_existing(self):
@@ -60,7 +61,7 @@ class TestGetTaskCommentsApi(TasksBaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(404, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_listing_api(self):
@@ -75,7 +76,7 @@ class TestGetTaskCommentsApi(TasksBaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(json.loads(actual_response.data), expected_response)
 
     if __name__ == "__main__":

--- a/tests/task_comments/test_api_modify_task_comment.py
+++ b/tests/task_comments/test_api_modify_task_comment.py
@@ -8,6 +8,7 @@ from app.database.sqlalchemy_extension import db
 from app.utils.validation_utils import get_length_validation_error_message
 from tests.tasks.tasks_base_setup import TasksBaseTestCase
 from tests.test_utils import get_test_request_header
+from http import HTTPStatus
 
 
 class TestModifyTaskCommentApi(TasksBaseTestCase):
@@ -39,7 +40,7 @@ class TestModifyTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(example="example")),
         )
 
-        self.assertEqual(400, actual_response.status_code)
+        self.assertEqual(HTTPStatus.BAD_REQUEST.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_modification_api_with_comment_too_long(self):
@@ -58,7 +59,7 @@ class TestModifyTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(comment="a" * 500)),
         )
 
-        self.assertEqual(400, actual_response.status_code)
+        self.assertEqual(HTTPStatus.BAD_REQUEST.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_modification_api_with_comment_not_string(self):
@@ -73,7 +74,7 @@ class TestModifyTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(comment=5)),
         )
 
-        self.assertEqual(400, actual_response.status_code)
+        self.assertEqual(HTTPStatus.BAD_REQUEST.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_modification_api_not_created_by_user(self):
@@ -88,7 +89,7 @@ class TestModifyTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(comment="comment")),
         )
 
-        self.assertEqual(403, actual_response.status_code)
+        self.assertEqual(HTTPStatus.FORBIDDEN.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_modification_api_with_relation_not_existing(self):
@@ -102,7 +103,7 @@ class TestModifyTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(comment="comment")),
         )
 
-        self.assertEqual(404, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_modification_api_with_task_not_existing(self):
@@ -117,7 +118,7 @@ class TestModifyTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(comment="comment")),
         )
 
-        self.assertEqual(404, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_modification_api_with_comment_not_existing(self):
@@ -131,7 +132,7 @@ class TestModifyTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(comment="comment")),
         )
 
-        self.assertEqual(404, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_modification_api_with_wrong_task_id(self):
@@ -146,7 +147,7 @@ class TestModifyTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(comment="comment")),
         )
 
-        self.assertEqual(404, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_full_task_comment_modification_api(self):
@@ -161,7 +162,7 @@ class TestModifyTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(comment="Modified comment.")),
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
         modified_comment = TaskCommentDAO.get_task_comment(1, 1)[0]

--- a/tests/task_comments/test_dao.py
+++ b/tests/task_comments/test_dao.py
@@ -3,6 +3,7 @@ import unittest
 from app import messages
 from app.api.dao.task_comment import TaskCommentDAO
 from tests.tasks.tasks_base_setup import TasksBaseTestCase
+from http import HTTPStatus
 
 
 class TestTaskCommentDao(TasksBaseTestCase):
@@ -66,7 +67,10 @@ class TestTaskCommentDao(TasksBaseTestCase):
 
         TaskCommentDAO.delete_comment(user_id=1, _id=1, task_id=1, relation_id=2)
 
-        expected_response = messages.TASK_COMMENT_DOES_NOT_EXIST, 404
+        expected_response = (
+            messages.TASK_COMMENT_DOES_NOT_EXIST,
+            HTTPStatus.NOT_FOUND.value,
+        )
         actual_response = TaskCommentDAO.get_task_comment(1, 1)
 
         # Verify that task comment was deleted


### PR DESCRIPTION
### Description

<!--- Include a summary of the change and relevant motivation/context. List any dependencies that are required for this change. --->
Refactored `tests/task_comments/` and changed hard-coded status codes to respective HTTPstatus.

Fixes #968 

### Type of Change: test

<!--- **Delete irrelevant options.** --->

### How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Provide instructions or GIFs so we can reproduce. List any relevant details for your test. -->
![Screenshot from 2021-01-21 19-37-32](https://user-images.githubusercontent.com/66686803/105363423-035cf800-5c22-11eb-9c6c-dc50bc35fe63.png)


### Checklist:

<!-- **Delete irrelevant options.** -->

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**

- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes
