### PR TITLE
Fix: Use Real number values of statuscode instead of enum expressions in Swagger

### DIFF
--- a/app/api/resources/mentorship_relation.py
+++ b/app/api/resources/mentorship_relation.py
@@ -35,10 +35,11 @@ class SendRequest(Resource):
     @mentorship_relation_ns.doc("send_request")
     @mentorship_relation_ns.expect(auth_header_parser, send_mentorship_request_body)
     @mentorship_relation_ns.response(
-        HTTPStatus.CREATED, "%s" % messages.MENTORSHIP_RELATION_WAS_SENT_SUCCESSFULLY
+        HTTPStatus.CREATED.value,
+        "%s" % messages.MENTORSHIP_RELATION_WAS_SENT_SUCCESSFULLY,
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.BAD_REQUEST,
+        HTTPStatus.BAD_REQUEST.value,
         "%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s"
         % (
             messages.MATCH_EITHER_MENTOR_OR_MENTEE,
@@ -56,7 +57,7 @@ class SendRequest(Resource):
         ),
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.UNAUTHORIZED,
+        HTTPStatus.UNAUTHORIZED.value,
         "%s\n%s\n%s"
         % (
             messages.TOKEN_HAS_EXPIRED,
@@ -65,7 +66,7 @@ class SendRequest(Resource):
         ),
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.NOT_FOUND,
+        HTTPStatus.NOT_FOUND.value,
         "%s\n%s" % (messages.MENTOR_DOES_NOT_EXIST, messages.MENTEE_DOES_NOT_EXIST),
     )
     def post(cls):
@@ -97,7 +98,7 @@ class SendRequest(Resource):
         response = DAO.create_mentorship_relation(user_sender_id, data)
 
         # if the mentorship relation creation failed dont send email and return
-        if response[1] != HTTPStatus.CREATED:
+        if response[1] != HTTPStatus.CREATED.value:
             return response
 
         if user_sender_id == data["mentee_id"]:
@@ -143,12 +144,12 @@ class GetAllMyMentorshipRelation(Resource):
         _in="query",
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.OK,
+        HTTPStatus.OK.value,
         "Return all user's mentorship relations, filtered by the relation state, was successfully.",
         model=mentorship_request_response_body,
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.UNAUTHORIZED,
+        HTTPStatus.UNAUTHORIZED.value,
         "%s\n%s\n%s"
         % (
             messages.TOKEN_HAS_EXPIRED,
@@ -157,7 +158,9 @@ class GetAllMyMentorshipRelation(Resource):
         ),
     )
     @mentorship_relation_ns.marshal_list_with(
-        mentorship_request_response_body, code=HTTPStatus.OK, description="Success"
+        mentorship_request_response_body,
+        code=HTTPStatus.OK.value,
+        description="Success",
     )
     def get(cls):
         """
@@ -191,10 +194,11 @@ class AcceptMentorshipRelation(Resource):
     @mentorship_relation_ns.doc("accept_mentorship_relation")
     @mentorship_relation_ns.expect(auth_header_parser)
     @mentorship_relation_ns.response(
-        HTTPStatus.OK, "%s" % messages.MENTORSHIP_RELATION_WAS_ACCEPTED_SUCCESSFULLY
+        HTTPStatus.OK.value,
+        "%s" % messages.MENTORSHIP_RELATION_WAS_ACCEPTED_SUCCESSFULLY,
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.FORBIDDEN,
+        HTTPStatus.FORBIDDEN.value,
         "%s\n%s\n%s\n%s"
         % (
             messages.NOT_PENDING_STATE_RELATION,
@@ -204,7 +208,7 @@ class AcceptMentorshipRelation(Resource):
         ),
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.UNAUTHORIZED,
+        HTTPStatus.UNAUTHORIZED.value,
         "%s\n%s\n%s"
         % (
             messages.TOKEN_HAS_EXPIRED,
@@ -213,7 +217,8 @@ class AcceptMentorshipRelation(Resource):
         ),
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.NOT_FOUND, "%s" % messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST
+        HTTPStatus.NOT_FOUND.value,
+        "%s" % messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST,
     )
     def put(cls, request_id):
         """
@@ -233,7 +238,7 @@ class AcceptMentorshipRelation(Resource):
         user_id = get_jwt_identity()
         response = DAO.accept_request(user_id=user_id, request_id=request_id)
 
-        if response[1] == HTTPStatus.OK:
+        if response[1] == HTTPStatus.OK.value:
             send_email_mentorship_relation_accepted(request_id)
 
         return response
@@ -246,10 +251,11 @@ class RejectMentorshipRelation(Resource):
     @mentorship_relation_ns.doc("reject_mentorship_relation")
     @mentorship_relation_ns.expect(auth_header_parser)
     @mentorship_relation_ns.response(
-        HTTPStatus.OK, "%s" % messages.MENTORSHIP_RELATION_WAS_REJECTED_SUCCESSFULLY
+        HTTPStatus.OK.value,
+        "%s" % messages.MENTORSHIP_RELATION_WAS_REJECTED_SUCCESSFULLY,
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.FORBIDDEN,
+        HTTPStatus.FORBIDDEN.value,
         "%s\n%s\n%s"
         % (
             messages.NOT_PENDING_STATE_RELATION,
@@ -258,7 +264,7 @@ class RejectMentorshipRelation(Resource):
         ),
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.UNAUTHORIZED,
+        HTTPStatus.UNAUTHORIZED.value,
         "%s\n%s\n%s"
         % (
             messages.TOKEN_HAS_EXPIRED,
@@ -267,7 +273,8 @@ class RejectMentorshipRelation(Resource):
         ),
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.NOT_FOUND, "%s" % messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST
+        HTTPStatus.NOT_FOUND.value,
+        "%s" % messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST,
     )
     def put(cls, request_id):
         """
@@ -296,15 +303,16 @@ class CancelMentorshipRelation(Resource):
     @mentorship_relation_ns.doc("cancel_mentorship_relation")
     @mentorship_relation_ns.expect(auth_header_parser)
     @mentorship_relation_ns.response(
-        HTTPStatus.OK, "%s" % messages.MENTORSHIP_RELATION_WAS_CANCELLED_SUCCESSFULLY
+        HTTPStatus.OK.value,
+        "%s" % messages.MENTORSHIP_RELATION_WAS_CANCELLED_SUCCESSFULLY,
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.BAD_REQUEST,
+        HTTPStatus.BAD_REQUEST.value,
         "%s\n%s"
         % (messages.UNACCEPTED_STATE_RELATION, messages.CANT_CANCEL_UNINVOLVED_REQUEST),
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.UNAUTHORIZED,
+        HTTPStatus.UNAUTHORIZED.value,
         "%s\n%s\n%s"
         % (
             messages.TOKEN_HAS_EXPIRED,
@@ -313,7 +321,8 @@ class CancelMentorshipRelation(Resource):
         ),
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.NOT_FOUND, "%s" % messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST
+        HTTPStatus.NOT_FOUND.value,
+        "%s" % messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST,
     )
     def put(cls, request_id):
         """
@@ -342,10 +351,11 @@ class DeleteMentorshipRelation(Resource):
     @mentorship_relation_ns.doc("delete_mentorship_relation")
     @mentorship_relation_ns.expect(auth_header_parser)
     @mentorship_relation_ns.response(
-        HTTPStatus.OK, "%s" % messages.MENTORSHIP_RELATION_WAS_DELETED_SUCCESSFULLY
+        HTTPStatus.OK.value,
+        "%s" % messages.MENTORSHIP_RELATION_WAS_DELETED_SUCCESSFULLY,
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.FORBIDDEN,
+        HTTPStatus.FORBIDDEN.value,
         "%s\n%s"
         % (
             messages.NOT_PENDING_STATE_RELATION,
@@ -353,7 +363,7 @@ class DeleteMentorshipRelation(Resource):
         ),
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.UNAUTHORIZED,
+        HTTPStatus.UNAUTHORIZED.value,
         "%s\n%s\n%s"
         % (
             messages.TOKEN_HAS_EXPIRED,
@@ -362,7 +372,8 @@ class DeleteMentorshipRelation(Resource):
         ),
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.NOT_FOUND, "%s" % messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST
+        HTTPStatus.NOT_FOUND.value,
+        "%s" % messages.MENTORSHIP_RELATION_REQUEST_DOES_NOT_EXIST,
     )
     def delete(cls, request_id):
         """
@@ -391,12 +402,12 @@ class ListPastMentorshipRelations(Resource):
     @mentorship_relation_ns.doc("get_past_mentorship_relations")
     @mentorship_relation_ns.expect(auth_header_parser)
     @mentorship_relation_ns.response(
-        HTTPStatus.OK,
+        HTTPStatus.OK.value,
         "Returned past mentorship relations with success.",
         model=mentorship_request_response_body,
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.UNAUTHORIZED,
+        HTTPStatus.UNAUTHORIZED.value,
         "%s\n%s\n%s"
         % (
             messages.TOKEN_HAS_EXPIRED,
@@ -405,7 +416,9 @@ class ListPastMentorshipRelations(Resource):
         ),
     )
     @mentorship_relation_ns.marshal_list_with(
-        mentorship_request_response_body, code=HTTPStatus.OK, description="Success"
+        mentorship_request_response_body,
+        code=HTTPStatus.OK.value,
+        description="Success",
     )
     def get(cls):
         """
@@ -431,12 +444,12 @@ class ListCurrentMentorshipRelation(Resource):
     @mentorship_relation_ns.doc("get_current_mentorship_relation")
     @mentorship_relation_ns.expect(auth_header_parser)
     @mentorship_relation_ns.response(
-        HTTPStatus.OK,
+        HTTPStatus.OK.value,
         "Returned current mentorship relation with success.",
         model=mentorship_request_response_body,
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.UNAUTHORIZED,
+        HTTPStatus.UNAUTHORIZED.value,
         "%s\n%s\n%s"
         % (
             messages.TOKEN_HAS_EXPIRED,
@@ -459,7 +472,10 @@ class ListCurrentMentorshipRelation(Resource):
         response = DAO.list_current_mentorship_relation(user_id)
 
         if isinstance(response, MentorshipRelationModel):
-            return marshal(response, mentorship_request_response_body), HTTPStatus.OK
+            return (
+                marshal(response, mentorship_request_response_body),
+                HTTPStatus.OK,
+            )
 
         return response
 
@@ -471,15 +487,17 @@ class ListPendingMentorshipRequests(Resource):
     @mentorship_relation_ns.doc("get_pending_mentorship_relations")
     @mentorship_relation_ns.expect(auth_header_parser)
     @mentorship_relation_ns.response(
-        HTTPStatus.OK,
+        HTTPStatus.OK.value,
         "Returned pending mentorship relation with success.",
         model=mentorship_request_response_body,
     )
     @mentorship_relation_ns.marshal_list_with(
-        mentorship_request_response_body, code=HTTPStatus.OK, description="Success"
+        mentorship_request_response_body,
+        code=HTTPStatus.OK.value,
+        description="Success",
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.UNAUTHORIZED,
+        HTTPStatus.UNAUTHORIZED.value,
         "%s\n%s\n%s"
         % (
             messages.TOKEN_HAS_EXPIRED,
@@ -511,13 +529,13 @@ class CreateTask(Resource):
     @mentorship_relation_ns.doc("create_task_in_mentorship_relation")
     @mentorship_relation_ns.expect(auth_header_parser, create_task_request_body)
     @mentorship_relation_ns.response(
-        HTTPStatus.CREATED, "%s" % messages.TASK_WAS_CREATED_SUCCESSFULLY
+        HTTPStatus.CREATED.value, "%s" % messages.TASK_WAS_CREATED_SUCCESSFULLY
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.FORBIDDEN, "%s" % messages.UNACCEPTED_STATE_RELATION
+        HTTPStatus.FORBIDDEN.value, "%s" % messages.UNACCEPTED_STATE_RELATION
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.UNAUTHORIZED,
+        HTTPStatus.UNAUTHORIZED.value,
         "%s\n%s\n%s"
         % (
             messages.TOKEN_HAS_EXPIRED,
@@ -526,7 +544,8 @@ class CreateTask(Resource):
         ),
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.FORBIDDEN, "%s" % messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION
+        HTTPStatus.FORBIDDEN.value,
+        "%s" % messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION,
     )
     def post(cls, request_id):
         """
@@ -574,10 +593,10 @@ class DeleteTask(Resource):
     @mentorship_relation_ns.doc("delete_task_in_mentorship_relation")
     @mentorship_relation_ns.expect(auth_header_parser)
     @mentorship_relation_ns.response(
-        HTTPStatus.OK, "%s" % messages.TASK_WAS_DELETED_SUCCESSFULLY
+        HTTPStatus.OK.value, "%s" % messages.TASK_WAS_DELETED_SUCCESSFULLY
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.UNAUTHORIZED,
+        HTTPStatus.UNAUTHORIZED.value,
         "%s\n%s\n%s\n%s"
         % (
             messages.TOKEN_HAS_EXPIRED,
@@ -587,7 +606,7 @@ class DeleteTask(Resource):
         ),
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.NOT_FOUND,
+        HTTPStatus.NOT_FOUND.value,
         "%s\n%s"
         % (messages.MENTORSHIP_RELATION_DOES_NOT_EXIST, messages.TASK_DOES_NOT_EXIST),
     )
@@ -623,12 +642,12 @@ class ListTasks(Resource):
     @mentorship_relation_ns.doc("list_tasks_in_mentorship_relation")
     @mentorship_relation_ns.expect(auth_header_parser)
     @mentorship_relation_ns.response(
-        HTTPStatus.OK,
+        HTTPStatus.OK.value,
         "List tasks from a mentorship relation with success.",
         model=list_tasks_response_body,
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.UNAUTHORIZED,
+        HTTPStatus.UNAUTHORIZED.value,
         "%s\n%s\n%s\n%s"
         % (
             messages.TOKEN_HAS_EXPIRED,
@@ -638,7 +657,7 @@ class ListTasks(Resource):
         ),
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.NOT_FOUND, "%s" % messages.MENTORSHIP_RELATION_DOES_NOT_EXIST
+        HTTPStatus.NOT_FOUND.value, "%s" % messages.MENTORSHIP_RELATION_DOES_NOT_EXIST
     )
     def get(cls, request_id):
         """
@@ -676,13 +695,13 @@ class UpdateTask(Resource):
     @mentorship_relation_ns.doc("update_task_in_mentorship_relation")
     @mentorship_relation_ns.expect(auth_header_parser)
     @mentorship_relation_ns.response(
-        HTTPStatus.OK, "%s" % messages.TASK_WAS_ACHIEVED_SUCCESSFULLY
+        HTTPStatus.OK.value, "%s" % messages.TASK_WAS_ACHIEVED_SUCCESSFULLY
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.BAD_REQUEST, "%s" % messages.TASK_WAS_ALREADY_ACHIEVED
+        HTTPStatus.BAD_REQUEST.value, "%s" % messages.TASK_WAS_ALREADY_ACHIEVED
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.UNAUTHORIZED,
+        HTTPStatus.UNAUTHORIZED.value,
         "%s\n%s\n%s\n%s"
         % (
             messages.TOKEN_HAS_EXPIRED,
@@ -692,7 +711,7 @@ class UpdateTask(Resource):
         ),
     )
     @mentorship_relation_ns.response(
-        HTTPStatus.NOT_FOUND,
+        HTTPStatus.NOT_FOUND.value,
         "%s\n%s"
         % (messages.MENTORSHIP_RELATION_DOES_NOT_EXIST, messages.TASK_DOES_NOT_EXIST),
     )
@@ -730,16 +749,16 @@ class CreateTaskComment(Resource):
     @mentorship_relation_ns.expect(auth_header_parser, task_comment_model)
     @mentorship_relation_ns.doc(
         responses={
-            HTTPStatus.CREATED: f"{messages.TASK_COMMENT_WAS_CREATED_SUCCESSFULLY}",
-            HTTPStatus.BAD_REQUEST: f"{messages.COMMENT_FIELD_IS_MISSING}<br>"
+            HTTPStatus.CREATED.value: f"{messages.TASK_COMMENT_WAS_CREATED_SUCCESSFULLY}",
+            HTTPStatus.BAD_REQUEST.value: f"{messages.COMMENT_FIELD_IS_MISSING}<br>"
             f"{messages.COMMENT_NOT_IN_STRING_FORMAT}<br>"
             f"{ {'message': get_length_validation_error_message('comment', None, COMMENT_MAX_LENGTH)}}<br>"
             f"{messages.UNACCEPTED_STATE_RELATION}",
-            HTTPStatus.UNAUTHORIZED: f"{messages.TOKEN_HAS_EXPIRED}<br>"
+            HTTPStatus.UNAUTHORIZED.value: f"{messages.TOKEN_HAS_EXPIRED}<br>"
             f"{messages.TOKEN_IS_INVALID}<br>"
             f"{messages.AUTHORISATION_TOKEN_IS_MISSING}<br>"
             f"{messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION}",
-            HTTPStatus.NOT_FOUND: f"{messages.USER_DOES_NOT_EXIST}<br>"
+            HTTPStatus.NOT_FOUND.value: f"{messages.USER_DOES_NOT_EXIST}<br>"
             f"{messages.MENTORSHIP_RELATION_DOES_NOT_EXIST}<br>"
             f"{messages.TASK_DOES_NOT_EXIST}",
         }
@@ -770,17 +789,17 @@ class TaskComment(Resource):
     @mentorship_relation_ns.expect(auth_header_parser, task_comment_model)
     @mentorship_relation_ns.doc(
         responses={
-            HTTPStatus.OK: f"{messages.TASK_COMMENT_WAS_UPDATED_SUCCESSFULLY}",
-            HTTPStatus.BAD_REQUEST: f"{messages.COMMENT_FIELD_IS_MISSING}<br>"
+            HTTPStatus.OK.value: f"{messages.TASK_COMMENT_WAS_UPDATED_SUCCESSFULLY}",
+            HTTPStatus.BAD_REQUEST.value: f"{messages.COMMENT_FIELD_IS_MISSING}<br>"
             f"{messages.COMMENT_NOT_IN_STRING_FORMAT}<br>"
             f"{ {'message':get_length_validation_error_message('comment', None, COMMENT_MAX_LENGTH)}}<br>"
             f"{messages.UNACCEPTED_STATE_RELATION}<br>"
             f"{messages.TASK_COMMENT_WAS_NOT_CREATED_BY_YOU}",
-            HTTPStatus.UNAUTHORIZED: f"{messages.TOKEN_HAS_EXPIRED}<br>"
+            HTTPStatus.UNAUTHORIZED.value: f"{messages.TOKEN_HAS_EXPIRED}<br>"
             f"{messages.TOKEN_IS_INVALID}<br>"
             f"{messages.AUTHORISATION_TOKEN_IS_MISSING}<br>"
             f"{messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION}",
-            HTTPStatus.NOT_FOUND: f"{messages.USER_DOES_NOT_EXIST}<br>"
+            HTTPStatus.NOT_FOUND.value: f"{messages.USER_DOES_NOT_EXIST}<br>"
             f"{messages.MENTORSHIP_RELATION_DOES_NOT_EXIST}<br>"
             f"{messages.TASK_DOES_NOT_EXIST}<br>"
             f"{messages.TASK_COMMENT_DOES_NOT_EXIST}<br>"
@@ -808,14 +827,14 @@ class TaskComment(Resource):
     @mentorship_relation_ns.expect(auth_header_parser)
     @mentorship_relation_ns.doc(
         responses={
-            HTTPStatus.OK: f"{messages.TASK_COMMENT_WAS_DELETED_SUCCESSFULLY}",
-            HTTPStatus.BAD_REQUEST: f"{messages.UNACCEPTED_STATE_RELATION}",
-            HTTPStatus.UNAUTHORIZED: f"{messages.TOKEN_HAS_EXPIRED}<br>"
+            HTTPStatus.OK.value: f"{messages.TASK_COMMENT_WAS_DELETED_SUCCESSFULLY}",
+            HTTPStatus.BAD_REQUEST.value: f"{messages.UNACCEPTED_STATE_RELATION}",
+            HTTPStatus.UNAUTHORIZED.value: f"{messages.TOKEN_HAS_EXPIRED}<br>"
             f"{messages.TOKEN_IS_INVALID}<br>"
             f"{messages.AUTHORISATION_TOKEN_IS_MISSING}<br>"
             f"{messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION}",
-            HTTPStatus.FORBIDDEN: f"{messages.TASK_COMMENT_WAS_NOT_CREATED_BY_YOU_DELETE}",
-            HTTPStatus.NOT_FOUND: f"{messages.USER_DOES_NOT_EXIST}<br>"
+            HTTPStatus.FORBIDDEN.value: f"{messages.TASK_COMMENT_WAS_NOT_CREATED_BY_YOU_DELETE}",
+            HTTPStatus.NOT_FOUND.value: f"{messages.USER_DOES_NOT_EXIST}<br>"
             f"{messages.MENTORSHIP_RELATION_DOES_NOT_EXIST}<br>"
             f"{messages.TASK_DOES_NOT_EXIST}<br>"
             f"{messages.TASK_COMMENT_DOES_NOT_EXIST}<br>"
@@ -840,18 +859,18 @@ class TaskComments(Resource):
     @jwt_required
     @mentorship_relation_ns.expect(auth_header_parser)
     @mentorship_relation_ns.response(
-        HTTPStatus.OK,
+        HTTPStatus.OK.value,
         f"{ messages.LIST_TASK_COMMENTS_WITH_SUCCESS}",
         task_comments_model,
     )
     @mentorship_relation_ns.doc(
         responses={
-            HTTPStatus.BAD_REQUEST: f"{messages.UNACCEPTED_STATE_RELATION}",
-            HTTPStatus.UNAUTHORIZED: f"{messages.TOKEN_HAS_EXPIRED}<br>"
+            HTTPStatus.BAD_REQUEST.value: f"{messages.UNACCEPTED_STATE_RELATION}",
+            HTTPStatus.UNAUTHORIZED.value: f"{messages.TOKEN_HAS_EXPIRED}<br>"
             f"{messages.TOKEN_IS_INVALID}<br>"
             f"{messages.AUTHORISATION_TOKEN_IS_MISSING}<br>"
             f"{messages.USER_NOT_INVOLVED_IN_THIS_MENTOR_RELATION}",
-            HTTPStatus.NOT_FOUND: f"{messages.USER_DOES_NOT_EXIST}<br>"
+            HTTPStatus.NOT_FOUND.value: f"{messages.USER_DOES_NOT_EXIST}<br>"
             f"{messages.MENTORSHIP_RELATION_DOES_NOT_EXIST}<br>"
             f"{messages.TASK_DOES_NOT_EXIST}",
         }

--- a/app/api/resources/mentorship_relation.py
+++ b/app/api/resources/mentorship_relation.py
@@ -40,7 +40,7 @@ class SendRequest(Resource):
     )
     @mentorship_relation_ns.response(
         HTTPStatus.BAD_REQUEST.value,
-       "%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s"
+        "%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s"
         % (
             messages.MATCH_EITHER_MENTOR_OR_MENTEE,
             messages.MENTOR_ID_SAME_AS_MENTEE_ID,


### PR DESCRIPTION
### Description
The values of  HTTPStatus codes shown on Swagger UI of mentorship_relation API changed to be in number format instead of Enum Representations. 
<!--- Include a summary of the change and relevant motivation/context. List any dependencies that are required for this change. --->

Fixes #939

Closed PR #942 
### Type of Change:

<!--- **Delete irrelevant options.** --->

- Code

- User Interface


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Go to ``` mentorship_relation```
Click on ```Post/mentorship_relation/send_request```(or any other task)
See Results

![image](https://user-images.githubusercontent.com/66299533/103148707-a5ef9b80-4788-11eb-9187-9dc84c226778.png)

<!-- Describe the tests you ran to verify your changes. Provide instructions or GIFs so we can reproduce. List any relevant details for your test. -->


### Checklist:

<!-- **Delete irrelevant options.** -->

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials


**Code/Quality Assurance Only**

- [x] My changes generate no new warnings 
- [x] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
