### PR TITLE
Tests: Use super() without arguments for Python3 only support

### DIFF
--- a/tests/admin/test_api_list_admin_users.py
+++ b/tests/admin/test_api_list_admin_users.py
@@ -18,7 +18,7 @@ from tests.test_data import user1, test_admin_user, test_admin_user_2, test_admi
 
 class TestListAdminUsersApi(BaseTestCase):
     def setUp(self):
-        super(TestListAdminUsersApi, self).setUp()
+        super().setUp()
 
         self.admin_user_2 = UserModel(
             name=test_admin_user_2["name"],

--- a/tests/admin/test_api_remove_admin_user.py
+++ b/tests/admin/test_api_remove_admin_user.py
@@ -18,7 +18,7 @@ from tests.test_data import test_admin_user_2, test_admin_user_3
 
 class TestRemoveAdminUsersApi(BaseTestCase):
     def setUp(self):
-        super(TestRemoveAdminUsersApi, self).setUp()
+        super().setUp()
 
         self.admin_user_1 = UserModel(
             name=test_admin_user_2["name"],

--- a/tests/cron_job_functions/test_delete_unverified_users_cron.py
+++ b/tests/cron_job_functions/test_delete_unverified_users_cron.py
@@ -12,7 +12,7 @@ from tests.test_data import user1, user2, user3
 
 class TestDeleteUnverifiedUsersCronFunction(BaseTestCase):
     def setUp(self):
-        super(TestDeleteUnverifiedUsersCronFunction, self).setUp()
+        super().setUp()
 
         self.verified_user = UserModel(
             name=user1["name"],

--- a/tests/cron_job_functions/test_mentorship_completion_cron.py
+++ b/tests/cron_job_functions/test_mentorship_completion_cron.py
@@ -20,7 +20,7 @@ class TestCompleteMentorshipRelationCronFunction(BaseTestCase):
     # User 1 is the mentorship relation requester = action user
     # User 2 is the receiver
     def setUp(self):
-        super(TestCompleteMentorshipRelationCronFunction, self).setUp()
+        super().setUp()
 
         self.first_user = UserModel(
             name=user1["name"],

--- a/tests/mentorship_relation/relation_base_setup.py
+++ b/tests/mentorship_relation/relation_base_setup.py
@@ -10,7 +10,7 @@ class MentorshipRelationBaseTestCase(BaseTestCase):
     # User 1 is the mentorship relation requester = action user
     # User 2 is the receiver
     def setUp(self):
-        super(MentorshipRelationBaseTestCase, self).setUp()
+        super().setUp()
 
         self.first_user = UserModel(
             name=user1["name"],

--- a/tests/mentorship_relation/test_api_accept_request.py
+++ b/tests/mentorship_relation/test_api_accept_request.py
@@ -14,7 +14,7 @@ from tests.test_utils import get_test_request_header
 
 class TestAcceptMentorshipRequestApi(MentorshipRelationBaseTestCase):
     def setUp(self):
-        super(TestAcceptMentorshipRequestApi, self).setUp()
+        super().setUp()
 
         self.notes_example = "description of a good mentorship relation"
 

--- a/tests/mentorship_relation/test_api_cancel_relation.py
+++ b/tests/mentorship_relation/test_api_cancel_relation.py
@@ -18,7 +18,7 @@ class TestCancelMentorshipRelationApi(MentorshipRelationBaseTestCase):
     # User 1 is the mentorship relation requester = action user
     # User 2 is the receiver
     def setUp(self):
-        super(TestCancelMentorshipRelationApi, self).setUp()
+        super().setUp()
 
         self.notes_example = "description of a good mentorship relation"
 

--- a/tests/mentorship_relation/test_api_delete_request.py
+++ b/tests/mentorship_relation/test_api_delete_request.py
@@ -17,7 +17,7 @@ class TestDeleteMentorshipRequestApi(MentorshipRelationBaseTestCase):
     # User 1 is the mentorship relation requester = action user
     # User 2 is the receiver
     def setUp(self):
-        super(TestDeleteMentorshipRequestApi, self).setUp()
+        super().setUp()
 
         self.notes_example = "description of a good mentorship relation"
         self.now_datetime = datetime.now()

--- a/tests/mentorship_relation/test_api_list_relations.py
+++ b/tests/mentorship_relation/test_api_list_relations.py
@@ -19,7 +19,7 @@ class TestListMentorshipRelationsApi(MentorshipRelationBaseTestCase):
     # User 1 is the mentorship relation requester = action user
     # User 2 is the receiver
     def setUp(self):
-        super(TestListMentorshipRelationsApi, self).setUp()
+        super().setUp()
 
         self.notes_example = "description of a good mentorship relation"
         self.now_datetime = datetime.now()

--- a/tests/mentorship_relation/test_api_reject_request.py
+++ b/tests/mentorship_relation/test_api_reject_request.py
@@ -17,7 +17,7 @@ class TestRejectMentorshipRequestApi(MentorshipRelationBaseTestCase):
     # User 1 is the mentorship relation requester = action user
     # User 2 is the receiver
     def setUp(self):
-        super(TestRejectMentorshipRequestApi, self).setUp()
+        super().setUp()
 
         self.notes_example = "description of a good mentorship relation"
         self.now_datetime = datetime.now()

--- a/tests/mentorship_relation/test_api_send_request.py
+++ b/tests/mentorship_relation/test_api_send_request.py
@@ -14,7 +14,7 @@ from tests.test_utils import get_test_request_header
 
 class TestSendRequestApi(MentorshipRelationBaseTestCase):
     def setUp(self):
-        super(TestSendRequestApi, self).setUp()
+        super().setUp()
 
     def test_created_error_code_for_send_request(self):
         auth_header = get_test_request_header(self.first_user.id)

--- a/tests/mentorship_relation/test_dao_accept_request.py
+++ b/tests/mentorship_relation/test_dao_accept_request.py
@@ -19,7 +19,7 @@ class TestMentorshipRelationAcceptRequestDAO(MentorshipRelationBaseTestCase):
     # User 1 is the mentorship relation requester = action user
     # User 2 is the receiver
     def setUp(self):
-        super(TestMentorshipRelationAcceptRequestDAO, self).setUp()
+        super().setUp()
 
         self.notes_example = "description of a good mentorship relation"
         self.now_datetime = datetime.now()

--- a/tests/mentorship_relation/test_dao_cancel_relation.py
+++ b/tests/mentorship_relation/test_dao_cancel_relation.py
@@ -18,7 +18,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
     # User 1 is the mentorship relation requester = action user
     # User 2 is the receiver
     def setUp(self):
-        super(TestMentorshipRelationListingDAO, self).setUp()
+        super().setUp()
 
         self.notes_example = "description of a good mentorship relation"
         self.now_datetime = datetime.now()

--- a/tests/mentorship_relation/test_dao_creation.py
+++ b/tests/mentorship_relation/test_dao_creation.py
@@ -14,7 +14,7 @@ class TestMentorshipRelationCreationDAO(MentorshipRelationBaseTestCase):
 
     # Setup consists of adding 2 users into the database
     def setUp(self):
-        super(TestMentorshipRelationCreationDAO, self).setUp()
+        super().setUp()
 
         self.notes_example = "description of a good mentorship relation"
 

--- a/tests/mentorship_relation/test_dao_delete_request.py
+++ b/tests/mentorship_relation/test_dao_delete_request.py
@@ -17,7 +17,7 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
     # User 1 is the mentorship relation requester = action user
     # User 2 is the receiver
     def setUp(self):
-        super(TestMentorshipRelationDeleteDAO, self).setUp()
+        super().setUp()
 
         self.first_user = UserModel(
             name=user1["name"],

--- a/tests/mentorship_relation/test_dao_list_relations.py
+++ b/tests/mentorship_relation/test_dao_list_relations.py
@@ -14,7 +14,7 @@ class TestListMentorshipRelationsDAO(MentorshipRelationBaseTestCase):
 
     # Setup consists of adding 2 users into the database
     def setUp(self):
-        super(TestListMentorshipRelationsDAO, self).setUp()
+        super().setUp()
 
         self.notes_example = "description of a good mentorship relation"
         self.now_datetime = datetime.now()

--- a/tests/mentorship_relation/test_dao_listing.py
+++ b/tests/mentorship_relation/test_dao_listing.py
@@ -16,7 +16,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
 
     # Setup consists of adding 2 users into the database
     def setUp(self):
-        super(TestMentorshipRelationListingDAO, self).setUp()
+        super().setUp()
 
         self.notes_example = "description of a good mentorship relation"
         self.now_datetime = datetime.now()

--- a/tests/mentorship_relation/test_dao_reject_mentorship_request.py
+++ b/tests/mentorship_relation/test_dao_reject_mentorship_request.py
@@ -18,7 +18,7 @@ class TestMentorshipRelationListingDAO(MentorshipRelationBaseTestCase):
     # User 1 is the mentorship relation requester = action user
     # User 2 is the receiver
     def setUp(self):
-        super(TestMentorshipRelationListingDAO, self).setUp()
+        super().setUp()
 
         self.notes_example = "description of a good mentorship relation"
         self.now_datetime = datetime.now()

--- a/tests/tasks/tasks_base_setup.py
+++ b/tests/tasks/tasks_base_setup.py
@@ -15,7 +15,7 @@ class TasksBaseTestCase(BaseTestCase):
     # User 1 is the mentorship relation requester = action user
     # User 2 is the receiver
     def setUp(self):
-        super(TasksBaseTestCase, self).setUp()
+        super().setUp()
 
         self.first_user = UserModel(
             name=user1["name"],

--- a/tests/tasks/test_tasks_list_database_model.py
+++ b/tests/tasks/test_tasks_list_database_model.py
@@ -8,7 +8,7 @@ from tests.base_test_case import BaseTestCase
 
 class TestTasksListModel(BaseTestCase):
     def setUp(self):
-        super(TestTasksListModel, self).setUp()
+        super().setUp()
 
         self.empty_tasks_list = TasksListModel()
         self.tasks_list_1 = TasksListModel()

--- a/tests/users/test_api_authentication.py
+++ b/tests/users/test_api_authentication.py
@@ -17,7 +17,7 @@ class TestProtectedApi(BaseTestCase):
 
     # User 1 which has email verified
     def setUp(self):
-        super(TestProtectedApi, self).setUp()
+        super().setUp()
 
         self.first_user = UserModel(
             name=user1["name"],

--- a/tests/users/test_api_change_password.py
+++ b/tests/users/test_api_change_password.py
@@ -23,7 +23,7 @@ from tests.test_utils import get_test_request_header
 
 class TestUserChangePasswordApi(BaseTestCase):
     def setUp(self):
-        super(TestUserChangePasswordApi, self).setUp()
+        super().setUp()
         self.first_user = UserModel(
             password=user1["password"],
             name="User1",

--- a/tests/users/test_api_get_other_user.py
+++ b/tests/users/test_api_get_other_user.py
@@ -14,7 +14,7 @@ from tests.test_utils import get_test_request_header
 
 class TestnGetOtherUserApi(BaseTestCase):
     def setUp(self):
-        super(TestnGetOtherUserApi, self).setUp()
+        super().setUp()
 
         self.verified_user = UserModel(
             name=user1["name"] + "    Example",

--- a/tests/users/test_api_home_statistics.py
+++ b/tests/users/test_api_home_statistics.py
@@ -13,7 +13,7 @@ from tests.test_utils import get_test_request_header
 
 class TestHomeStatisticsApi(BaseTestCase):
     def setUp(self):
-        super(TestHomeStatisticsApi, self).setUp()
+        super().setUp()
 
         self.user1 = UserModel("User1", "user1", "__test__", "test@email.com", True)
         self.user2 = UserModel("User2", "user2", "__test__", "test2@email.com", True)

--- a/tests/users/test_api_list_users.py
+++ b/tests/users/test_api_list_users.py
@@ -18,7 +18,7 @@ from tests.test_data import user1, user2, user3
 
 class TestListUsersApi(BaseTestCase):
     def setUp(self):
-        super(TestListUsersApi, self).setUp()
+        super().setUp()
 
         self.verified_user = UserModel(
             name=user1["name"] + "    Example",

--- a/tests/users/test_api_login.py
+++ b/tests/users/test_api_login.py
@@ -24,7 +24,7 @@ class TestUserLoginApi(BaseTestCase):
     # User 1 does not have email verified
     # User 2 has email verified
     def setUp(self):
-        super(TestUserLoginApi, self).setUp()
+        super().setUp()
 
         self.first_user = UserModel(
             name=user1["name"],

--- a/tests/users/test_api_refresh.py
+++ b/tests/users/test_api_refresh.py
@@ -15,7 +15,7 @@ class TestUserRefreshApi(BaseTestCase):
 
     # User 1 which has email verified
     def setUp(self):
-        super(TestUserRefreshApi, self).setUp()
+        super().setUp()
 
         self.first_user = UserModel(
             name=user1["name"],

--- a/tests/users/test_dao_dashboard.py
+++ b/tests/users/test_dao_dashboard.py
@@ -14,7 +14,7 @@ from tests.test_data import user1, user2
 
 class TestUserDao(BaseTestCase):
     def setUp(self):
-        super(TestUserDao, self).setUp()
+        super().setUp()
 
         self.first_user = UserModel(
             name=user1["name"],


### PR DESCRIPTION
### Description

Refactored .super() function in each of the tests for Python3 only support.

Fixes #595

### Type of Change:

<!--- **Delete irrelevant options.** --->

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?

Ran python3 -m unittest test tests/folder/file.py for every test manually

All tests passing.

Screenshot taken after running 

``` python3 -m unittest test tests/users/test_api_list_users.py ```

![image](https://user-images.githubusercontent.com/66299533/105823263-f144d600-5fe2-11eb-8209-e3ec6d92df8c.png)

Similarly, all the tests were tested with successful result

Also this
![image](https://user-images.githubusercontent.com/66299533/105826752-16d3de80-5fe7-11eb-9dae-87ce3d2ded36.png)


### Checklist:

<!-- **Delete irrelevant options.** -->

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**

- [x] My changes generate no new warnings 
- [x] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published in downstream modules
