### PR TITLE
docs: used HTTPStatus instead of hard-coded values in tests/users

### DIFF
--- a/app/api/resources/admin.py
+++ b/app/api/resources/admin.py
@@ -13,14 +13,14 @@ add_models_to_namespace(admin_ns)
 
 
 @admin_ns.route("admin/new")
-@admin_ns.response(HTTPStatus.FORBIDDEN, f"{messages.USER_IS_NOW_AN_ADMIN}")
-@admin_ns.response(HTTPStatus.BAD_REQUEST, f"{messages.USER_IS_ALREADY_AN_ADMIN}")
+@admin_ns.response(HTTPStatus.FORBIDDEN.value, f"{messages.USER_IS_NOW_AN_ADMIN}")
+@admin_ns.response(HTTPStatus.BAD_REQUEST.value, f"{messages.USER_IS_ALREADY_AN_ADMIN}")
 @admin_ns.response(
-    HTTPStatus.UNAUTHORIZED,
+    HTTPStatus.UNAUTHORIZED.value,
     f"{messages.TOKEN_HAS_EXPIRED}\n{messages.TOKEN_IS_INVALID}\n{messages.AUTHORISATION_TOKEN_IS_MISSING}",
 )
-@admin_ns.response(HTTPStatus.FORBIDDEN, f"{messages.USER_ASSIGN_NOT_ADMIN}")
-@admin_ns.response(HTTPStatus.NOT_FOUND, f"{messages.USER_DOES_NOT_EXIST}")
+@admin_ns.response(HTTPStatus.FORBIDDEN.value, f"{messages.USER_ASSIGN_NOT_ADMIN}")
+@admin_ns.response(HTTPStatus.NOT_FOUND.value, f"{messages.USER_DOES_NOT_EXIST}")
 class AssignNewUserAdmin(Resource):
     @classmethod
     @jwt_required
@@ -45,14 +45,14 @@ class AssignNewUserAdmin(Resource):
 
 
 @admin_ns.route("admin/remove")
-@admin_ns.response(HTTPStatus.OK, f"{messages.USER_ADMIN_STATUS_WAS_REVOKED}")
-@admin_ns.response(HTTPStatus.BAD_REQUEST, f"{messages.USER_IS_NOT_AN_ADMIN}")
+@admin_ns.response(HTTPStatus.OK.value, f"{messages.USER_ADMIN_STATUS_WAS_REVOKED}")
+@admin_ns.response(HTTPStatus.BAD_REQUEST.value, f"{messages.USER_IS_NOT_AN_ADMIN}")
 @admin_ns.response(
-    HTTPStatus.UNAUTHORIZED,
+    HTTPStatus.UNAUTHORIZED.value,
     f"{messages.TOKEN_HAS_EXPIRED}\n{messages.TOKEN_IS_INVALID}\n{messages.AUTHORISATION_TOKEN_IS_MISSING}",
 )
-@admin_ns.response(HTTPStatus.FORBIDDEN, f"{messages.USER_REVOKE_NOT_ADMIN}")
-@admin_ns.response(HTTPStatus.NOT_FOUND, f"{messages.USER_DOES_NOT_EXIST}")
+@admin_ns.response(HTTPStatus.FORBIDDEN.value, f"{messages.USER_REVOKE_NOT_ADMIN}")
+@admin_ns.response(HTTPStatus.NOT_FOUND.value, f"{messages.USER_DOES_NOT_EXIST}")
 class RevokeUserAdmin(Resource):
     @classmethod
     @jwt_required
@@ -81,15 +81,15 @@ class ListAdmins(Resource):
     @classmethod
     @jwt_required
     @admin_ns.doc("get_list_of_admins")
-    @admin_ns.response(HTTPStatus.OK, "Success.", public_admin_user_api_model)
+    @admin_ns.response(HTTPStatus.OK.value, "Success.", public_admin_user_api_model)
     @admin_ns.doc(
         responses={
-            HTTPStatus.UNAUTHORIZED: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
+            HTTPStatus.UNAUTHORIZED.value: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
             f"{messages.TOKEN_IS_INVALID['message']}<br>"
             f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}"
         }
     )
-    @admin_ns.response(HTTPStatus.FORBIDDEN, f"{messages.USER_IS_NOT_AN_ADMIN}")
+    @admin_ns.response(HTTPStatus.FORBIDDEN.value, f"{messages.USER_IS_NOT_AN_ADMIN}")
     @admin_ns.expect(auth_header_parser)
     def get(cls):
         """

--- a/app/api/resources/admin.py
+++ b/app/api/resources/admin.py
@@ -15,7 +15,10 @@ add_models_to_namespace(admin_ns)
 @admin_ns.route("admin/new")
 @admin_ns.response(HTTPStatus.FORBIDDEN.value, f"{messages.USER_IS_NOW_AN_ADMIN}")
 @admin_ns.response(HTTPStatus.BAD_REQUEST.value, f"{messages.USER_IS_ALREADY_AN_ADMIN}")
-@admin_ns.response(HTTPStatus.UNAUTHORIZED.value,f"{messages.TOKEN_HAS_EXPIRED}\n{messages.TOKEN_IS_INVALID}\n{messages.AUTHORISATION_TOKEN_IS_MISSING}")
+@admin_ns.response(
+    HTTPStatus.UNAUTHORIZED.value,
+    f"{messages.TOKEN_HAS_EXPIRED}\n{messages.TOKEN_IS_INVALID}\n{messages.AUTHORISATION_TOKEN_IS_MISSING}",
+)
 @admin_ns.response(HTTPStatus.FORBIDDEN.value, f"{messages.USER_ASSIGN_NOT_ADMIN}")
 @admin_ns.response(HTTPStatus.NOT_FOUND.value, f"{messages.USER_DOES_NOT_EXIST}")
 class AssignNewUserAdmin(Resource):
@@ -44,13 +47,18 @@ class AssignNewUserAdmin(Resource):
 @admin_ns.route("admin/remove")
 @admin_ns.response(HTTPStatus.OK.value, f"{messages.USER_ADMIN_STATUS_WAS_REVOKED}")
 @admin_ns.response(HTTPStatus.BAD_REQUEST.value, f"{messages.USER_IS_NOT_AN_ADMIN}")
-@admin_ns.response(HTTPStatus.UNAUTHORIZED.value,f"{messages.TOKEN_HAS_EXPIRED}\n{messages.TOKEN_IS_INVALID}\n{messages.AUTHORISATION_TOKEN_IS_MISSING}")
+@admin_ns.response(
+    HTTPStatus.UNAUTHORIZED.value,
+    f"{messages.TOKEN_HAS_EXPIRED}\n{messages.TOKEN_IS_INVALID}\n{messages.AUTHORISATION_TOKEN_IS_MISSING}",
+)
 @admin_ns.response(HTTPStatus.FORBIDDEN.value, f"{messages.USER_REVOKE_NOT_ADMIN}")
 @admin_ns.response(HTTPStatus.NOT_FOUND.value, f"{messages.USER_DOES_NOT_EXIST}")
 class RevokeUserAdmin(Resource):
     @classmethod
     @jwt_required
-    @admin_ns.expect(auth_header_parser, assign_and_revoke_user_admin_request_body, validate=True)
+    @admin_ns.expect(
+        auth_header_parser, assign_and_revoke_user_admin_request_body, validate=True
+    )
     def post(cls):
         """
         Revoke admin status from another User Admin.

--- a/app/api/resources/admin.py
+++ b/app/api/resources/admin.py
@@ -13,14 +13,11 @@ add_models_to_namespace(admin_ns)
 
 
 @admin_ns.route("admin/new")
-@admin_ns.response(HTTPStatus.FORBIDDEN, f"{messages.USER_IS_NOW_AN_ADMIN}")
-@admin_ns.response(HTTPStatus.BAD_REQUEST, f"{messages.USER_IS_ALREADY_AN_ADMIN}")
-@admin_ns.response(
-    HTTPStatus.UNAUTHORIZED,
-    f"{messages.TOKEN_HAS_EXPIRED}\n{messages.TOKEN_IS_INVALID}\n{messages.AUTHORISATION_TOKEN_IS_MISSING}",
-)
-@admin_ns.response(HTTPStatus.FORBIDDEN, f"{messages.USER_ASSIGN_NOT_ADMIN}")
-@admin_ns.response(HTTPStatus.NOT_FOUND, f"{messages.USER_DOES_NOT_EXIST}")
+@admin_ns.response(HTTPStatus.FORBIDDEN.value, f"{messages.USER_IS_NOW_AN_ADMIN}")
+@admin_ns.response(HTTPStatus.BAD_REQUEST.value, f"{messages.USER_IS_ALREADY_AN_ADMIN}")
+@admin_ns.response(HTTPStatus.UNAUTHORIZED.value,f"{messages.TOKEN_HAS_EXPIRED}\n{messages.TOKEN_IS_INVALID}\n{messages.AUTHORISATION_TOKEN_IS_MISSING}")
+@admin_ns.response(HTTPStatus.FORBIDDEN.value, f"{messages.USER_ASSIGN_NOT_ADMIN}")
+@admin_ns.response(HTTPStatus.NOT_FOUND.value, f"{messages.USER_DOES_NOT_EXIST}")
 class AssignNewUserAdmin(Resource):
     @classmethod
     @jwt_required
@@ -45,20 +42,15 @@ class AssignNewUserAdmin(Resource):
 
 
 @admin_ns.route("admin/remove")
-@admin_ns.response(HTTPStatus.OK, f"{messages.USER_ADMIN_STATUS_WAS_REVOKED}")
-@admin_ns.response(HTTPStatus.BAD_REQUEST, f"{messages.USER_IS_NOT_AN_ADMIN}")
-@admin_ns.response(
-    HTTPStatus.UNAUTHORIZED,
-    f"{messages.TOKEN_HAS_EXPIRED}\n{messages.TOKEN_IS_INVALID}\n{messages.AUTHORISATION_TOKEN_IS_MISSING}",
-)
-@admin_ns.response(HTTPStatus.FORBIDDEN, f"{messages.USER_REVOKE_NOT_ADMIN}")
-@admin_ns.response(HTTPStatus.NOT_FOUND, f"{messages.USER_DOES_NOT_EXIST}")
+@admin_ns.response(HTTPStatus.OK.value, f"{messages.USER_ADMIN_STATUS_WAS_REVOKED}")
+@admin_ns.response(HTTPStatus.BAD_REQUEST.value, f"{messages.USER_IS_NOT_AN_ADMIN}")
+@admin_ns.response(HTTPStatus.UNAUTHORIZED.value,f"{messages.TOKEN_HAS_EXPIRED}\n{messages.TOKEN_IS_INVALID}\n{messages.AUTHORISATION_TOKEN_IS_MISSING}")
+@admin_ns.response(HTTPStatus.FORBIDDEN.value, f"{messages.USER_REVOKE_NOT_ADMIN}")
+@admin_ns.response(HTTPStatus.NOT_FOUND.value, f"{messages.USER_DOES_NOT_EXIST}")
 class RevokeUserAdmin(Resource):
     @classmethod
     @jwt_required
-    @admin_ns.expect(
-        auth_header_parser, assign_and_revoke_user_admin_request_body, validate=True
-    )
+    @admin_ns.expect(auth_header_parser, assign_and_revoke_user_admin_request_body, validate=True)
     def post(cls):
         """
         Revoke admin status from another User Admin.
@@ -81,15 +73,15 @@ class ListAdmins(Resource):
     @classmethod
     @jwt_required
     @admin_ns.doc("get_list_of_admins")
-    @admin_ns.response(HTTPStatus.OK, "Success.", public_admin_user_api_model)
+    @admin_ns.response(HTTPStatus.OK.value, "Success.", public_admin_user_api_model)
     @admin_ns.doc(
         responses={
-            HTTPStatus.UNAUTHORIZED: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
+            HTTPStatus.UNAUTHORIZED.value: f"{messages.TOKEN_HAS_EXPIRED['message']}<br>"
             f"{messages.TOKEN_IS_INVALID['message']}<br>"
             f"{messages.AUTHORISATION_TOKEN_IS_MISSING['message']}"
         }
     )
-    @admin_ns.response(HTTPStatus.FORBIDDEN, f"{messages.USER_IS_NOT_AN_ADMIN}")
+    @admin_ns.response(HTTPStatus.FORBIDDEN.value, f"{messages.USER_IS_NOT_AN_ADMIN}")
     @admin_ns.expect(auth_header_parser)
     def get(cls):
         """

--- a/tests/users/test_api_authentication.py
+++ b/tests/users/test_api_authentication.py
@@ -38,14 +38,14 @@ class TestProtectedApi(BaseTestCase):
             "/user", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_user_profile_without_header_api(self):
         expected_response = messages.AUTHORISATION_TOKEN_IS_MISSING
         actual_response = self.client.get("/user", follow_redirects=True)
 
-        self.assertEqual(HTTPStatus.UNAUTHORIZED.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_user_profile_incomplete_token_api(self):
@@ -56,7 +56,7 @@ class TestProtectedApi(BaseTestCase):
             "/user", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(HTTPStatus.UNAUTHORIZED.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_user_profile_with_token_expired_api(self):
@@ -68,7 +68,7 @@ class TestProtectedApi(BaseTestCase):
             "/user", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(HTTPStatus.UNAUTHORIZED.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
 

--- a/tests/users/test_api_authentication.py
+++ b/tests/users/test_api_authentication.py
@@ -1,6 +1,6 @@
 import unittest
 from datetime import timedelta
-
+from http import HTTPStatus
 from flask import json
 from flask_restx import marshal
 
@@ -38,14 +38,14 @@ class TestProtectedApi(BaseTestCase):
             "/user", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_user_profile_without_header_api(self):
         expected_response = messages.AUTHORISATION_TOKEN_IS_MISSING
         actual_response = self.client.get("/user", follow_redirects=True)
 
-        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_user_profile_incomplete_token_api(self):
@@ -56,7 +56,7 @@ class TestProtectedApi(BaseTestCase):
             "/user", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_user_profile_with_token_expired_api(self):
@@ -68,7 +68,7 @@ class TestProtectedApi(BaseTestCase):
             "/user", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
 

--- a/tests/users/test_api_change_password.py
+++ b/tests/users/test_api_change_password.py
@@ -67,7 +67,7 @@ class TestUserChangePasswordApi(BaseTestCase):
                 },
                 follow_redirects=True,
             )
-            self.assertEqual((HTTPStatus.UNAUTHORIZED, response.status_code))
+            self.assertEqual(HTTPStatus.UNAUTHORIZED, response.status_code)
             self.assertEqual(expected_response, json.loads(response.data))
 
     def test_change_password_to_empty_one(self):

--- a/tests/users/test_api_change_password.py
+++ b/tests/users/test_api_change_password.py
@@ -52,7 +52,7 @@ class TestUserChangePasswordApi(BaseTestCase):
                 follow_redirects=True,
                 headers=self.auth_header,
             )
-            self.assertEqual(HTTPStatus.CREATED.value, response.status_code)
+            self.assertEqual(HTTPStatus.CREATED, response.status_code)
             self.assertEqual(expected_response, json.loads(response.data))
 
     def test_change_password_with_authentication_token_missing(self):
@@ -67,7 +67,7 @@ class TestUserChangePasswordApi(BaseTestCase):
                 },
                 follow_redirects=True,
             )
-            self.assertEqual((HTTPStatus.UNAUTHORIZED.value, response.status_code))
+            self.assertEqual((HTTPStatus.UNAUTHORIZED, response.status_code))
             self.assertEqual(expected_response, json.loads(response.data))
 
     def test_change_password_to_empty_one(self):
@@ -87,7 +87,7 @@ class TestUserChangePasswordApi(BaseTestCase):
                 follow_redirects=True,
                 headers=self.auth_header,
             )
-            self.assertEqual(HTTPStatus.BAD_REQUEST.value, response.status_code)
+            self.assertEqual(HTTPStatus.BAD_REQUEST, response.status_code)
             self.assertEqual(expected_response, json.loads(response.data))
 
     def test_change_password_to_one_with_empty_spaces(self):
@@ -122,7 +122,7 @@ class TestUserChangePasswordApi(BaseTestCase):
                 follow_redirects=True,
                 headers=auth_header,
             )
-            self.assertEqual(HTTPStatus.UNAUTHORIZED.value, response.status_code)
+            self.assertEqual(HTTPStatus.UNAUTHORIZED, response.status_code)
             self.assertEqual(expected_response, json.loads(response.data))
 
 

--- a/tests/users/test_api_change_password.py
+++ b/tests/users/test_api_change_password.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 import unittest
-
+from http import HTTPStatus
 from app.api.validations.user import PASSWORD_MIN_LENGTH, PASSWORD_MAX_LENGTH
 from app.database.models.user import UserModel
 from app.database.sqlalchemy_extension import db
@@ -52,7 +52,7 @@ class TestUserChangePasswordApi(BaseTestCase):
                 follow_redirects=True,
                 headers=self.auth_header,
             )
-            self.assertEqual(201, response.status_code)
+            self.assertEqual(HTTPStatus.CREATED.value, response.status_code)
             self.assertEqual(expected_response, json.loads(response.data))
 
     def test_change_password_with_authentication_token_missing(self):
@@ -67,7 +67,7 @@ class TestUserChangePasswordApi(BaseTestCase):
                 },
                 follow_redirects=True,
             )
-            self.assertEqual(401, response.status_code)
+            self.assertEqual((HTTPStatus.UNAUTHORIZED.value, response.status_code))
             self.assertEqual(expected_response, json.loads(response.data))
 
     def test_change_password_to_empty_one(self):
@@ -87,7 +87,7 @@ class TestUserChangePasswordApi(BaseTestCase):
                 follow_redirects=True,
                 headers=self.auth_header,
             )
-            self.assertEqual(400, response.status_code)
+            self.assertEqual(HTTPStatus.BAD_REQUEST.value, response.status_code)
             self.assertEqual(expected_response, json.loads(response.data))
 
     def test_change_password_to_one_with_empty_spaces(self):
@@ -103,7 +103,7 @@ class TestUserChangePasswordApi(BaseTestCase):
                 follow_redirects=True,
                 headers=self.auth_header,
             )
-            self.assertEqual(400, response.status_code)
+            self.assertEqual(HTTPStatus.BAD_REQUEST.value, response.status_code)
             self.assertEqual(expected_response, json.loads(response.data))
 
     def test_change_password_with_authentication_token_expired(self):
@@ -122,7 +122,7 @@ class TestUserChangePasswordApi(BaseTestCase):
                 follow_redirects=True,
                 headers=auth_header,
             )
-            self.assertEqual(401, response.status_code)
+            self.assertEqual(HTTPStatus.UNAUTHORIZED.value, response.status_code)
             self.assertEqual(expected_response, json.loads(response.data))
 
 

--- a/tests/users/test_api_change_password.py
+++ b/tests/users/test_api_change_password.py
@@ -103,7 +103,7 @@ class TestUserChangePasswordApi(BaseTestCase):
                 follow_redirects=True,
                 headers=self.auth_header,
             )
-            self.assertEqual(HTTPStatus.BAD_REQUEST.value, response.status_code)
+            self.assertEqual(HTTPStatus.BAD_REQUEST , response.status_code)
             self.assertEqual(expected_response, json.loads(response.data))
 
     def test_change_password_with_authentication_token_expired(self):

--- a/tests/users/test_api_change_password.py
+++ b/tests/users/test_api_change_password.py
@@ -103,7 +103,7 @@ class TestUserChangePasswordApi(BaseTestCase):
                 follow_redirects=True,
                 headers=self.auth_header,
             )
-            self.assertEqual(HTTPStatus.BAD_REQUEST , response.status_code)
+            self.assertEqual(HTTPStatus.BAD_REQUEST, response.status_code)
             self.assertEqual(expected_response, json.loads(response.data))
 
     def test_change_password_with_authentication_token_expired(self):

--- a/tests/users/test_api_get_other_user.py
+++ b/tests/users/test_api_get_other_user.py
@@ -47,7 +47,7 @@ class TestnGetOtherUserApi(BaseTestCase):
             follow_redirects=True,
             headers=auth_header,
         )
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_user_invalid_user_id_for_other_user(self):
@@ -55,7 +55,7 @@ class TestnGetOtherUserApi(BaseTestCase):
         actual_response = self.client.get(
             "/users/abc", follow_redirects=True, headers=auth_header
         )
-        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND, actual_response.status_code)
 
 
 if __name__ == "__main__":

--- a/tests/users/test_api_get_other_user.py
+++ b/tests/users/test_api_get_other_user.py
@@ -47,7 +47,7 @@ class TestnGetOtherUserApi(BaseTestCase):
             follow_redirects=True,
             headers=auth_header,
         )
-        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_user_invalid_user_id_for_other_user(self):
@@ -55,7 +55,7 @@ class TestnGetOtherUserApi(BaseTestCase):
         actual_response = self.client.get(
             "/users/abc", follow_redirects=True, headers=auth_header
         )
-        self.assertEqual(HTTPStatus.NOT_FOUND, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
 
 
 if __name__ == "__main__":

--- a/tests/users/test_api_home_statistics.py
+++ b/tests/users/test_api_home_statistics.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 from flask import json
-
+from http import HTTPStatus
 from app import messages
 from app.database.models.mentorship_relation import MentorshipRelationModel
 from app.database.models.tasks_list import TasksListModel
@@ -29,7 +29,7 @@ class TestHomeStatisticsApi(BaseTestCase):
     def test_relations_non_auth(self):
         expected_response = messages.AUTHORISATION_TOKEN_IS_MISSING
         actual_response = self.client.get("/home", follow_redirects=True)
-        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_relations_invalid_id(self):
@@ -39,7 +39,7 @@ class TestHomeStatisticsApi(BaseTestCase):
         actual_response = self.client.get(
             "/home", follow_redirects=True, headers=auth_header
         )
-        self.assertEqual(404, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
         self.assertEqual(messages.USER_NOT_FOUND, json.loads(actual_response.data))
 
     def test_pending_requests_auth(self):
@@ -75,7 +75,7 @@ class TestHomeStatisticsApi(BaseTestCase):
         actual_response = self.client.get(
             "/home", follow_redirects=True, headers=auth_header
         )
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_accepted_requests_auth(self):
@@ -111,7 +111,7 @@ class TestHomeStatisticsApi(BaseTestCase):
         actual_response = self.client.get(
             "/home", follow_redirects=True, headers=auth_header
         )
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_rejected_requests(self):
@@ -147,7 +147,7 @@ class TestHomeStatisticsApi(BaseTestCase):
         actual_response = self.client.get(
             "/home", follow_redirects=True, headers=auth_header
         )
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_completed_relations(self):
@@ -183,7 +183,7 @@ class TestHomeStatisticsApi(BaseTestCase):
         actual_response = self.client.get(
             "/home", follow_redirects=True, headers=auth_header
         )
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_cancelled_relations(self):
@@ -218,7 +218,7 @@ class TestHomeStatisticsApi(BaseTestCase):
         actual_response = self.client.get(
             "/home", follow_redirects=True, headers=auth_header
         )
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_achievements(self):
@@ -281,5 +281,5 @@ class TestHomeStatisticsApi(BaseTestCase):
         actual_response = self.client.get(
             "/home", follow_redirects=True, headers=auth_header
         )
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))

--- a/tests/users/test_api_home_statistics.py
+++ b/tests/users/test_api_home_statistics.py
@@ -29,7 +29,7 @@ class TestHomeStatisticsApi(BaseTestCase):
     def test_relations_non_auth(self):
         expected_response = messages.AUTHORISATION_TOKEN_IS_MISSING
         actual_response = self.client.get("/home", follow_redirects=True)
-        self.assertEqual(HTTPStatus.UNAUTHORIZED.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED , actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_relations_invalid_id(self):
@@ -39,7 +39,7 @@ class TestHomeStatisticsApi(BaseTestCase):
         actual_response = self.client.get(
             "/home", follow_redirects=True, headers=auth_header
         )
-        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND , actual_response.status_code)
         self.assertEqual(messages.USER_NOT_FOUND, json.loads(actual_response.data))
 
     def test_pending_requests_auth(self):
@@ -75,7 +75,7 @@ class TestHomeStatisticsApi(BaseTestCase):
         actual_response = self.client.get(
             "/home", follow_redirects=True, headers=auth_header
         )
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK , actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_accepted_requests_auth(self):
@@ -111,7 +111,7 @@ class TestHomeStatisticsApi(BaseTestCase):
         actual_response = self.client.get(
             "/home", follow_redirects=True, headers=auth_header
         )
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK , actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_rejected_requests(self):
@@ -147,7 +147,7 @@ class TestHomeStatisticsApi(BaseTestCase):
         actual_response = self.client.get(
             "/home", follow_redirects=True, headers=auth_header
         )
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_completed_relations(self):
@@ -183,7 +183,7 @@ class TestHomeStatisticsApi(BaseTestCase):
         actual_response = self.client.get(
             "/home", follow_redirects=True, headers=auth_header
         )
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_cancelled_relations(self):
@@ -218,7 +218,7 @@ class TestHomeStatisticsApi(BaseTestCase):
         actual_response = self.client.get(
             "/home", follow_redirects=True, headers=auth_header
         )
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_achievements(self):
@@ -281,5 +281,5 @@ class TestHomeStatisticsApi(BaseTestCase):
         actual_response = self.client.get(
             "/home", follow_redirects=True, headers=auth_header
         )
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))

--- a/tests/users/test_api_home_statistics.py
+++ b/tests/users/test_api_home_statistics.py
@@ -29,7 +29,7 @@ class TestHomeStatisticsApi(BaseTestCase):
     def test_relations_non_auth(self):
         expected_response = messages.AUTHORISATION_TOKEN_IS_MISSING
         actual_response = self.client.get("/home", follow_redirects=True)
-        self.assertEqual(HTTPStatus.UNAUTHORIZED , actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_relations_invalid_id(self):
@@ -39,7 +39,7 @@ class TestHomeStatisticsApi(BaseTestCase):
         actual_response = self.client.get(
             "/home", follow_redirects=True, headers=auth_header
         )
-        self.assertEqual(HTTPStatus.NOT_FOUND , actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND, actual_response.status_code)
         self.assertEqual(messages.USER_NOT_FOUND, json.loads(actual_response.data))
 
     def test_pending_requests_auth(self):
@@ -75,7 +75,7 @@ class TestHomeStatisticsApi(BaseTestCase):
         actual_response = self.client.get(
             "/home", follow_redirects=True, headers=auth_header
         )
-        self.assertEqual(HTTPStatus.OK , actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_accepted_requests_auth(self):
@@ -111,7 +111,7 @@ class TestHomeStatisticsApi(BaseTestCase):
         actual_response = self.client.get(
             "/home", follow_redirects=True, headers=auth_header
         )
-        self.assertEqual(HTTPStatus.OK , actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_rejected_requests(self):

--- a/tests/users/test_api_list_users.py
+++ b/tests/users/test_api_list_users.py
@@ -1,6 +1,6 @@
 import unittest
 from datetime import datetime, timedelta
-
+from http import HTTPStatus
 from flask import json
 from flask_restx import marshal
 
@@ -75,7 +75,7 @@ class TestListUsersApi(BaseTestCase):
         expected_response = messages.AUTHORISATION_TOKEN_IS_MISSING
         actual_response = self.client.get("/users", follow_redirects=True)
 
-        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_without_search_query_resource_auth(self):
@@ -89,7 +89,7 @@ class TestListUsersApi(BaseTestCase):
             "/users", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_with_a_search_query_resource_auth(self):
@@ -99,7 +99,7 @@ class TestListUsersApi(BaseTestCase):
             "/users?search=b", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_with_a_search_query_all_caps_resource_auth(self):
@@ -109,7 +109,7 @@ class TestListUsersApi(BaseTestCase):
             "/users?search=USERB", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_with_a_search_query_with_spaces_resource_auth(self):
@@ -121,7 +121,7 @@ class TestListUsersApi(BaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_with_search_with_special_characters_resource_auth(self):
@@ -133,7 +133,7 @@ class TestListUsersApi(BaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_with_a_page_query_resource_auth(self):
@@ -147,7 +147,7 @@ class TestListUsersApi(BaseTestCase):
             "/users?page=1", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_with_a_page_query_out_of_range_resource_auth(self):
@@ -157,7 +157,7 @@ class TestListUsersApi(BaseTestCase):
             "/users?page=2", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_with_a_page_and_per_page_query_resource_auth(self):
@@ -167,7 +167,7 @@ class TestListUsersApi(BaseTestCase):
             "/users?page=1&per_page=1", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_with_a_partial_page_and_per_page_query_resource_auth(self):
@@ -177,7 +177,7 @@ class TestListUsersApi(BaseTestCase):
             "/users?page=2&per_page=2", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_resource_verified_users(self):
@@ -187,7 +187,7 @@ class TestListUsersApi(BaseTestCase):
             "/users/verified", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_with_a_page_query_resource_verified_users(self):
@@ -197,7 +197,7 @@ class TestListUsersApi(BaseTestCase):
             "/users/verified?page=1", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_with_a_page_query_out_of_range_resource_verified_users(
@@ -209,7 +209,7 @@ class TestListUsersApi(BaseTestCase):
             "/users/verified?page=2", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_with_a_page_and_per_page_query_resource_verified_users(
@@ -223,7 +223,7 @@ class TestListUsersApi(BaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_with_a_page_and_empty_per_page_query_resource_verified_users(
@@ -237,7 +237,7 @@ class TestListUsersApi(BaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_relation(self):
@@ -257,7 +257,7 @@ class TestListUsersApi(BaseTestCase):
             "/users", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_with_a_search_query_with_username_resource_auth(self):
@@ -269,7 +269,7 @@ class TestListUsersApi(BaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
 

--- a/tests/users/test_api_list_users.py
+++ b/tests/users/test_api_list_users.py
@@ -75,7 +75,7 @@ class TestListUsersApi(BaseTestCase):
         expected_response = messages.AUTHORISATION_TOKEN_IS_MISSING
         actual_response = self.client.get("/users", follow_redirects=True)
 
-        self.assertEqual(HTTPStatus.UNAUTHORIZED.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_without_search_query_resource_auth(self):
@@ -89,7 +89,7 @@ class TestListUsersApi(BaseTestCase):
             "/users", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_with_a_search_query_resource_auth(self):
@@ -99,7 +99,7 @@ class TestListUsersApi(BaseTestCase):
             "/users?search=b", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_with_a_search_query_all_caps_resource_auth(self):
@@ -109,7 +109,7 @@ class TestListUsersApi(BaseTestCase):
             "/users?search=USERB", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_with_a_search_query_with_spaces_resource_auth(self):
@@ -121,7 +121,7 @@ class TestListUsersApi(BaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_with_search_with_special_characters_resource_auth(self):
@@ -133,7 +133,7 @@ class TestListUsersApi(BaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_with_a_page_query_resource_auth(self):
@@ -147,7 +147,7 @@ class TestListUsersApi(BaseTestCase):
             "/users?page=1", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_with_a_page_query_out_of_range_resource_auth(self):
@@ -157,7 +157,7 @@ class TestListUsersApi(BaseTestCase):
             "/users?page=2", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_with_a_page_and_per_page_query_resource_auth(self):
@@ -167,7 +167,7 @@ class TestListUsersApi(BaseTestCase):
             "/users?page=1&per_page=1", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_with_a_partial_page_and_per_page_query_resource_auth(self):
@@ -177,7 +177,7 @@ class TestListUsersApi(BaseTestCase):
             "/users?page=2&per_page=2", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_resource_verified_users(self):
@@ -187,7 +187,7 @@ class TestListUsersApi(BaseTestCase):
             "/users/verified", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_with_a_page_query_resource_verified_users(self):
@@ -197,7 +197,7 @@ class TestListUsersApi(BaseTestCase):
             "/users/verified?page=1", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_with_a_page_query_out_of_range_resource_verified_users(
@@ -209,7 +209,7 @@ class TestListUsersApi(BaseTestCase):
             "/users/verified?page=2", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_with_a_page_and_per_page_query_resource_verified_users(
@@ -223,7 +223,7 @@ class TestListUsersApi(BaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_with_a_page_and_empty_per_page_query_resource_verified_users(
@@ -237,7 +237,7 @@ class TestListUsersApi(BaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_relation(self):
@@ -257,7 +257,7 @@ class TestListUsersApi(BaseTestCase):
             "/users", follow_redirects=True, headers=auth_header
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_list_users_api_with_a_search_query_with_username_resource_auth(self):
@@ -269,7 +269,7 @@ class TestListUsersApi(BaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
 

--- a/tests/users/test_api_login.py
+++ b/tests/users/test_api_login.py
@@ -66,7 +66,7 @@ class TestUserLoginApi(BaseTestCase):
             self.assertEqual(1, len(response.json))
             self.assertEqual(messages.WRONG_USERNAME_OR_PASSWORD, response.json)
 
-            self.assertEqual(HTTPStatus.UNAUTHORIZED, response.status_code)
+            self.assertEqual(HTTPStatus.UNAUTHORIZED.value, response.status_code)
 
     def test_user_login_non_verified_user(self):
         with self.client:
@@ -87,7 +87,7 @@ class TestUserLoginApi(BaseTestCase):
             self.assertEqual(
                 messages.USER_HAS_NOT_VERIFIED_EMAIL_BEFORE_LOGIN, response.json
             )
-            self.assertEqual(403, response.status_code)
+            self.assertEqual(HTTPStatus.FORBIDDEN.value, response.status_code)
 
     def test_user_login_verified_user(self):
         with self.client:
@@ -104,7 +104,7 @@ class TestUserLoginApi(BaseTestCase):
             self.assertIsNotNone(response.json.get("refresh_token"))
             self.assertIsNotNone(response.json.get("refresh_expiry"))
             self.assertEqual(4, len(response.json))
-            self.assertEqual(200, response.status_code)
+            self.assertEqual(HTTPStatus.OK.value, response.status_code)
 
 
 if __name__ == "__main__":

--- a/tests/users/test_api_login.py
+++ b/tests/users/test_api_login.py
@@ -66,7 +66,7 @@ class TestUserLoginApi(BaseTestCase):
             self.assertEqual(1, len(response.json))
             self.assertEqual(messages.WRONG_USERNAME_OR_PASSWORD, response.json)
 
-            self.assertEqual(HTTPStatus.UNAUTHORIZED.value, response.status_code)
+            self.assertEqual(HTTPStatus.UNAUTHORIZED, response.status_code)
 
     def test_user_login_non_verified_user(self):
         with self.client:
@@ -87,7 +87,7 @@ class TestUserLoginApi(BaseTestCase):
             self.assertEqual(
                 messages.USER_HAS_NOT_VERIFIED_EMAIL_BEFORE_LOGIN, response.json
             )
-            self.assertEqual(HTTPStatus.FORBIDDEN.value, response.status_code)
+            self.assertEqual(HTTPStatus.FORBIDDEN, response.status_code)
 
     def test_user_login_verified_user(self):
         with self.client:
@@ -104,7 +104,7 @@ class TestUserLoginApi(BaseTestCase):
             self.assertIsNotNone(response.json.get("refresh_token"))
             self.assertIsNotNone(response.json.get("refresh_expiry"))
             self.assertEqual(4, len(response.json))
-            self.assertEqual(HTTPStatus.OK.value, response.status_code)
+            self.assertEqual(HTTPStatus.OK, response.status_code)
 
 
 if __name__ == "__main__":

--- a/tests/users/test_api_refresh.py
+++ b/tests/users/test_api_refresh.py
@@ -1,6 +1,6 @@
 import unittest
 from datetime import timedelta
-
+from http import HTTPStatus
 from flask import json
 
 from app import messages
@@ -42,13 +42,13 @@ class TestUserRefreshApi(BaseTestCase):
             self.assertIsNotNone(response.json.get("access_token"))
             self.assertIsNotNone(response.json.get("access_expiry"))
             self.assertEqual(2, len(response.json))
-            self.assertEqual(200, response.status_code)
+            self.assertEqual(HTTPStatus.OK.value, response.status_code)
 
     def test_user_refresh_without_header(self):
         expected_response = messages.AUTHORISATION_TOKEN_IS_MISSING
         actual_response = self.client.post("/refresh", follow_redirects=True)
 
-        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_user_refresh_invalid_token(self):
@@ -63,7 +63,7 @@ class TestUserRefreshApi(BaseTestCase):
                 content_type="application/json",
             )
 
-            self.assertEqual(401, actual_response.status_code)
+            self.assertEqual(HTTPStatus.UNAUTHORIZED.value, actual_response.status_code)
             self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_user_refresh_expired_token(self):
@@ -80,7 +80,7 @@ class TestUserRefreshApi(BaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
 

--- a/tests/users/test_api_refresh.py
+++ b/tests/users/test_api_refresh.py
@@ -42,13 +42,13 @@ class TestUserRefreshApi(BaseTestCase):
             self.assertIsNotNone(response.json.get("access_token"))
             self.assertIsNotNone(response.json.get("access_expiry"))
             self.assertEqual(2, len(response.json))
-            self.assertEqual(HTTPStatus.OK.value, response.status_code)
+            self.assertEqual(HTTPStatus.OK, response.status_code)
 
     def test_user_refresh_without_header(self):
         expected_response = messages.AUTHORISATION_TOKEN_IS_MISSING
         actual_response = self.client.post("/refresh", follow_redirects=True)
 
-        self.assertEqual(HTTPStatus.UNAUTHORIZED.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_user_refresh_invalid_token(self):
@@ -63,7 +63,7 @@ class TestUserRefreshApi(BaseTestCase):
                 content_type="application/json",
             )
 
-            self.assertEqual(HTTPStatus.UNAUTHORIZED.value, actual_response.status_code)
+            self.assertEqual(HTTPStatus.UNAUTHORIZED, actual_response.status_code)
             self.assertEqual(expected_response, json.loads(actual_response.data))
 
     def test_user_refresh_expired_token(self):
@@ -80,7 +80,7 @@ class TestUserRefreshApi(BaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(HTTPStatus.UNAUTHORIZED.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
 

--- a/tests/users/test_api_update_user.py
+++ b/tests/users/test_api_update_user.py
@@ -195,7 +195,7 @@ class TestUpdateUserApi(BaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(HTTPStatus.OK,actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
         self.assertEqual(test_need_mentoring, self.first_user.need_mentoring)
 

--- a/tests/users/test_api_update_user.py
+++ b/tests/users/test_api_update_user.py
@@ -46,7 +46,7 @@ class TestUpdateUserApi(BaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(HTTPStatus.BAD_REQUEST,, actual_response.status_code)
+        self.assertEqual(HTTPStatus.BAD_REQUEST, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_update_username_not_taken(self):

--- a/tests/users/test_api_update_user.py
+++ b/tests/users/test_api_update_user.py
@@ -19,7 +19,7 @@ class TestUpdateUserApi(BaseTestCase):
         expected_response = messages.AUTHORISATION_TOKEN_IS_MISSING
         actual_response = self.client.put("/user", follow_redirects=True)
 
-        self.assertEqual(HTTPStatus.UNAUTHORIZED.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_update_username_already_taken(self):
@@ -46,7 +46,7 @@ class TestUpdateUserApi(BaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(HTTPStatus.BAD_REQUEST.value,, actual_response.status_code)
+        self.assertEqual(HTTPStatus.BAD_REQUEST,, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_update_username_not_taken(self):
@@ -74,7 +74,7 @@ class TestUpdateUserApi(BaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
         self.assertEqual(user1_new_username, self.first_user.username)
 
@@ -113,7 +113,7 @@ class TestUpdateUserApi(BaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(HTTPStatus.BAD_REQUEST.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.BAD_REQUEST, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
         self.assertNotEqual(random_generated_username, self.first_user.username)
         self.assertEqual(user1["username"], self.first_user.username)
@@ -146,7 +146,7 @@ class TestUpdateUserApi(BaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
         self.assertEqual(test_mentor_availability, self.first_user.available_to_mentor)
@@ -159,7 +159,7 @@ class TestUpdateUserApi(BaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
         self.assertEqual(
@@ -195,7 +195,7 @@ class TestUpdateUserApi(BaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(HTTPStatus.OK.value,actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK,actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
         self.assertEqual(test_need_mentoring, self.first_user.need_mentoring)
 
@@ -225,7 +225,7 @@ class TestUpdateUserApi(BaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(HTTPStatus.BAD_REQUEST.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.BAD_REQUEST, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
 

--- a/tests/users/test_api_update_user.py
+++ b/tests/users/test_api_update_user.py
@@ -1,7 +1,7 @@
 import unittest
 from random import SystemRandom
 from string import ascii_lowercase
-
+from http import HTTPStatus
 from flask import json
 
 from app import messages
@@ -19,7 +19,7 @@ class TestUpdateUserApi(BaseTestCase):
         expected_response = messages.AUTHORISATION_TOKEN_IS_MISSING
         actual_response = self.client.put("/user", follow_redirects=True)
 
-        self.assertEqual(401, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_update_username_already_taken(self):
@@ -46,7 +46,7 @@ class TestUpdateUserApi(BaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(400, actual_response.status_code)
+        self.assertEqual(HTTPStatus.BAD_REQUEST.value,, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_update_username_not_taken(self):
@@ -74,7 +74,7 @@ class TestUpdateUserApi(BaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
         self.assertEqual(user1_new_username, self.first_user.username)
 
@@ -113,7 +113,7 @@ class TestUpdateUserApi(BaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(400, actual_response.status_code)
+        self.assertEqual(HTTPStatus.BAD_REQUEST.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
         self.assertNotEqual(random_generated_username, self.first_user.username)
         self.assertEqual(user1["username"], self.first_user.username)
@@ -146,7 +146,7 @@ class TestUpdateUserApi(BaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
         self.assertEqual(test_mentor_availability, self.first_user.available_to_mentor)
@@ -159,7 +159,7 @@ class TestUpdateUserApi(BaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
         self.assertEqual(
@@ -195,7 +195,7 @@ class TestUpdateUserApi(BaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(200, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK.value,actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
         self.assertEqual(test_need_mentoring, self.first_user.need_mentoring)
 
@@ -225,7 +225,7 @@ class TestUpdateUserApi(BaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(400, actual_response.status_code)
+        self.assertEqual(HTTPStatus.BAD_REQUEST.value, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
 

--- a/tests/users/test_dao.py
+++ b/tests/users/test_dao.py
@@ -66,7 +66,8 @@ class TestUserDao(BaseTestCase):
         self.assertTrue(user.is_email_verified)
         self.assertIsNotNone(user.email_verification_date)
         self.assertEqual(
-            (messages.ACCOUNT_ALREADY_CONFIRMED_AND_THANKS, HTTPStatus.OK ), actual_result
+            (messages.ACCOUNT_ALREADY_CONFIRMED_AND_THANKS, HTTPStatus.OK),
+            actual_result,
         )
 
     def test_dao_confirm_registration_bad_token(self):
@@ -96,7 +97,8 @@ class TestUserDao(BaseTestCase):
         self.assertFalse(user.is_email_verified)
         self.assertIsNone(user.email_verification_date)
         self.assertEqual(
-            (messages.EMAIL_EXPIRED_OR_TOKEN_IS_INVALID, HTTPStatus.BAD_REQUEST ), actual_result
+            (messages.EMAIL_EXPIRED_OR_TOKEN_IS_INVALID, HTTPStatus.BAD_REQUEST),
+            actual_result,
         )
 
     def test_dao_confirm_registration_of_already_verified_user(self):
@@ -124,7 +126,9 @@ class TestUserDao(BaseTestCase):
         actual_result = dao.confirm_registration(good_token)
 
         self.assertTrue(user.is_email_verified)
-        self.assertEqual((messages.ACCOUNT_ALREADY_CONFIRMED, HTTPStatus.OK ), actual_result)
+        self.assertEqual(
+            (messages.ACCOUNT_ALREADY_CONFIRMED, HTTPStatus.OK), actual_result
+        )
 
     def test_dao_delete_only_user_admin(self):
         dao = UserDAO()
@@ -140,7 +144,9 @@ class TestUserDao(BaseTestCase):
         self.assertTrue(after_delete_user.is_admin)
         self.assertIsNotNone(after_delete_user)
         self.assertEqual(1, after_delete_user.id)
-        self.assertEqual((messages.USER_CANT_DELETE, HTTPStatus.BAD_REQUEST), dao_result)
+        self.assertEqual(
+            (messages.USER_CANT_DELETE, HTTPStatus.BAD_REQUEST), dao_result
+        )
 
     def test_get_achievements(self):
         dao = UserDAO()

--- a/tests/users/test_dao.py
+++ b/tests/users/test_dao.py
@@ -1,7 +1,7 @@
 import datetime
 import unittest
 from werkzeug.security import check_password_hash
-
+from http import HTTPStatus
 from app import messages
 from app.api.email_utils import generate_confirmation_token
 from app.api.dao.user import UserDAO
@@ -66,7 +66,7 @@ class TestUserDao(BaseTestCase):
         self.assertTrue(user.is_email_verified)
         self.assertIsNotNone(user.email_verification_date)
         self.assertEqual(
-            (messages.ACCOUNT_ALREADY_CONFIRMED_AND_THANKS, 200), actual_result
+            (messages.ACCOUNT_ALREADY_CONFIRMED_AND_THANKS, HTTPStatus.OK.value), actual_result
         )
 
     def test_dao_confirm_registration_bad_token(self):
@@ -96,7 +96,7 @@ class TestUserDao(BaseTestCase):
         self.assertFalse(user.is_email_verified)
         self.assertIsNone(user.email_verification_date)
         self.assertEqual(
-            (messages.EMAIL_EXPIRED_OR_TOKEN_IS_INVALID, 400), actual_result
+            (messages.EMAIL_EXPIRED_OR_TOKEN_IS_INVALID, HTTPStatus.BAD_REQUEST.value), actual_result
         )
 
     def test_dao_confirm_registration_of_already_verified_user(self):
@@ -124,7 +124,7 @@ class TestUserDao(BaseTestCase):
         actual_result = dao.confirm_registration(good_token)
 
         self.assertTrue(user.is_email_verified)
-        self.assertEqual((messages.ACCOUNT_ALREADY_CONFIRMED, 200), actual_result)
+        self.assertEqual((messages.ACCOUNT_ALREADY_CONFIRMED, HTTPStatus.OK.value), actual_result)
 
     def test_dao_delete_only_user_admin(self):
         dao = UserDAO()
@@ -140,7 +140,7 @@ class TestUserDao(BaseTestCase):
         self.assertTrue(after_delete_user.is_admin)
         self.assertIsNotNone(after_delete_user)
         self.assertEqual(1, after_delete_user.id)
-        self.assertEqual((messages.USER_CANT_DELETE, 400), dao_result)
+        self.assertEqual((messages.USER_CANT_DELETE, HTTPStatus.BAD_REQUEST.value), dao_result)
 
     def test_get_achievements(self):
         dao = UserDAO()

--- a/tests/users/test_dao.py
+++ b/tests/users/test_dao.py
@@ -66,7 +66,7 @@ class TestUserDao(BaseTestCase):
         self.assertTrue(user.is_email_verified)
         self.assertIsNotNone(user.email_verification_date)
         self.assertEqual(
-            (messages.ACCOUNT_ALREADY_CONFIRMED_AND_THANKS, HTTPStatus.OK.value), actual_result
+            (messages.ACCOUNT_ALREADY_CONFIRMED_AND_THANKS, HTTPStatus.OK ), actual_result
         )
 
     def test_dao_confirm_registration_bad_token(self):
@@ -96,7 +96,7 @@ class TestUserDao(BaseTestCase):
         self.assertFalse(user.is_email_verified)
         self.assertIsNone(user.email_verification_date)
         self.assertEqual(
-            (messages.EMAIL_EXPIRED_OR_TOKEN_IS_INVALID, HTTPStatus.BAD_REQUEST.value), actual_result
+            (messages.EMAIL_EXPIRED_OR_TOKEN_IS_INVALID, HTTPStatus.BAD_REQUEST ), actual_result
         )
 
     def test_dao_confirm_registration_of_already_verified_user(self):
@@ -124,7 +124,7 @@ class TestUserDao(BaseTestCase):
         actual_result = dao.confirm_registration(good_token)
 
         self.assertTrue(user.is_email_verified)
-        self.assertEqual((messages.ACCOUNT_ALREADY_CONFIRMED, HTTPStatus.OK.value), actual_result)
+        self.assertEqual((messages.ACCOUNT_ALREADY_CONFIRMED, HTTPStatus.OK ), actual_result)
 
     def test_dao_delete_only_user_admin(self):
         dao = UserDAO()
@@ -140,7 +140,7 @@ class TestUserDao(BaseTestCase):
         self.assertTrue(after_delete_user.is_admin)
         self.assertIsNotNone(after_delete_user)
         self.assertEqual(1, after_delete_user.id)
-        self.assertEqual((messages.USER_CANT_DELETE, HTTPStatus.BAD_REQUEST.value), dao_result)
+        self.assertEqual((messages.USER_CANT_DELETE, HTTPStatus.BAD_REQUEST), dao_result)
 
     def test_get_achievements(self):
         dao = UserDAO()


### PR DESCRIPTION
### Description

<!--- Include a summary of the change and relevant motivation/context. List any dependencies that are required for this change. --->
This patch replaces the hardcoded response codes in tests/user with their corresponding HTTPStatus codes. This will help in better readability and scalability.
Fixes #957

### Type of Change:

- Documentation

### How Has This Been Tested?

Ran unit tests on local machine and they returned OK status.

### Checklist:

<!-- **Delete irrelevant options.** -->

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**

- [ ] My changes generate no new warnings 
- [ ] New and existing unit tests pass locally with my changes

