### PR TITLE
Fix: Multiple relation requests from a user to same member

### DIFF
--- a/app/api/dao/mentorship_relation.py
+++ b/app/api/dao/mentorship_relation.py
@@ -92,7 +92,17 @@ class MentorshipRelationDAO:
         )
         for relation in all_mentor_relations:
             if relation.state == MentorshipRelationState.ACCEPTED:
+                if relation.mentee_id == mentee_id:
+                    return (
+                        messages.RELATION_REQUEST_ALREADY_ACCEPTED,
+                        HTTPStatus.CONFLICT,
+                    )
                 return messages.MENTOR_ALREADY_IN_A_RELATION, HTTPStatus.BAD_REQUEST
+            elif (
+                relation.state == MentorshipRelationState.PENDING
+                and relation.mentee_id == mentee_id
+            ):
+                return messages.RELATION_REQUEST_ALREADY_PENDING, HTTPStatus.CONFLICT
 
         all_mentee_relations = (
             mentee_user.mentor_relations + mentee_user.mentee_relations

--- a/app/messages.py
+++ b/app/messages.py
@@ -83,6 +83,7 @@ MENTOR_NOT_AVAILABLE_TO_MENTOR = {
 }
 MENTOR_ALREADY_IN_A_RELATION = {"message": "Mentor user is already in a relationship."}
 
+
 # Mentee availability
 MENTEE_NOT_AVAIL_TO_BE_MENTORED = {
     "message": "Mentee user is not available" " to be mentored."
@@ -185,6 +186,12 @@ UNACCEPTED_STATE_RELATION = {
 }
 MENTORSHIP_RELATION_NOT_IN_ACCEPT_STATE = {
     "message": "Mentorship relation is" " not in the accepted state."
+}
+RELATION_REQUEST_ALREADY_PENDING = {
+    "message": "Mentorship request already has been sent already and is pending. "
+}
+RELATION_REQUEST_ALREADY_ACCEPTED = {
+    "message": "This Mentorship request was accepted. "
 }
 
 # Login errors

--- a/tests/mentorship_relation/test_api_send_request.py
+++ b/tests/mentorship_relation/test_api_send_request.py
@@ -89,6 +89,37 @@ class TestSendRequestApi(MentorshipRelationBaseTestCase):
         self.assertEqual(HTTPStatus.BAD_REQUEST, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
+    # When a mentee tries to send request multiple time to same mentor
+    def test_fail_send_multiple_request_to_same_mentor(self):
+        auth_header = get_test_request_header(self.first_user.id)
+        expected_response = messages.MENTORSHIP_RELATION_WAS_SENT_SUCCESSFULLY
+        test_payload = {
+            "mentor_id": self.second_user.id,
+            "mentee_id": self.first_user.id,
+            "end_date": int((datetime.now() + timedelta(days=40)).timestamp()),
+            "notes": "some notes",
+        }
+        # First request (sent successfully)
+        actual_response = self.client.post(
+            "/mentorship_relation/send_request",
+            headers=auth_header,
+            content_type="application/json",
+            data=json.dumps(test_payload),
+        )
+        self.assertEqual(HTTPStatus.CREATED, actual_response.status_code)
+        self.assertDictEqual(expected_response, json.loads(actual_response.data))
+
+        expected_response = messages.RELATION_REQUEST_ALREADY_PENDING
+        # Second request (not created)
+        actual_response = self.client.post(
+            "/mentorship_relation/send_request",
+            headers=auth_header,
+            content_type="application/json",
+            data=json.dumps(test_payload),
+        )
+        self.assertEqual(HTTPStatus.CONFLICT, actual_response.status_code)
+        self.assertDictEqual(expected_response, json.loads(actual_response.data))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description
A user was able to send multiple mentorship request to the same member. 

So, I added a check on relation.state and returned HTTPS.CONFLICT  
Fixes #866 

### Type of Change:
- Code


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
Manually through postman
Ran all tests
![Screenshot from 2021-02-03 22-08-14](https://user-images.githubusercontent.com/58214248/106778797-5bf1b380-666c-11eb-9709-a0cf339d6fd0.png)

### Mocks
 ![Screenshot from 2021-02-03 22-09-34](https://user-images.githubusercontent.com/58214248/106778993-8b082500-666c-11eb-8a1d-3267f0d31fab.png)


### Checklist:

- [X] My PR follows the style guidelines of this project
- [X] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**

- [X] My changes generate no new warnings 



