### PR TITLE
test: Create user journey for request deletion

### DIFF
--- a/tests/user_journey/test_request_deletion_path.py
+++ b/tests/user_journey/test_request_deletion_path.py
@@ -1,0 +1,115 @@
+import unittest
+from datetime import datetime, timedelta
+from http import HTTPStatus
+
+from flask import json
+from flask_restx import marshal
+
+from app import messages
+from app.api.models.user import public_user_api_model
+from app.database.models.mentorship_relation import MentorshipRelationModel
+from app.utils.enum_utils import MentorshipRelationState
+from app.database.models.tasks_list import TasksListModel
+from app.database.models.user import UserModel
+from app.database.sqlalchemy_extension import db
+from app.utils.enum_utils import MentorshipRelationState
+from tests.base_test_case import BaseTestCase
+from tests.test_utils import get_test_request_header
+from tests.test_data import user1, user2
+from app.api.models.mentorship_relation import mentorship_request_response_body
+
+
+class TestRequestDeletionPath(BaseTestCase):
+    """
+    Scenario: User A (mentor) and User B (mentee). The mentee sends
+    a mentorship request to the mentor and then deletes the request.
+    - User B (mentee) sends a request to User A (mentor)
+    - User B (mentee) deletes the request
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        # Defining mentor for this test
+        self.mentor = UserModel(
+            name="Mentor A",
+            email=user1["email"],
+            username=user1["username"],
+            password=user1["password"],
+            terms_and_conditions_checked=user1["terms_and_conditions_checked"],
+        )
+
+        # Defining mentee for this test
+        self.mentee = UserModel(
+            name="Mentee B",
+            email=user2["email"],
+            username=user2["username"],
+            password=user2["password"],
+            terms_and_conditions_checked=user2["terms_and_conditions_checked"],
+        )
+
+        self.mentor.is_email_verified = True
+        self.mentor.available_to_mentor = True
+        self.mentee.is_email_verified = True
+        self.mentee.need_mentoring = True
+
+        db.session.add(self.mentor)
+        db.session.add(self.mentee)
+        db.session.commit()
+
+        self.test_description = "A request for mentorship"
+
+    def test_deletion_path(self):
+
+        mentor_auth_header = get_test_request_header(self.mentor.id)
+        mentee_auth_header = get_test_request_header(self.mentee.id)
+
+        # The mentee sends a new mentorship request to the mentor
+        request_body = {
+            "mentor_id": self.mentor.id,
+            "mentee_id": self.mentee.id,
+            "end_date": int((datetime.now() + timedelta(weeks=5)).timestamp()),
+            "notes": self.test_description,
+        }
+        send_request_response = self.client.post(
+            "/mentorship_relation/send_request",
+            headers=mentee_auth_header,
+            content_type="application/json",
+            data=json.dumps(request_body),
+        )
+
+        self.assertEqual(HTTPStatus.CREATED, send_request_response.status_code)
+
+        # Receiving the mentorship request on the mentor's side
+        received_requests_response = self.client.get(
+            "/mentorship_relations",
+            headers=mentor_auth_header,
+            content_type="application/json",
+        )
+        requests = json.loads(received_requests_response.data)
+        request_id = requests[0]["id"]
+
+        self.assertIsNotNone(request_id)
+
+        ## The mentee deletes the request by themself
+        deletion_response = self.client.delete(
+            f"/mentorship_relation/{request_id}", headers=mentee_auth_header
+        )
+        deletion_request = json.loads(deletion_response.data)
+        self.assertEqual(
+            messages.MENTORSHIP_RELATION_WAS_DELETED_SUCCESSFULLY, deletion_request
+        )
+        self.assertEqual(HTTPStatus.OK, deletion_response.status_code)
+
+        # Checking the mentorship request on the mentor's side(if it's still visible)
+        received_requests_response = self.client.get(
+            "/mentorship_relations",
+            headers=mentor_auth_header,
+            content_type="application/json",
+        )
+        requests = json.loads(received_requests_response.data)
+        self.assertEqual(len(requests), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description

This patch creates a user journey test depicting the process of sending a new mentorship request by a mentee to a mentor. The mentee then deletes the request sent. 


Fixes #911 

### Type of Change:

<!--- **Delete irrelevant options.** --->

- Code
- Quality Assurance


**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?

![Screenshot from 2021-02-18 21-32-34](https://user-images.githubusercontent.com/58214248/108385084-5205ae00-7231-11eb-8def-fa8ca2a65649.png)



### Checklist:

<!-- **Delete irrelevant options.** -->

- [X] My PR follows the style guidelines of this project
- [X] I have performed a self-review of my own code or materials
- [X] I have commented on my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

**Code/Quality Assurance Only**

- [X] My changes generate no new warnings 
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
