### PR TITLE
Bugfix: Fix response message when user is not the creator of the mentorship request

### DIFF
--- a/app/api/dao/mentorship_relation.py
+++ b/app/api/dao/mentorship_relation.py
@@ -335,13 +335,13 @@ class MentorshipRelationDAO:
                 HTTPStatus.NOT_FOUND,
             )
 
+        # verify if user created the mentorship request
+        if request.action_user_id != user_id:
+            return messages.CANT_DELETE_REQUEST_YOU_DIDNT_CREATE, HTTPStatus.FORBIDDEN
+
         # verify if request is in pending state
         if request.state != MentorshipRelationState.PENDING:
             return messages.NOT_PENDING_STATE_RELATION, HTTPStatus.FORBIDDEN
-
-        # verify if user created the mentorship request
-        if request.action_user_id != user_id:
-            return messages.CANT_DELETE_UNINVOLVED_REQUEST, HTTPStatus.FORBIDDEN
 
         # All was checked
         request.delete_from_db()

--- a/app/api/resources/mentorship_relation.py
+++ b/app/api/resources/mentorship_relation.py
@@ -319,7 +319,7 @@ class DeleteMentorshipRelation(Resource):
     @mentorship_relation_ns.response(
         HTTPStatus.FORBIDDEN,
         f"{messages.NOT_PENDING_STATE_RELATION}\n"
-        f"{messages.CANT_DELETE_UNINVOLVED_REQUEST}",
+        f"{messages.CANT_DELETE_REQUEST_YOU_DIDNT_CREATE}",
     )
     @mentorship_relation_ns.response(
         HTTPStatus.UNAUTHORIZED,

--- a/app/messages.py
+++ b/app/messages.py
@@ -137,7 +137,7 @@ CANT_REJECT_UNINVOLVED_RELATION_REQUEST = {
 CANT_CANCEL_UNINVOLVED_REQUEST = {
     "message": "You cannot cancel a mentorship" " relation where you are not involved."
 }
-CANT_DELETE_UNINVOLVED_REQUEST = {
+CANT_DELETE_REQUEST_YOU_DIDNT_CREATE = {
     "message": "You cannot delete a mentorship" " request that you did not create."
 }
 NOT_IN_MENTORED_RELATION_CURRENTLY = {

--- a/tests/mentorship_relation/test_api_delete_request.py
+++ b/tests/mentorship_relation/test_api_delete_request.py
@@ -81,7 +81,7 @@ class TestDeleteMentorshipRequestApi(MentorshipRelationBaseTestCase):
             )
         self.assertEqual(HTTPStatus.FORBIDDEN, response.status_code)
         self.assertDictEqual(
-            messages.CANT_DELETE_UNINVOLVED_REQUEST, json.loads(response.data)
+            messages.CANT_DELETE_REQUEST_YOU_DIDNT_CREATE, json.loads(response.data)
         )
         self.assertIsNotNone(
             MentorshipRelationModel.query.filter_by(id=request_id).first()

--- a/tests/mentorship_relation/test_dao_delete_request.py
+++ b/tests/mentorship_relation/test_dao_delete_request.py
@@ -146,66 +146,28 @@ class TestMentorshipRelationDeleteDAO(BaseTestCase):
         self,
     ):
         relation_id = self.mentorship_relation.id
+        relation_states = [
+            relation_state
+            for relation_state in MentorshipRelationState
+            if relation_state != MentorshipRelationState.PENDING
+        ]
 
-        self.mentorship_relation.state = MentorshipRelationState.ACCEPTED
-        db.session.add(self.mentorship_relation)
-        db.session.commit()
+        for relation_state in relation_states:
+            # persist the mentorship_relation
+            self.mentorship_relation.state = relation_state
+            db.session.add(self.mentorship_relation)
+            db.session.commit()
 
-        result = MentorshipRelationDAO.delete_request(
-            self.second_user.id, self.mentorship_relation.id
-        )
-        self.assertEqual(
-            (messages.CANT_DELETE_REQUEST_YOU_DIDNT_CREATE, HTTPStatus.FORBIDDEN),
-            result,
-        )
-        self.assertIsNotNone(
-            MentorshipRelationModel.query.filter_by(id=relation_id).first()
-        )
-
-        self.mentorship_relation.state = MentorshipRelationState.COMPLETED
-        db.session.add(self.mentorship_relation)
-        db.session.commit()
-
-        result = MentorshipRelationDAO.delete_request(
-            self.second_user.id, self.mentorship_relation.id
-        )
-        self.assertEqual(
-            (messages.CANT_DELETE_REQUEST_YOU_DIDNT_CREATE, HTTPStatus.FORBIDDEN),
-            result,
-        )
-        self.assertIsNotNone(
-            MentorshipRelationModel.query.filter_by(id=relation_id).first()
-        )
-
-        self.mentorship_relation.state = MentorshipRelationState.CANCELLED
-        db.session.add(self.mentorship_relation)
-        db.session.commit()
-
-        result = MentorshipRelationDAO.delete_request(
-            self.second_user.id, self.mentorship_relation.id
-        )
-        self.assertEqual(
-            (messages.CANT_DELETE_REQUEST_YOU_DIDNT_CREATE, HTTPStatus.FORBIDDEN),
-            result,
-        )
-        self.assertIsNotNone(
-            MentorshipRelationModel.query.filter_by(id=relation_id).first()
-        )
-
-        self.mentorship_relation.state = MentorshipRelationState.REJECTED
-        db.session.add(self.mentorship_relation)
-        db.session.commit()
-
-        result = MentorshipRelationDAO.delete_request(
-            self.second_user.id, self.mentorship_relation.id
-        )
-        self.assertEqual(
-            (messages.CANT_DELETE_REQUEST_YOU_DIDNT_CREATE, HTTPStatus.FORBIDDEN),
-            result,
-        )
-        self.assertIsNotNone(
-            MentorshipRelationModel.query.filter_by(id=relation_id).first()
-        )
+            result = MentorshipRelationDAO.delete_request(
+                self.second_user.id, self.mentorship_relation.id
+            )
+            self.assertEqual(
+                (messages.CANT_DELETE_REQUEST_YOU_DIDNT_CREATE, HTTPStatus.FORBIDDEN),
+                result,
+            )
+            self.assertIsNotNone(
+                MentorshipRelationModel.query.filter_by(id=relation_id).first()
+            )
 
     def test_dao_mentorship_delete_request_not_in_pending_state(self):
         relation_id = self.mentorship_relation.id


### PR DESCRIPTION
### Description

Fixes the response message when the user is not the creator of the mentorship request.
Fixes #771.

### Type of Change:
- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
1. Tested through Swagger UI:
- Case 1:  the user didn't create the mentorship request
![image](https://user-images.githubusercontent.com/16724101/108741618-33582d80-7537-11eb-8c70-e4639f1365f8.png)
- Case 2: creator deleted the request
![image](https://user-images.githubusercontent.com/16724101/108743314-f68d3600-7538-11eb-92d6-0da4f15b5cd0.png)
- Case 3: mentorship request is not in the `pending` state
![image](https://user-images.githubusercontent.com/16724101/108744190-f0e42000-7539-11eb-9a25-6607b8a31ad8.png)
- Case 4: the user was part of the mentorship request, but not the creator
![image](https://user-images.githubusercontent.com/16724101/108744325-17a25680-753a-11eb-8578-57ff1e900c50.png)

2. Unit tests pass (all of them) -> especially observed one that tests this feature
### Checklist:

<!-- **Delete irrelevant options.** -->

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**

- [x] My changes generate no new warnings 
- [x] New and existing unit tests pass locally with my changes

