### PR TITLE
refactor: remove redundant usage of .value

### DIFF
--- a/tests/task_comments/test_api_create_task_comment.py
+++ b/tests/task_comments/test_api_create_task_comment.py
@@ -27,7 +27,7 @@ class TestCreateTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(example="example")),
         )
 
-        self.assertEqual(HTTPStatus.BAD_REQUEST.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.BAD_REQUEST, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_creation_api_with_comment_not_string(self):
@@ -41,7 +41,7 @@ class TestCreateTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(comment=5)),
         )
 
-        self.assertEqual(HTTPStatus.BAD_REQUEST.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.BAD_REQUEST, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_creation_api_with_comment_too_long(self):
@@ -59,7 +59,7 @@ class TestCreateTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(comment="a" * 500)),
         )
 
-        self.assertEqual(HTTPStatus.BAD_REQUEST.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.BAD_REQUEST, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_creation_api_with_relation_not_existing(self):
@@ -73,7 +73,7 @@ class TestCreateTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(comment="comment")),
         )
 
-        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_creation_api_with_task_not_existing(self):
@@ -87,7 +87,7 @@ class TestCreateTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(comment="comment")),
         )
 
-        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_full_task_comment_creation_api(self):
@@ -104,7 +104,7 @@ class TestCreateTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(comment="comment")),
         )
 
-        self.assertEqual(HTTPStatus.CREATED.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.CREATED, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
         new_comment = TaskCommentDAO.get_task_comment(1, 1)[0]

--- a/tests/task_comments/test_api_delete_task_comment.py
+++ b/tests/task_comments/test_api_delete_task_comment.py
@@ -35,7 +35,7 @@ class TestDeleteTaskCommentApi(TasksBaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(HTTPStatus.UNAUTHORIZED.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_deletion_api_user_not_involved(self):
@@ -49,7 +49,7 @@ class TestDeleteTaskCommentApi(TasksBaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(HTTPStatus.UNAUTHORIZED.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_deletion_api_not_created_by_user(self):
@@ -63,7 +63,7 @@ class TestDeleteTaskCommentApi(TasksBaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(HTTPStatus.FORBIDDEN.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.FORBIDDEN, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_deletion_api_with_relation_not_existing(self):
@@ -76,7 +76,7 @@ class TestDeleteTaskCommentApi(TasksBaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_deletion_api_with_task_not_existing(self):
@@ -90,7 +90,7 @@ class TestDeleteTaskCommentApi(TasksBaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_deletion_api_with_comment_not_existing(self):
@@ -103,7 +103,7 @@ class TestDeleteTaskCommentApi(TasksBaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_modification_api_with_wrong_task_id(self):
@@ -117,7 +117,7 @@ class TestDeleteTaskCommentApi(TasksBaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_deletion_api(self):
@@ -131,12 +131,12 @@ class TestDeleteTaskCommentApi(TasksBaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
         modified_comment = TaskCommentDAO.get_task_comment(1, 1)
         self.assertEqual(modified_comment[0], messages.TASK_COMMENT_DOES_NOT_EXIST)
-        self.assertEqual(modified_comment[1], HTTPStatus.NOT_FOUND.value)
+        self.assertEqual(modified_comment[1], HTTPStatus.NOT_FOUND)
 
     if __name__ == "__main__":
         unittest.main()

--- a/tests/task_comments/test_api_get_task_comments.py
+++ b/tests/task_comments/test_api_get_task_comments.py
@@ -35,7 +35,7 @@ class TestGetTaskCommentsApi(TasksBaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(HTTPStatus.UNAUTHORIZED.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.UNAUTHORIZED, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_listing_api_with_task_not_existing(self):
@@ -48,7 +48,7 @@ class TestGetTaskCommentsApi(TasksBaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_listing_api_with_relation_not_existing(self):
@@ -61,7 +61,7 @@ class TestGetTaskCommentsApi(TasksBaseTestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_listing_api(self):
@@ -76,7 +76,7 @@ class TestGetTaskCommentsApi(TasksBaseTestCase):
             headers=auth_header,
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(json.loads(actual_response.data), expected_response)
 
     if __name__ == "__main__":

--- a/tests/task_comments/test_api_modify_task_comment.py
+++ b/tests/task_comments/test_api_modify_task_comment.py
@@ -40,7 +40,7 @@ class TestModifyTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(example="example")),
         )
 
-        self.assertEqual(HTTPStatus.BAD_REQUEST.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.BAD_REQUEST, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_modification_api_with_comment_too_long(self):
@@ -59,7 +59,7 @@ class TestModifyTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(comment="a" * 500)),
         )
 
-        self.assertEqual(HTTPStatus.BAD_REQUEST.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.BAD_REQUEST, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_modification_api_with_comment_not_string(self):
@@ -74,7 +74,7 @@ class TestModifyTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(comment=5)),
         )
 
-        self.assertEqual(HTTPStatus.BAD_REQUEST.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.BAD_REQUEST, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_modification_api_not_created_by_user(self):
@@ -89,7 +89,7 @@ class TestModifyTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(comment="comment")),
         )
 
-        self.assertEqual(HTTPStatus.FORBIDDEN.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.FORBIDDEN, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_modification_api_with_relation_not_existing(self):
@@ -103,7 +103,7 @@ class TestModifyTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(comment="comment")),
         )
 
-        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_modification_api_with_task_not_existing(self):
@@ -118,7 +118,7 @@ class TestModifyTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(comment="comment")),
         )
 
-        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_modification_api_with_comment_not_existing(self):
@@ -132,7 +132,7 @@ class TestModifyTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(comment="comment")),
         )
 
-        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_task_comment_modification_api_with_wrong_task_id(self):
@@ -147,7 +147,7 @@ class TestModifyTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(comment="comment")),
         )
 
-        self.assertEqual(HTTPStatus.NOT_FOUND.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.NOT_FOUND, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
     def test_full_task_comment_modification_api(self):
@@ -162,7 +162,7 @@ class TestModifyTaskCommentApi(TasksBaseTestCase):
             data=json.dumps(dict(comment="Modified comment.")),
         )
 
-        self.assertEqual(HTTPStatus.OK.value, actual_response.status_code)
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
         modified_comment = TaskCommentDAO.get_task_comment(1, 1)[0]


### PR DESCRIPTION
### Description

Removed redundant usage of .value in assertEqual methods. 

Fixes #1010

### Type of Change:

- Code

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

