### PR TITLE
Remove expiry

### DIFF
--- a/app/api/models/user.py
+++ b/app/api/models/user.py
@@ -158,14 +158,8 @@ login_response_body_model = Model(
     "Login response data model",
     {
         "access_token": fields.String(required=True, description="User's access token"),
-        "access_expiry": fields.Float(
-            required=True, description="Access token expiry UNIX timestamp"
-        ),
         "refresh_token": fields.String(
             required=True, description="User's refresh token"
-        ),
-        "refresh_expiry": fields.Float(
-            required=True, description="Refresh token expiry UNIX timestamp"
         ),
     },
 )
@@ -174,9 +168,6 @@ refresh_response_body_model = Model(
     "Refresh response data model",
     {
         "access_token": fields.String(required=True, description="User's access token"),
-        "access_expiry": fields.Float(
-            required=True, description="Access token expiry UNIX timestamp"
-        ),
     },
 )
 

--- a/app/api/resources/user.py
+++ b/app/api/resources/user.py
@@ -428,20 +428,14 @@ class RefreshUser(Resource):
     def post(cls):
         """Refresh user's access
 
-        The return value is an access token and the expiry timestamp.
+        The return value is an access token.
         The token is valid for 1 week.
         """
         user_id = get_jwt_identity()
         access_token = create_access_token(identity=user_id)
 
-        from run import application
-
-        access_expiry = datetime.utcnow() + application.config.get(
-            "JWT_ACCESS_TOKEN_EXPIRES"
-        )
-
         return (
-            {"access_token": access_token, "access_expiry": access_expiry.timestamp()},
+            {"access_token": access_token},
             HTTPStatus.OK,
         )
 
@@ -472,7 +466,7 @@ class LoginUser(Resource):
 
         The user can login with (username or email) + password.
         Username field can be either the User's username or the email.
-        The return value is an access token and the expiry timestamp.
+        The return value is an access token.
         The token is valid for 1 week.
         """
         # if not request.is_json:
@@ -500,21 +494,10 @@ class LoginUser(Resource):
         access_token = create_access_token(identity=user.id)
         refresh_token = create_refresh_token(identity=user.id)
 
-        from run import application
-
-        access_expiry = datetime.utcnow() + application.config.get(
-            "JWT_ACCESS_TOKEN_EXPIRES"
-        )
-        refresh_expiry = datetime.utcnow() + application.config.get(
-            "JWT_REFRESH_TOKEN_EXPIRES"
-        )
-
         return (
             {
                 "access_token": access_token,
-                "access_expiry": access_expiry.timestamp(),
                 "refresh_token": refresh_token,
-                "refresh_expiry": refresh_expiry.timestamp(),
             },
             HTTPStatus.OK,
         )

--- a/tests/users/test_api_login.py
+++ b/tests/users/test_api_login.py
@@ -59,9 +59,7 @@ class TestUserLoginApi(BaseTestCase):
             )
 
             self.assertIsNone(response.json.get("access_token"))
-            #self.assertIsNone(response.json.get("access_expiry"))
             self.assertIsNone(response.json.get("refresh_token"))
-            #self.assertIsNone(response.json.get("refresh_expiry"))
 
             self.assertEqual(1, len(response.json))
             self.assertEqual(messages.WRONG_USERNAME_OR_PASSWORD, response.json)
@@ -80,9 +78,7 @@ class TestUserLoginApi(BaseTestCase):
             )
 
             self.assertIsNone(response.json.get("access_token"))
-            #self.assertIsNone(response.json.get("access_expiry"))
             self.assertIsNone(response.json.get("refresh_token"))
-            #self.assertIsNone(response.json.get("refresh_expiry"))
             self.assertEqual(1, len(response.json))
             self.assertEqual(
                 messages.USER_HAS_NOT_VERIFIED_EMAIL_BEFORE_LOGIN, response.json
@@ -100,9 +96,7 @@ class TestUserLoginApi(BaseTestCase):
                 content_type="application/json",
             )
             self.assertIsNotNone(response.json.get("access_token"))
-            #self.assertIsNotNone(response.json.get("access_expiry"))
             self.assertIsNotNone(response.json.get("refresh_token"))
-            #self.assertIsNotNone(response.json.get("refresh_expiry"))
             self.assertEqual(2, len(response.json))
             self.assertEqual(HTTPStatus.OK, response.status_code)
 

--- a/tests/users/test_api_login.py
+++ b/tests/users/test_api_login.py
@@ -100,9 +100,9 @@ class TestUserLoginApi(BaseTestCase):
                 content_type="application/json",
             )
             self.assertIsNotNone(response.json.get("access_token"))
-            self.assertIsNotNone(response.json.get("access_expiry"))
+            #self.assertIsNotNone(response.json.get("access_expiry"))
             self.assertIsNotNone(response.json.get("refresh_token"))
-            self.assertIsNotNone(response.json.get("refresh_expiry"))
+            #self.assertIsNotNone(response.json.get("refresh_expiry"))
             self.assertEqual(4, len(response.json))
             self.assertEqual(HTTPStatus.OK, response.status_code)
 

--- a/tests/users/test_api_refresh.py
+++ b/tests/users/test_api_refresh.py
@@ -40,7 +40,7 @@ class TestUserRefreshApi(BaseTestCase):
             )
 
             self.assertIsNotNone(response.json.get("access_token"))
-            self.assertIsNotNone(response.json.get("access_expiry"))
+            #self.assertIsNotNone(response.json.get("access_expiry"))
             self.assertEqual(2, len(response.json))
             self.assertEqual(HTTPStatus.OK, response.status_code)
 

--- a/tests/users/test_api_refresh.py
+++ b/tests/users/test_api_refresh.py
@@ -40,7 +40,6 @@ class TestUserRefreshApi(BaseTestCase):
             )
 
             self.assertIsNotNone(response.json.get("access_token"))
-            #self.assertIsNotNone(response.json.get("access_expiry"))
             self.assertEqual(1, len(response.json))
             self.assertEqual(HTTPStatus.OK, response.status_code)
 


### PR DESCRIPTION
### Description

Remove expiry time of access and refresh from responses of login and refresh endpoints.

Fixes #1009

### Type of Change:

- Code: 

1. access_expiry and refresh_expiry removed from login endpoint as well as login_response_body_model.
2. access_expiry has been removed from refresh endpoint as well as refresh_response_body_model.
3. doc strings are also removed for access_expiry and refresh_expiry.

### How Has This Been Tested?

It has been tested locally on my system.

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged
- [ ] Update Postman API at /docs folder
- [ ] Update Swagger documentation and the exported file at /docs folder

**Code/Quality Assurance Only**

- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
