### PR TITLE
display last 3 achievements

### DIFF
--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -462,9 +462,9 @@ class UserDAO:
 
         achievements = UserDAO.get_achievements(user_id)
         if achievements:
-            # We only need the first three of these achievements
-            achievements = achievements[0:3]
-            sorted(achievements, key=itemgetter("created_at"))
+            # We only need the last three of these achievements
+            achievements = achievements[-3:]
+            achievements.sort(key=itemgetter("completed_at"), reverse=True)
 
         response = {
             "name": user.name,

--- a/tests/users/test_api_home_statistics.py
+++ b/tests/users/test_api_home_statistics.py
@@ -295,9 +295,9 @@ class TestHomeStatisticsApi(BaseTestCase):
         tasks_list = TasksListModel()
         task_created_time = datetime.utcnow().timestamp()
         task_completed_time = task_created_time + 100
-        for i in range(5):
+        for i in range(1, 5):
             tasks_list.add_task(
-                description="Test task " + i,
+                description="Test task " + str(i),
                 created_at=task_created_time,
                 is_done=True,
                 completed_at=task_completed_time + (i * 60),

--- a/tests/users/test_api_home_statistics.py
+++ b/tests/users/test_api_home_statistics.py
@@ -297,10 +297,10 @@ class TestHomeStatisticsApi(BaseTestCase):
         task_completed_time = task_created_time + 100
         for i in range(5):
             tasks_list.add_task(
-                description="Test task "+i,
+                description="Test task " + i,
                 created_at=task_created_time,
                 is_done=True,
-                completed_at=task_completed_time+(i*60),
+                completed_at=task_completed_time + (i * 60),
             )
         db.session.add(tasks_list)
         db.session.commit()
@@ -328,26 +328,26 @@ class TestHomeStatisticsApi(BaseTestCase):
             "cancelled_relations": 0,
             "achievements": [
                 {
-                    "completed_at": task_completed_time+4*60,
+                    "completed_at": task_completed_time + 4 * 60,
                     "created_at": task_created_time,
                     "description": "Test task 4",
                     "id": 4,
                     "is_done": True,
                 },
                 {
-                    "completed_at": task_completed_time+3*60,
+                    "completed_at": task_completed_time + 3 * 60,
                     "created_at": task_created_time,
                     "description": "Test task 3",
                     "id": 3,
                     "is_done": True,
                 },
                 {
-                    "completed_at": task_completed_time+2*60,
+                    "completed_at": task_completed_time + 2 * 60,
                     "created_at": task_created_time,
                     "description": "Test task 2",
                     "id": 2,
                     "is_done": True,
-                }
+                },
             ],
         }
         auth_header = get_test_request_header(self.user1.id)

--- a/tests/users/test_api_home_statistics.py
+++ b/tests/users/test_api_home_statistics.py
@@ -223,7 +223,7 @@ class TestHomeStatisticsApi(BaseTestCase):
         self.assertEqual(HTTPStatus.OK, actual_response.status_code)
         self.assertEqual(expected_response, json.loads(actual_response.data))
 
-    def test_achievements(self):
+    def test_achievements_incomplete(self):
         start_date = datetime.utcnow()
         end_date = start_date + timedelta(weeks=4)
         start_date = start_date.timestamp()
@@ -275,6 +275,77 @@ class TestHomeStatisticsApi(BaseTestCase):
                     "created_at": task_created_time,
                     "description": "Test task",
                     "id": 1,  # This is the only task in the list
+                    "is_done": True,
+                }
+            ],
+        }
+        auth_header = get_test_request_header(self.user1.id)
+        actual_response = self.client.get(
+            "/home", follow_redirects=True, headers=auth_header
+        )
+        self.assertEqual(HTTPStatus.OK, actual_response.status_code)
+        self.assertEqual(expected_response, json.loads(actual_response.data))
+
+    def test_achievements_last_three(self):
+        start_date = datetime.utcnow()
+        end_date = start_date + timedelta(weeks=4)
+        start_date = start_date.timestamp()
+        end_date = end_date.timestamp()
+
+        tasks_list = TasksListModel()
+        task_created_time = datetime.utcnow().timestamp()
+        task_completed_time = task_created_time + 100
+        for i in range(5):
+            tasks_list.add_task(
+                description="Test task "+i,
+                created_at=task_created_time,
+                is_done=True,
+                completed_at=task_completed_time+(i*60),
+            )
+        db.session.add(tasks_list)
+        db.session.commit()
+
+        mentorship_relation = MentorshipRelationModel(
+            action_user_id=self.user2.id,
+            mentor_user=self.user1,
+            mentee_user=self.user2,
+            creation_date=start_date,
+            end_date=end_date,
+            state=MentorshipRelationState.ACCEPTED,
+            notes="",
+            tasks_list=tasks_list,
+        )
+
+        db.session.add(mentorship_relation)
+        db.session.commit()
+
+        expected_response = {
+            "name": "User1",
+            "pending_requests": 0,
+            "accepted_requests": 1,
+            "rejected_requests": 0,
+            "completed_relations": 0,
+            "cancelled_relations": 0,
+            "achievements": [
+                {
+                    "completed_at": task_completed_time+4*60,
+                    "created_at": task_created_time,
+                    "description": "Test task 4",
+                    "id": 4,
+                    "is_done": True,
+                },
+                {
+                    "completed_at": task_completed_time+3*60,
+                    "created_at": task_created_time,
+                    "description": "Test task 3",
+                    "id": 3,
+                    "is_done": True,
+                },
+                {
+                    "completed_at": task_completed_time+2*60,
+                    "created_at": task_created_time,
+                    "description": "Test task 2",
+                    "id": 2,
                     "is_done": True,
                 }
             ],


### PR DESCRIPTION
### Description
The achievements list retrieved from /home endpoint retrieves the **latest** three achievements, instead of the **first** three.

Fixes #393 

### Type of Change:

- Code
- Quality Assurance


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?

- I added a new test in test_api_home_statistics.py
- I also tested it manually by creating 5 tasks (and set them to complete). The result at GET /home should be the last three achievements (ex. id 5,4,3 instead of 1,2,3). 
![image](https://user-images.githubusercontent.com/24480679/126238953-015d77fc-4cfb-407b-8293-996036bdff73.png)



### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas


**Code/Quality Assurance Only**

- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
