### PR TITLE
Add missing tests in Mentorship Relation

### DIFF
--- a/tests/mentorship_relation/test_api_reject_request.py
+++ b/tests/mentorship_relation/test_api_reject_request.py
@@ -59,6 +59,25 @@ class TestRejectMentorshipRequestApi(MentorshipRelationBaseTestCase):
                 json.loads(response.data),
             )
 
+    def test_reject_request_by_uninvolved_user(self):
+        self.assertEqual(
+            MentorshipRelationState.PENDING, self.mentorship_relation.state
+        )
+        with self.client:
+            # admin_user acts as uninvolved 3rd user
+            response = self.client.put(
+                f"/mentorship_relation/{self.mentorship_relation.id}/reject",
+                headers=get_test_request_header(self.admin_user.id),
+            )
+            self.assertEqual(HTTPStatus.FORBIDDEN, response.status_code)
+            self.assertEqual(
+                MentorshipRelationState.PENDING, self.mentorship_relation.state
+            )
+            self.assertDictEqual(
+                messages.CANT_REJECT_UNINVOLVED_RELATION_REQUEST,
+                json.loads(response.data),
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/mentorship_relation/test_dao_creation.py
+++ b/tests/mentorship_relation/test_dao_creation.py
@@ -248,7 +248,7 @@ class TestMentorshipRelationCreationDAO(MentorshipRelationBaseTestCase):
 
         self.assertEqual(messages.INVALID_END_DATE, result[0])
         self.assertEqual(HTTPStatus.BAD_REQUEST, result[1])
-    
+
     def test_dao_create_mentorship_relation_with_same_id_mentor_mentee(self):
         dao = MentorshipRelationDAO()
         data = dict(
@@ -261,6 +261,21 @@ class TestMentorshipRelationCreationDAO(MentorshipRelationBaseTestCase):
 
         result = dao.create_mentorship_relation(self.first_user.id, data)
         self.assertDictEqual(messages.MENTOR_ID_SAME_AS_MENTEE_ID, result[0])
+        query_mentorship_relation = MentorshipRelationModel.query.first()
+        self.assertIsNone(query_mentorship_relation)
+
+    def test_dao_create_mentorship_relation_incorrect_end_time(self):
+        dao = MentorshipRelationDAO()
+        data = dict(
+            mentor_id=self.first_user.id,
+            mentee_id=self.second_user.id,
+            end_date=self.now_datetime.timestamp() - 5000,
+            notes=self.notes_example,
+            tasks_list=TasksListModel(),
+        )
+
+        result = dao.create_mentorship_relation(self.first_user.id, data)
+        self.assertDictEqual(messages.END_TIME_BEFORE_PRESENT, result[0])
         query_mentorship_relation = MentorshipRelationModel.query.first()
         self.assertIsNone(query_mentorship_relation)
 

--- a/tests/mentorship_relation/test_dao_creation.py
+++ b/tests/mentorship_relation/test_dao_creation.py
@@ -311,6 +311,39 @@ class TestMentorshipRelationCreationDAO(MentorshipRelationBaseTestCase):
         query_mentorship_relation = MentorshipRelationModel.query.first()
         self.assertIsNone(query_mentorship_relation)
 
+    def test_dao_create_mentorship_relation_duration_max(self):
+        dao = MentorshipRelationDAO()
+        end_date_max = (
+            self.now_datetime + dao.MAXIMUM_MENTORSHIP_DURATION + timedelta(seconds=30)
+        )
+        data = dict(
+            mentor_id=self.first_user.id,
+            mentee_id=self.second_user.id,
+            end_date=end_date_max.timestamp(),
+            notes=self.notes_example,
+            tasks_list=TasksListModel(),
+        )
+
+        result = dao.create_mentorship_relation(self.first_user.id, data)
+        self.assertDictEqual(messages.MENTOR_TIME_GREATER_THAN_MAX_TIME, result[0])
+        query_mentorship_relation = MentorshipRelationModel.query.first()
+        self.assertIsNone(query_mentorship_relation)
+
+    def test_dao_create_mentorship_relation_duration_min(self):
+        dao = MentorshipRelationDAO()
+        data = dict(
+            mentor_id=self.first_user.id,
+            mentee_id=self.second_user.id,
+            end_date=(self.now_datetime + dao.MINIMUM_MENTORSHIP_DURATION).timestamp(),
+            notes=self.notes_example,
+            tasks_list=TasksListModel(),
+        )
+
+        result = dao.create_mentorship_relation(self.first_user.id, data)
+        self.assertDictEqual(messages.MENTOR_TIME_LESS_THAN_MIN_TIME, result[0])
+        query_mentorship_relation = MentorshipRelationModel.query.first()
+        self.assertIsNone(query_mentorship_relation)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/mentorship_relation/test_dao_creation.py
+++ b/tests/mentorship_relation/test_dao_creation.py
@@ -248,6 +248,21 @@ class TestMentorshipRelationCreationDAO(MentorshipRelationBaseTestCase):
 
         self.assertEqual(messages.INVALID_END_DATE, result[0])
         self.assertEqual(HTTPStatus.BAD_REQUEST, result[1])
+    
+    def test_dao_create_mentorship_relation_with_same_id_mentor_mentee(self):
+        dao = MentorshipRelationDAO()
+        data = dict(
+            mentor_id=self.first_user.id,
+            mentee_id=self.first_user.id,
+            end_date=self.end_date_example.timestamp(),
+            notes=self.notes_example,
+            tasks_list=TasksListModel(),
+        )
+
+        result = dao.create_mentorship_relation(self.first_user.id, data)
+        self.assertDictEqual(messages.MENTOR_ID_SAME_AS_MENTEE_ID, result[0])
+        query_mentorship_relation = MentorshipRelationModel.query.first()
+        self.assertIsNone(query_mentorship_relation)
 
 
 if __name__ == "__main__":

--- a/tests/mentorship_relation/test_dao_creation.py
+++ b/tests/mentorship_relation/test_dao_creation.py
@@ -279,6 +279,38 @@ class TestMentorshipRelationCreationDAO(MentorshipRelationBaseTestCase):
         query_mentorship_relation = MentorshipRelationModel.query.first()
         self.assertIsNone(query_mentorship_relation)
 
+    def test_dao_create_mentorship_relation_not_available_mentor(self):
+        dao = MentorshipRelationDAO()
+        self.first_user.available_to_mentor = False
+        data = dict(
+            mentor_id=self.first_user.id,
+            mentee_id=self.second_user.id,
+            end_date=self.end_date_example.timestamp(),
+            notes=self.notes_example,
+            tasks_list=TasksListModel(),
+        )
+
+        result = dao.create_mentorship_relation(self.first_user.id, data)
+        self.assertDictEqual(messages.MENTOR_NOT_AVAILABLE_TO_MENTOR, result[0])
+        query_mentorship_relation = MentorshipRelationModel.query.first()
+        self.assertIsNone(query_mentorship_relation)
+
+    def test_dao_create_mentorship_relation_not_available_mentee(self):
+        dao = MentorshipRelationDAO()
+        self.second_user.need_mentoring = False
+        data = dict(
+            mentor_id=self.first_user.id,
+            mentee_id=self.second_user.id,
+            end_date=self.end_date_example.timestamp(),
+            notes=self.notes_example,
+            tasks_list=TasksListModel(),
+        )
+
+        result = dao.create_mentorship_relation(self.first_user.id, data)
+        self.assertDictEqual(messages.MENTEE_NOT_AVAIL_TO_BE_MENTORED, result[0])
+        query_mentorship_relation = MentorshipRelationModel.query.first()
+        self.assertIsNone(query_mentorship_relation)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description

Add missing tests for Mentorship relation. 
Fixes #990 

#### New Tests
Mentioned in the issue:
- [x] Same id for mentor and mentee (MENTOR_ID_SAME_AS_MENTEE_ID)
- [x] Incorrect End Time (END_TIME_BEFORE_PRESENT)
- [x] Incorrect Mentor time (ex. MENTOR_TIME_GREATER_THAN_MAX_TIME)
- [x] Mentor not available (MENTOR_NOT_AVAILABLE_TO_MENTOR)
- [x] Mentee not available (MENTEE_NOT_AVAIL_TO_BE_MENTORED)
- [x] Reject uninvolved relation request (CANT_REJECT_UNINVOLVED_RELATION_REQUEST)

Other Tests suggestions : 
- [x] Reject request AUTHORISATION_TOKEN_IS_MISSING
- [x] Reject request TOKEN_HAS_EXPIRED

### Type of Change:

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
` python -m unittest tests/mentorship_relation/test_dao_creation.py
`

### Checklist:

<!-- **Delete irrelevant options.** -->

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**

- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
