### PR TITLE
Fix: Medium icon is now visible in Docusaurus footer

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -37,6 +37,11 @@ module.exports = {
           position: "right",
         },
         {
+          href: "https://medium.com/anitab-org-open-source",
+          label: "Medium",
+          position: "right",
+        },
+        {
           href: "https://github.com/anitab-org/mentorship-backend",
           label: "GitHub",
           position: "right",


### PR DESCRIPTION
### Description
The medium link was added but its icon was not visible. So, added it to the items Array.


Fixes #1148

### Type of Change:

<!--- **Delete irrelevant options.** --->

- Code
- Quality Assurance
- User Interface
- Outreach
- Documentation

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Provide instructions or GIFs so we can reproduce. List any relevant details for your test. -->
No tests needed.

### Checklist:

<!-- **Delete irrelevant options.** -->

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials


**Code/Quality Assurance Only**

- [x] My changes generate no new warnings

