### PR TITLE
feat: updated task_comment information to include if comment owned by user

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
     rev: 21.5b1
     hooks:
     -   id: black
+        additional_dependencies: ['click==8.0.4']
         args: [--check]
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2

--- a/app/api/dao/mentorship_relation.py
+++ b/app/api/dao/mentorship_relation.py
@@ -136,12 +136,14 @@ class MentorshipRelationDAO:
             message: A message corresponding to the completed action; success if all relationships of a given user are listed, failure if otherwise.
         """
         # To check if the entered 'state' is valid.
-        valid_states = ["PENDING", "ACCEPTED", "REJECTED", "CANCELLED", "COMPLETED"]
+        # valid_states = ["PENDING", "ACCEPTED", "REJECTED", "CANCELLED", "COMPLETED"]
 
         def isValidState(rel_state):
-            if rel_state in valid_states:
-                return True
-            return False
+            try:
+                MentorshipRelationState[rel_state]
+            except KeyError:
+                return False
+            return True
 
         user = UserModel.find_by_id(user_id)
         all_relations = user.mentor_relations + user.mentee_relations

--- a/app/api/models/task_comment.py
+++ b/app/api/models/task_comment.py
@@ -15,7 +15,11 @@ task_comments_model = Model(
     "Task comments model",
     {
         "id": fields.Integer(required=True, description="Task comment's id."),
-        "user_id": fields.Integer(required=True, description="User's id."),
+        "sent_by_me": fields.Boolean(required=True, description="If sent by user."),
+        "user": {
+            "id": fields.Integer(required=True, description="User's id."),
+            "name": fields.String(required=True, description="User's name."),
+        },
         "task_id": fields.Integer(required=True, description="Task's id."),
         "relation_id": fields.Integer(required=True, description="Relation's id."),
         "creation_date": fields.Float(

--- a/app/database/models/task_comment.py
+++ b/app/database/models/task_comment.py
@@ -22,6 +22,7 @@ class TaskCommentModel(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"))
+    user_name = db.Column(db.String, db.ForeignKey("users.name"))
     task_id = db.Column(db.Integer, db.ForeignKey("tasks_list.id"))
     relation_id = db.Column(db.Integer, db.ForeignKey("mentorship_relations.id"))
     creation_date = db.Column(db.Float, nullable=False)
@@ -40,8 +41,17 @@ class TaskCommentModel(db.Model):
 
     def json(self):
         """Returns information of task comment as a JSON object."""
+        if self.id == self.user_id:
+            sent_by_me = True
+        else:
+            sent_by_me = False
         return {
             "id": self.id,
+            "sent_by_me": sent_by_me,
+            "user": {
+                "id": self.user_id,
+                "name": self.user_name,
+            },
             "user_id": self.user_id,
             "task_id": self.task_id,
             "relation_id": self.relation_id,

--- a/tests/admin/test_api_revoking_admin_role.py
+++ b/tests/admin/test_api_revoking_admin_role.py
@@ -6,9 +6,8 @@ from flask import json
 from app import messages
 from app.database.models.user import UserModel
 from app.database.sqlalchemy_extension import db
-
 from tests.base_test_case import BaseTestCase
-from tests.test_data import user1, test_admin_user_2
+from tests.test_data import test_admin_user_2, user1
 from tests.test_utils import get_test_request_header
 
 

--- a/tests/user_journey/test_rejection_path.py
+++ b/tests/user_journey/test_rejection_path.py
@@ -3,20 +3,14 @@ from datetime import datetime, timedelta
 from http import HTTPStatus
 
 from flask import json
-from flask_restx import marshal
 
 from app import messages
-from app.api.models.user import public_user_api_model
-from app.database.models.mentorship_relation import MentorshipRelationModel
-from app.utils.enum_utils import MentorshipRelationState
-from app.database.models.tasks_list import TasksListModel
 from app.database.models.user import UserModel
 from app.database.sqlalchemy_extension import db
 from app.utils.enum_utils import MentorshipRelationState
 from tests.base_test_case import BaseTestCase
-from tests.test_utils import get_test_request_header
 from tests.test_data import user1, user2
-from app.api.models.mentorship_relation import mentorship_request_response_body
+from tests.test_utils import get_test_request_header
 
 
 class TestRejectionPath(BaseTestCase):
@@ -118,7 +112,7 @@ class TestRejectionPath(BaseTestCase):
 
         # Mentee discovers that the request has been rejected
         mentee_current_rejected_relation = self.client.get(
-            f"/mentorship_relations/current", headers=mentee_auth_header
+            "/mentorship_relations/current", headers=mentee_auth_header
         )
         self.assertEqual(HTTPStatus.OK, mentee_current_rejected_relation.status_code)
 


### PR DESCRIPTION
### Description

Getting a `task_comment` model now returns an object with these fields:
{
            "id": self.id,
            "sent_by_me": sent_by_me,
            "user": {
                "id": self.user_id,
                "name": self.user_name,
            },
            "user_id": self.user_id,
            "task_id": self.task_id,
            "relation_id": self.relation_id,
            "creation_date": self.creation_date,
            "modification_date": self.modification_date,
            "comment": self.comment,
}

Fixes # [685]

### Type of Change:

<!--- **Delete irrelevant options.** --->

- Code
- Enhancement


### How Has This Been Tested?

I ran the unit tests again, making sure to run `python -m unittest discover tests` with my updated code.


### Checklist:

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] Any dependent changes have been merged

- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
