### PR TITLE
Fix Medium icon which is hidden on Docusaurus footer

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -47,15 +47,15 @@ module.exports = {
       style: "dark",
       copyright: `
         <div>
-            <a href="https://www.facebook.com/AnitaB.0rg/" rel="noopener noreferrer" target="_blank"><i id="social-fb" class="fa fa-facebook-square fa-3x social"></i></a>
-            <a href="https://twitter.com/anitab_org" rel="noopener noreferrer" target="_blank"><i id="social-tw" class="fa fa-twitter-square fa-3x social"></i></a>
-            <a href="https://www.linkedin.com/company/anitab-org/" rel="noopener noreferrer" target="_blank"><i id="fa fa-linkedin-square fa-3x social" class="fa fa-linkedin-square fa-3x social"></i></a>
-            <a href="https://www.instagram.com/anitab_org/" rel="noopener noreferrer" target="_blank"><i id="fa fa-instagram-square fa-2x social" class="fa fa-instagram fa-3x social"></i></a>
-            <a href="https://medium.com/anitab-org-open-source" rel="noopener noreferrer" target="_blank"><i id="fa fa-medium" class="fa fa-medium fa-3x social"></i></a>
-            <a href="https://github.com/anitab-org/mentorship-backend" rel="noopener noreferrer" target="_blank"><i id="fa fa-github" class="fa fa-github fa-3x social"></i></a>
+          <a href="https://www.facebook.com/AnitaB.0rg/" rel="noopener noreferrer" target="_blank"><i id="social-fb" class="fa-brands fa-facebook-square fa-3x social"></i></a>
+          <a href="https://twitter.com/anitab_org" rel="noopener noreferrer" target="_blank"><i id="social-tw" class="fa-brands fa-twitter-square fa-3x social"></i></a>
+          <a href="https://www.linkedin.com/company/anitab-org/" rel="noopener noreferrer" target="_blank"><i id="fa fa-linkedin fa-3x social" class="fa-brands fa-linkedin fa-3x social"></i></a>
+          <a href="https://www.instagram.com/anitab_org/" rel="noopener noreferrer" target="_blank"><i id="fa fa-instagram-square fa-2x social" class="fa-brands fa-instagram-square fa-3x social"></i></a>
+          <a href="https://medium.com/anitab-org-open-source" rel="noopener noreferrer" target="_blank"><i id="fa fa-medium" class="fa-brands fa-medium fa-3x social"></i></a>
+          <a href="https://github.com/anitab-org/mentorship-backend" rel="noopener noreferrer" target="_blank"><i id="fa-brands fa-github" class="fa-brands fa-github fa-3x social"></i></a>
         </div>
         <b>Copyright © ${new Date().getFullYear()} AnitaB.org</b>
-        <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
+        <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
       `,
     },
   },


### PR DESCRIPTION
### Description

The medium icon can not be seen because the icon only appeared in library starting from version 4.3.0. Therefore, I have updated the version of the library and added the medium icon. 

The icon are similar except the instagram icon which was upgraded I guess.

Fixes #1148

### Type of Change:

- Code

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)



### How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes. Provide instructions or GIFs so we can reproduce. List any relevant details for your test. -->



### Checklist:

<!-- **Delete irrelevant options.** -->

- [X] My PR follows the style guidelines of this project
- [X] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**

- [X] My changes generate no new warnings
<img width="1435" alt="Screen Shot 2022-07-10 at 03 03 39" src="https://user-images.githubusercontent.com/40865688/178122564-8f3bd83f-3f3a-46bb-8f34-de85aad97671.png">


