### PR TITLE
Solved Issue #596 of updating user with current username

### DIFF
--- a/app/api/dao/user.py
+++ b/app/api/dao/user.py
@@ -227,6 +227,13 @@ class UserDAO:
 
             # username should be unique
             if user_with_same_username:
+                # If requested update username is current username of user, OK status, nothing updated
+                if user.username == username:
+                    return (
+                    messages.CURRENT_USERNAME_NO_FIELDS_UPDATED,
+                    HTTPStatus.OK,
+                    )
+                # Otherwise, error: cannot change username to existing one
                 return (
                     messages.USER_USES_A_USERNAME_THAT_ALREADY_EXISTS,
                     HTTPStatus.BAD_REQUEST,

--- a/app/messages.py
+++ b/app/messages.py
@@ -159,6 +159,9 @@ USER_USES_AN_EMAIL_ID_THAT_ALREADY_EXISTS = {
 USER_IS_NOT_REGISTERED_IN_THE_SYSTEM = {
     "message": "You are not registered in the system."
 }
+CURRENT_USERNAME_NO_FIELDS_UPDATED = {
+    "message": "Updated username is the same as current username. No fields have been updated."
+}
 NAME_LENGTH_GREATER_THAN_MAX_LIMIT = {
     "message": "The {field_name} field has"
     " to be shorter than {max_limit}"

--- a/tests/users/test_api_update_user.py
+++ b/tests/users/test_api_update_user.py
@@ -230,5 +230,28 @@ class TestUpdateUserApi(BaseTestCase):
         self.assertDictEqual(expected_response, json.loads(actual_response.data))
 
 
+    def test_update_same_username(self):
+            self.first_user = UserModel(**user1)
+            self.first_user.is_email_verified = True
+
+            db.session.add(self.first_user)
+            db.session.commit()
+
+            new_username = self.first_user.username
+            auth_header = get_test_request_header(self.first_user.id)
+            expected_response = messages.CURRENT_USERNAME_NO_FIELDS_UPDATED
+            actual_response = self.client.put(
+                "/user",
+                follow_redirects=True,
+                headers=auth_header,
+                data=json.dumps(dict(username=new_username)),
+                content_type="application/json",
+            )
+
+            self.assertEqual(HTTPStatus.OK, actual_response.status_code)
+            self.assertDictEqual(expected_response, json.loads(actual_response.data))
+            self.assertEqual(new_username, self.first_user.username)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description

Fixed Issue #596 such that when a user attempts to update their username with their current username (ex. user "123" tries to update the username to "123"), they receive an HTTP OK response and not an error. No fields will be updated and the message attached to the OK response reports that accordingly.

A test has been added to the test file to cover this edge case.

Fixes #596 

### Type of Change:
- Code
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
New test method that creates a user and tries to update the username to the existing username. It asserts that the response code and message are as expected. The test passed on local device.

### Checklist:
- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [ ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] Any dependent changes have been merged

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published in downstream modules
